### PR TITLE
feat: redesign blackjack table surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A single-player, seven-seat Blackjack table implemented with a pure TypeScript e
 - ✅ Comprehensive action validation (hit, stand, double, split, surrender, insurance)
 - ✅ Multi-seat play (up to seven simultaneous hands sharing a bankroll)
 - ✅ Persistent €100 bankroll stored in `localStorage`
-- ✅ Tailwind + shadcn/ui interface with clear totals, flags, and rule badges
+- ✅ Tailwind + shadcn/ui casino table with felt surface, curved payouts text, chip tray, and contextual action bar
 - ✅ Extensive unit tests covering totals, splits, doubles, surrender, insurance, payouts, and dealer logic
 
 ## Getting Started
@@ -75,7 +75,7 @@ These modules are pure TypeScript (no React). React components interact through 
 ## UI Structure
 
 - `src/store/useGameStore.ts` – Zustand store with hydration (`localStorage`), error handling, and action wrappers.
-- `src/components/` – React components for seats, dealer area, control bar, rule badges, and shadcn/ui primitives.
+- `src/components/` – React components, including the casino table surface (`table/` folder), rule badges, and shadcn/ui primitives.
 - `src/pages/App.tsx` – top-level page wiring state and layout.
 - `src/services/AudioService.ts` – stubbed audio service ready for future SFX.
 
@@ -104,6 +104,13 @@ Run all tests with `npm run test` (uses the jsdom environment).
 - **Set table limits**: configure `minBet` / `maxBet`.
 
 After editing, no rebuild is required—Vite hot reloads rule changes.
+
+## Casino Table UI
+
+- **Dependencies**: the felt table uses `@iconify/react` and `@iconify-json/game-icons` for shoe/discard icons and card backs. Install with `npm install @iconify/react @iconify-json/game-icons` (already included).
+- **Colours & layout**: tweak felt, chip, and gold accents in `src/theme/palette.ts`. Seat arcs, dealer area, and curved text paths live in `src/components/table/coords.ts`.
+- **Chip interaction**: pick a denomination from the chip tray (bottom toolbar), then left-click a bet circle to add that chip or right-click to remove it (context menu is suppressed). Seats auto-sit when you place the first chip and can be left via the “Leave” control during betting.
+- **Icons**: all decorative icons (shoe, discard tray, card back emblem) are sourced from the `game-icons` Iconify collection.
 
 ## Limitations & Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "blackjack",
       "version": "1.0.0",
       "dependencies": {
+        "@iconify-json/game-icons": "^1.2.3",
+        "@iconify/react": "^6.0.2",
         "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
@@ -627,6 +629,36 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@iconify-json/game-icons": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@iconify-json/game-icons/-/game-icons-1.2.3.tgz",
+      "integrity": "sha512-JnrHQjNI/2nJxlnEAPlU4ta6S44XTX7RJnBUyBV27GbVhJhfwpY9kqzkTqmPs4nyAJaGUjZwOcnBUQ9Dc21nlA==",
+      "license": "CC-BY-3.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-6.0.2.tgz",
+      "integrity": "sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "lint": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
+    "@iconify-json/game-icons": "^1.2.3",
+    "@iconify/react": "^6.0.2",
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
@@ -23,11 +25,11 @@
   "devDependencies": {
     "@eslint/js": "^8.55.0",
     "@testing-library/react": "^14.0.0",
-    "@typescript-eslint/eslint-plugin": "^6.15.0",
-    "@typescript-eslint/parser": "^6.15.0",
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
+    "@typescript-eslint/eslint-plugin": "^6.15.0",
+    "@typescript-eslint/parser": "^6.15.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.55.0",

--- a/src/components/RuleBadges.tsx
+++ b/src/components/RuleBadges.tsx
@@ -1,12 +1,22 @@
 import React from "react";
 import type { RuleConfig } from "../engine/types";
+import { palette } from "../theme/palette";
 
 interface RuleBadgesProps {
   rules: RuleConfig;
 }
 
 const Badge = ({ label }: { label: string }) => (
-  <span className="rounded-full bg-emerald-800 px-3 py-1 text-xs font-semibold text-emerald-100">{label}</span>
+  <span
+    className="rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.25em]"
+    style={{
+      borderColor: "rgba(200, 162, 74, 0.5)",
+      backgroundColor: "rgba(12, 46, 36, 0.7)",
+      color: palette.text
+    }}
+  >
+    {label}
+  </span>
 );
 
 export const RuleBadges: React.FC<RuleBadgesProps> = ({ rules }) => {

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { SeatCard } from "./SeatCard";
-import { DealerArea } from "./DealerArea";
-import { ControlsBar } from "./ControlsBar";
-import { RuleBadges } from "./RuleBadges";
 import type { GameState } from "../engine/types";
 import { formatCurrency } from "../utils/currency";
+import { RuleBadges } from "./RuleBadges";
+import { TableLayout } from "./table/TableLayout";
+import { ChipTray } from "./table/ChipTray";
+import type { ChipDenomination } from "../theme/palette";
+import { Button } from "./ui/button";
 
 interface TableProps {
   game: GameState;
@@ -35,56 +36,116 @@ const penetrationPercentage = (game: GameState): string => {
   return `${Math.round(penetration * 100)}%`;
 };
 
+const hasReadySeat = (game: GameState): boolean => {
+  const readySeats = game.seats.filter((seat) => seat.occupied && seat.baseBet >= game.rules.minBet);
+  if (readySeats.length === 0) {
+    return false;
+  }
+  const total = readySeats.reduce((sum, seat) => sum + seat.baseBet, 0);
+  return total <= game.bankroll;
+};
+
 export const Table: React.FC<TableProps> = ({ game, actions }) => {
-  const seats = game.seats;
+  const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
+
+  const handleSelectChip = (value: ChipDenomination) => {
+    setActiveChip(value);
+  };
+
+  const totalPendingBets = game.seats.reduce((sum, seat) => sum + seat.baseBet, 0);
+
   return (
-    <div className="space-y-6">
-      <header className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-emerald-700 bg-emerald-950/40 p-4">
-        <div>
-          <h1 className="text-2xl font-bold">Blackjack</h1>
-          <p className="text-sm text-emerald-200">Bankroll: {formatCurrency(game.bankroll)}</p>
+    <div className="flex flex-col gap-6 text-emerald-50">
+      <header className="rounded-3xl border border-[#c8a24a]/40 bg-[#0c2c22]/80 px-6 py-5 shadow-[0_20px_50px_rgba(0,0,0,0.45)] backdrop-blur">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.5em] text-emerald-200">Casino Table</p>
+            <h1 className="mt-2 text-4xl font-semibold tracking-widest text-emerald-50">Blackjack</h1>
+            <p className="mt-3 text-sm text-emerald-200">
+              Bankroll <span className="font-semibold text-emerald-50">{formatCurrency(game.bankroll)}</span>
+            </p>
+            <p className="text-sm text-emerald-200">Pending bets {formatCurrency(totalPendingBets)}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-4 text-sm text-emerald-100 md:grid-cols-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-300">Round</p>
+              <p className="mt-1 text-lg font-semibold text-emerald-50">{game.roundCount}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-300">Phase</p>
+              <p className="mt-1 text-lg font-semibold text-emerald-50">{game.phase}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-300">Cards</p>
+              <p className="mt-1 text-lg font-semibold text-emerald-50">{game.shoe.cards.length}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-300">Discard</p>
+              <p className="mt-1 text-lg font-semibold text-emerald-50">{game.shoe.discard.length}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-300">Penetration</p>
+              <p className="mt-1 text-lg font-semibold text-emerald-50">{penetrationPercentage(game)}</p>
+            </div>
+            <div className="col-span-2 md:col-span-1">
+              <RuleBadges rules={game.rules} />
+            </div>
+          </div>
         </div>
-        <div className="text-sm text-emerald-200">
-          <p>Cards remaining: {game.shoe.cards.length}</p>
-          <p>Discard pile: {game.shoe.discard.length}</p>
-          <p>Penetration: {penetrationPercentage(game)}</p>
-        </div>
-        <div className="text-sm text-emerald-200">
-          <p>Round: {game.roundCount}</p>
-          <p>Phase: {game.phase}</p>
-        </div>
-        <RuleBadges rules={game.rules} />
       </header>
 
-      <DealerArea game={game} />
+      <TableLayout
+        game={game}
+        activeChip={activeChip}
+        onSetBet={actions.setBet}
+        onSit={actions.sit}
+        onLeave={actions.leave}
+        onInsurance={actions.takeInsurance}
+        onDeclineInsurance={actions.declineInsurance}
+        onHit={actions.playerHit}
+        onStand={actions.playerStand}
+        onDouble={actions.playerDouble}
+        onSplit={actions.playerSplit}
+        onSurrender={actions.playerSurrender}
+      />
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {seats.map((seat) => (
-          <SeatCard
-            key={seat.index}
-            seat={seat}
-            game={game}
-            onSit={actions.sit}
-            onLeave={actions.leave}
-            onBetChange={actions.setBet}
-            onHit={actions.playerHit}
-            onStand={actions.playerStand}
-            onDouble={actions.playerDouble}
-            onSplit={actions.playerSplit}
-            onSurrender={actions.playerSurrender}
-            onInsurance={actions.takeInsurance}
-            onDeclineInsurance={actions.declineInsurance}
-          />
-        ))}
+      <div className="flex justify-center">
+        <ChipTray activeChip={activeChip} onSelect={handleSelectChip} disabled={game.phase !== "betting"} />
       </div>
 
-      <ControlsBar
-        game={game}
-        onDeal={actions.deal}
-        onFinishInsurance={actions.finishInsurance}
-        onNextRound={actions.nextRound}
-        onPlayDealer={actions.playDealer}
-      />
+      <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+        <div className="rounded-3xl border border-[#c8a24a]/30 bg-[#0b2d22]/80 p-6 shadow-[0_20px_60px_rgba(0,0,0,0.45)]">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-200">Round Controls</h2>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Button onClick={actions.deal} disabled={game.phase !== "betting" || !hasReadySeat(game)}>
+              Deal
+            </Button>
+            <Button variant="outline" onClick={actions.finishInsurance} disabled={game.phase !== "insurance"}>
+              Finish Insurance
+            </Button>
+            <Button variant="outline" onClick={actions.playDealer} disabled={game.phase !== "dealerPlay"}>
+              Play Dealer
+            </Button>
+            <Button variant="outline" onClick={actions.nextRound} disabled={game.phase !== "settlement"}>
+              Next Round
+            </Button>
+          </div>
+          <p className="mt-4 text-xs text-emerald-200">
+            Minimum bet {formatCurrency(game.rules.minBet)} · Maximum bet {formatCurrency(game.rules.maxBet)}
+          </p>
+        </div>
+        <div className="rounded-3xl border border-[#c8a24a]/30 bg-[#0b2d22]/80 p-6 shadow-[0_20px_60px_rgba(0,0,0,0.45)]">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-200">Messages</h2>
+          <div className="mt-4 max-h-64 space-y-2 overflow-y-auto pr-2 text-sm text-emerald-100">
+            {game.messageLog.length === 0 && <p className="text-emerald-300/70">Table is quiet.</p>}
+            {game.messageLog.map((message, index) => (
+              <div key={`${message}-${index}`} className="rounded-lg bg-[#11382b]/70 px-3 py-2">
+                {message}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/table/BetSpotOverlay.tsx
+++ b/src/components/table/BetSpotOverlay.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { Button } from "../ui/button";
+import { ChipSVG } from "./ChipSVG";
+import type { ChipDenomination } from "../../theme/palette";
+import { palette } from "../../theme/palette";
+import { defaultTableAnchors, toPixels } from "./coords";
+import type { GameState, Hand, Seat } from "../../engine/types";
+import { formatCurrency } from "../../utils/currency";
+
+interface BetSpotOverlayProps {
+  game: GameState;
+  dimensions: { width: number; height: number };
+  activeChip: ChipDenomination;
+  onSetBet: (seatIndex: number, amount: number) => void;
+  onSit: (seatIndex: number) => void;
+  onLeave: (seatIndex: number) => void;
+  onInsurance: (seatIndex: number, handId: string, amount: number) => void;
+  onDeclineInsurance: (seatIndex: number, handId: string) => void;
+}
+
+const CHIP_ORDER: ChipDenomination[] = [500, 100, 25, 5, 1];
+
+const computeChipStack = (amount: number): ChipDenomination[] => {
+  const stack: ChipDenomination[] = [];
+  let remaining = Math.max(0, Math.floor(amount));
+  for (const value of CHIP_ORDER) {
+    const count = Math.floor(remaining / value);
+    for (let i = 0; i < count; i += 1) {
+      stack.push(value);
+    }
+    remaining -= count * value;
+  }
+  return stack;
+};
+
+const renderChipStack = (chips: ChipDenomination[]): React.ReactNode => {
+  if (chips.length === 0) {
+    return null;
+  }
+  const maxVisible = 5;
+  const visible = chips.slice(0, maxVisible);
+  const overflow = chips.length - visible.length;
+  return (
+    <div className="relative flex h-[60px] w-[60px] items-center justify-center">
+      {visible.map((chip, index) => (
+        <ChipSVG
+          key={`${chip}-${index}`}
+          value={chip}
+          size={42}
+          shadow={index === visible.length - 1}
+          className="absolute"
+          style={{ transform: `translateY(-${index * 4}px)` }}
+        />
+      ))}
+      {overflow > 0 && (
+        <span
+          className="absolute bottom-[-18px] text-[10px] font-semibold uppercase tracking-[0.3em]"
+          style={{ color: palette.subtleText }}
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const totalPendingBets = (seats: Seat[]): number => seats.reduce((sum, seat) => sum + seat.baseBet, 0);
+
+const seatInsurancePrompt = (
+  seat: Seat,
+  hand: Hand,
+  game: GameState,
+  onInsurance: BetSpotOverlayProps["onInsurance"],
+  onDeclineInsurance: BetSpotOverlayProps["onDeclineInsurance"]
+): React.ReactNode => {
+  const alreadyResolved = hand.insuranceBet !== undefined;
+  if (!seat.occupied || game.phase !== "insurance" || alreadyResolved || hand.isResolved) {
+    return null;
+  }
+  const maxInsurance = Math.floor(hand.bet / 2);
+  const cappedAmount = Math.min(maxInsurance, Math.floor(game.bankroll));
+  const disabled = cappedAmount <= 0;
+  return (
+    <div
+      key={hand.id}
+      className="pointer-events-auto absolute left-1/2 top-full z-10 mt-3 -translate-x-1/2 rounded-lg border border-[#c8a24a]/60 bg-[#0d3024]/95 px-3 py-2 text-xs shadow-lg"
+    >
+      <p className="font-semibold tracking-wide" style={{ color: palette.gold }}>
+        Insurance?
+      </p>
+      <div className="mt-2 flex gap-2">
+        <Button
+          size="sm"
+          onClick={() => onInsurance(seat.index, hand.id, cappedAmount)}
+          disabled={disabled}
+        >
+          Take {formatCurrency(cappedAmount)}
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => onDeclineInsurance(seat.index, hand.id)}>
+          Skip
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const BetSpotOverlay: React.FC<BetSpotOverlayProps> = ({
+  game,
+  dimensions,
+  activeChip,
+  onSetBet,
+  onSit,
+  onLeave,
+  onInsurance,
+  onDeclineInsurance
+}) => {
+  const isBettingPhase = game.phase === "betting";
+  const seats = game.seats;
+  const totalBets = totalPendingBets(seats);
+
+  const handleAddChip = (seat: Seat): void => {
+    if (!isBettingPhase) {
+      return;
+    }
+    if (!seat.occupied) {
+      onSit(seat.index);
+    }
+    const remainingBankroll = Math.max(0, Math.floor(game.bankroll - (totalBets - seat.baseBet)));
+    if (remainingBankroll <= 0) {
+      return;
+    }
+    const nextAmount = Math.min(seat.baseBet + activeChip, seat.baseBet + remainingBankroll);
+    if (nextAmount !== seat.baseBet) {
+      onSetBet(seat.index, nextAmount);
+    }
+  };
+
+  const handleRemoveChip = (seat: Seat): void => {
+    if (!isBettingPhase) {
+      return;
+    }
+    const nextAmount = Math.max(0, seat.baseBet - activeChip);
+    if (nextAmount !== seat.baseBet) {
+      onSetBet(seat.index, nextAmount);
+    }
+  };
+
+  return (
+    <div className="pointer-events-none absolute inset-0">
+      {seats.map((seat) => {
+        const anchor = defaultTableAnchors.seats[seat.index];
+        const { x, y } = toPixels(anchor.x, anchor.y, dimensions);
+        const scaleX = dimensions.width / defaultTableAnchors.viewBox.width;
+        const circleSize = defaultTableAnchors.seatRadius * 2 * scaleX;
+        const chipStack = computeChipStack(seat.baseBet);
+        const showSit = isBettingPhase && !seat.occupied;
+        return (
+          <div key={seat.index} className="absolute" style={{ left: x, top: y }}>
+            <button
+              type="button"
+              className="pointer-events-auto -translate-x-1/2 -translate-y-1/2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a24a]"
+              style={{ width: circleSize, height: circleSize, backgroundColor: "transparent" }}
+              onClick={() => handleAddChip(seat)}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                handleRemoveChip(seat);
+              }}
+              disabled={!isBettingPhase}
+              aria-label={`Bet spot for seat ${seat.index + 1}`}
+            />
+            <div className="pointer-events-none flex -translate-x-1/2 -translate-y-[110%] flex-col items-center gap-2">
+              {renderChipStack(chipStack)}
+              {seat.baseBet > 0 && (
+                <span
+                  className="rounded-full px-3 py-1 text-xs font-semibold tracking-[0.3em]"
+                  style={{ backgroundColor: "rgba(12, 46, 36, 0.8)", color: palette.line }}
+                >
+                  {formatCurrency(seat.baseBet)}
+                </span>
+              )}
+            </div>
+            {showSit && (
+              <div className="pointer-events-auto absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2">
+                <Button size="sm" onClick={() => onSit(seat.index)}>
+                  Sit
+                </Button>
+              </div>
+            )}
+            {seat.occupied && isBettingPhase && (
+              <div className="pointer-events-auto absolute left-1/2 top-[85%] -translate-x-1/2">
+                <Button size="sm" variant="ghost" onClick={() => onLeave(seat.index)}>
+                  Leave
+                </Button>
+              </div>
+            )}
+            {seat.hands.map((hand) => seatInsurancePrompt(seat, hand, game, onInsurance, onDeclineInsurance))}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/table/CardLayer.tsx
+++ b/src/components/table/CardLayer.tsx
@@ -1,0 +1,255 @@
+import React from "react";
+import { Icon } from "@iconify/react";
+import { palette } from "../../theme/palette";
+import { toPixels, defaultTableAnchors } from "./coords";
+import type { GameState, Hand, Seat } from "../../engine/types";
+import { getHandTotals, isBust } from "../../engine/totals";
+import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
+import { Button } from "../ui/button";
+import { formatCurrency } from "../../utils/currency";
+
+interface CardLayerProps {
+  game: GameState;
+  dimensions: { width: number; height: number };
+  onHit: () => void;
+  onStand: () => void;
+  onDouble: () => void;
+  onSplit: () => void;
+  onSurrender: () => void;
+}
+
+const cardStyle = {
+  backgroundColor: "rgba(20, 64, 48, 0.85)",
+  border: `1.5px solid ${palette.line}`,
+  color: palette.text
+};
+
+const cardBackStyle = {
+  backgroundColor: palette.cardBack,
+  border: `1.5px solid ${palette.cardBackBorder}`,
+  color: palette.gold
+};
+
+const renderCard = (content: React.ReactNode, key: string, faceDown = false): React.ReactNode => (
+  <div
+    key={key}
+    className="flex h-[108px] w-[78px] items-center justify-center rounded-xl text-lg font-semibold"
+    style={faceDown ? cardBackStyle : cardStyle}
+  >
+    {content}
+  </div>
+);
+
+const renderHandBadges = (hand: Hand): React.ReactNode => {
+  const badges: string[] = [];
+  if (hand.isBlackjack) badges.push("Blackjack");
+  if (hand.isDoubled) badges.push("Doubled");
+  if (hand.isSurrendered) badges.push("Surrendered");
+  if (hand.isSplitHand) badges.push("Split");
+  if (hand.hasActed) badges.push("Acted");
+  if (isBust(hand)) badges.push("Bust");
+  if (badges.length === 0) {
+    return null;
+  }
+  return (
+    <div className="flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.25em]" style={{ color: palette.subtleText }}>
+      {badges.map((badge) => (
+        <span key={badge} className="rounded-full bg-[#123428]/70 px-2 py-1 font-semibold">
+          {badge}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+const SeatHandCluster = (
+  seat: Seat,
+  seatIndex: number,
+  dimensions: { width: number; height: number },
+  children: React.ReactNode,
+  isActive: boolean
+): React.ReactNode => {
+  const anchor = defaultTableAnchors.seats[seatIndex];
+  const { x, y } = toPixels(anchor.x, anchor.y - defaultTableAnchors.seatRadius - 70, dimensions);
+  return (
+    <div
+      key={`${seat.index}-cluster`}
+      className="absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-3"
+      style={{
+        left: x,
+        top: y,
+        boxShadow: isActive
+          ? "0 0 0 2px rgba(200, 162, 74, 0.65), 0 18px 45px rgba(0,0,0,0.45)"
+          : "0 12px 35px rgba(0,0,0,0.35)"
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+const ActiveActionBar: React.FC<{
+  hand: Hand;
+  game: GameState;
+  onHit: () => void;
+  onStand: () => void;
+  onDouble: () => void;
+  onSplit: () => void;
+  onSurrender: () => void;
+}> = ({ hand, game, onHit, onStand, onDouble, onSplit, onSurrender }) => {
+  const legal = {
+    hit: canHit(hand),
+    stand: !hand.isResolved,
+    double: canDouble(hand, game.rules) && game.bankroll >= hand.bet,
+    split: canSplit(hand, game.seats[hand.parentSeatIndex], game.rules) && game.bankroll >= hand.bet,
+    surrender: canSurrender(hand, game.rules)
+  };
+  return (
+    <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-[#c8a24a]/70 bg-[#0e3125]/95 px-4 py-2 text-xs uppercase tracking-[0.3em]">
+      <Button size="sm" onClick={onHit} disabled={!legal.hit}>
+        Hit
+      </Button>
+      <Button size="sm" variant="outline" onClick={onStand} disabled={!legal.stand}>
+        Stand
+      </Button>
+      <Button size="sm" variant="outline" onClick={onDouble} disabled={!legal.double}>
+        Double
+      </Button>
+      <Button size="sm" variant="outline" onClick={onSplit} disabled={!legal.split}>
+        Split
+      </Button>
+      <Button size="sm" variant="outline" onClick={onSurrender} disabled={!legal.surrender}>
+        Surrender
+      </Button>
+    </div>
+  );
+};
+
+export const CardLayer: React.FC<CardLayerProps> = ({
+  game,
+  dimensions,
+  onHit,
+  onStand,
+  onDouble,
+  onSplit,
+  onSurrender
+}) => {
+  const revealHole =
+    game.phase === "dealerPlay" || game.phase === "settlement" || game.dealer.hand.isBlackjack;
+  const dealerCards = game.dealer.hand.cards;
+  const dealerAnchor = defaultTableAnchors.dealerArea;
+  const dealerPosition = toPixels(
+    dealerAnchor.x + dealerAnchor.width / 2,
+    dealerAnchor.y + dealerAnchor.height / 2,
+    dimensions
+  );
+  const dealerBoxSize = {
+    width: (dealerAnchor.width / defaultTableAnchors.viewBox.width) * dimensions.width,
+    height: (dealerAnchor.height / defaultTableAnchors.viewBox.height) * dimensions.height
+  };
+
+  const dealerTotals = getHandTotals(game.dealer.hand);
+
+  return (
+    <div className="pointer-events-none absolute inset-0 text-sm" style={{ color: palette.text }}>
+      <div
+        className="flex flex-col items-center gap-3"
+        style={{
+          position: "absolute",
+          left: dealerPosition.x,
+          top: dealerPosition.y,
+          width: dealerBoxSize.width,
+          transform: "translate(-50%, -50%)"
+        }}
+      >
+        <div className="flex gap-3">
+          {dealerCards.map((card, index) => {
+            if (index === 1 && !revealHole) {
+              return renderCard(<Icon icon="game-icons:card-random" width={28} height={28} />, `dealer-${index}`, true);
+            }
+            return renderCard(`${card.rank}${card.suit}`, `dealer-${index}`);
+          })}
+        </div>
+        <div className="rounded-full bg-[#0d3124]/80 px-4 py-1 text-xs uppercase tracking-[0.25em]">
+          {revealHole
+            ? dealerTotals.soft && dealerTotals.soft !== dealerTotals.hard
+              ? `Dealer ${dealerTotals.hard} / ${dealerTotals.soft}`
+              : `Dealer ${dealerTotals.hard}`
+            : "Dealer showing"}
+        </div>
+      </div>
+
+      {game.seats.map((seat) => {
+        const isActiveSeat = game.activeSeatIndex === seat.index;
+        if (!seat.occupied && seat.baseBet === 0) {
+          return null;
+        }
+        const hands = seat.hands.length > 0 ? seat.hands : [];
+        const clusterChildren: React.ReactNode[] = [];
+
+        if (hands.length === 0 && seat.baseBet > 0) {
+          clusterChildren.push(
+            <span
+              key="pending"
+              className="rounded-full bg-[#0d3124]/75 px-4 py-1 text-xs uppercase tracking-[0.3em]"
+            >
+              Ready with {formatCurrency(seat.baseBet)}
+            </span>
+          );
+        }
+
+        hands.forEach((hand, handIndex) => {
+          const isActiveHand =
+            game.activeSeatIndex === seat.index && game.activeHandId === hand.id && game.phase === "playerActions";
+          const cards = hand.cards.map((card, index) => {
+            return renderCard(`${card.rank}${card.suit}`, `${hand.id}-${index}`);
+          });
+          const handTotals = getHandTotals(hand);
+          clusterChildren.push(
+            <div key={hand.id} className="flex flex-col items-center gap-2">
+              <div className="flex gap-3" style={{ transform: `translateX(${handIndex * 14}px)` }}>
+                {cards}
+              </div>
+              <div
+                className="rounded-full bg-[#0c2e23]/85 px-3 py-1 text-[11px] uppercase tracking-[0.3em]"
+                style={{ color: palette.text }}
+              >
+                {handTotals.soft && handTotals.soft !== handTotals.hard
+                  ? `Total ${handTotals.hard} / ${handTotals.soft}`
+                  : `Total ${handTotals.hard}`}
+              </div>
+              <div className="text-[10px] uppercase tracking-[0.3em]" style={{ color: palette.subtleText }}>
+                Bet {formatCurrency(hand.bet)}
+              </div>
+              {hand.insuranceBet !== undefined && (
+                <div className="text-[10px] uppercase tracking-[0.3em]" style={{ color: palette.subtleText }}>
+                  {hand.insuranceBet > 0
+                    ? `Insurance ${formatCurrency(hand.insuranceBet)}`
+                    : "Insurance declined"}
+                </div>
+              )}
+              {renderHandBadges(hand)}
+              {isActiveHand && (
+                <ActiveActionBar
+                  hand={hand}
+                  game={game}
+                  onHit={onHit}
+                  onStand={onStand}
+                  onDouble={onDouble}
+                  onSplit={onSplit}
+                  onSurrender={onSurrender}
+                />
+              )}
+            </div>
+          );
+        });
+
+        if (clusterChildren.length === 0) {
+          return null;
+        }
+
+        return SeatHandCluster(seat, seat.index, dimensions, clusterChildren, isActiveSeat);
+      })}
+    </div>
+  );
+};

--- a/src/components/table/ChipSVG.tsx
+++ b/src/components/table/ChipSVG.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { chipPalette, type ChipDenomination } from "../../theme/palette";
+
+interface ChipSVGProps {
+  value: ChipDenomination;
+  size?: number;
+  shadow?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export const ChipSVG: React.FC<ChipSVGProps> = ({ value, size = 56, shadow = false, className, style }) => {
+  const colors = chipPalette[value];
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      width={size}
+      height={size}
+      className={className}
+      style={{
+        filter: shadow ? "drop-shadow(0 6px 12px rgba(0,0,0,0.35))" : undefined,
+        ...style
+      }}
+    >
+      <defs>
+        <linearGradient id={`chip-base-${value}`} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor={colors.base} />
+          <stop offset="100%" stopColor={colors.accent} />
+        </linearGradient>
+      </defs>
+      <circle cx="50" cy="50" r="48" fill={`url(#chip-base-${value})`} stroke={colors.accent} strokeWidth="2" />
+      <circle cx="50" cy="50" r="34" fill={colors.base} stroke={colors.accent} strokeWidth="3" />
+      {Array.from({ length: 8 }).map((_, index) => {
+        const angle = (index * Math.PI) / 4;
+        const x1 = 50 + Math.cos(angle) * 40;
+        const y1 = 50 + Math.sin(angle) * 40;
+        const x2 = 50 + Math.cos(angle) * 48;
+        const y2 = 50 + Math.sin(angle) * 48;
+        return <line key={index} x1={x1} y1={y1} x2={x2} y2={y2} stroke={colors.accent} strokeWidth={4} strokeLinecap="round" />;
+      })}
+      <text x="50" y="58" fill={colors.text} fontSize="28" fontWeight="700" textAnchor="middle">
+        {value}
+      </text>
+    </svg>
+  );
+};

--- a/src/components/table/ChipTray.tsx
+++ b/src/components/table/ChipTray.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { ChipSVG } from "./ChipSVG";
+import type { ChipDenomination } from "../../theme/palette";
+import { palette } from "../../theme/palette";
+
+const CHIP_VALUES: ChipDenomination[] = [1, 5, 25, 100, 500];
+
+interface ChipTrayProps {
+  activeChip: ChipDenomination;
+  onSelect: (value: ChipDenomination) => void;
+  disabled?: boolean;
+}
+
+export const ChipTray: React.FC<ChipTrayProps> = ({ activeChip, onSelect, disabled = false }) => {
+  return (
+    <div className="rounded-full border border-[#c8a24a]/50 bg-[#102e24]/90 px-6 py-3 shadow-[0_12px_30px_rgba(0,0,0,0.5)]">
+      <div className="flex items-center gap-6">
+        <span
+          className="text-xs font-semibold uppercase tracking-[0.3em]"
+          style={{ color: palette.subtleText }}
+        >
+          Chips
+        </span>
+        <div className="flex items-center gap-4">
+          {CHIP_VALUES.map((value) => {
+            const isActive = activeChip === value;
+            const buttonClasses = [
+              "relative rounded-full transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+              disabled ? "pointer-events-none opacity-60" : "hover:-translate-y-1"
+            ].join(" ");
+            return (
+              <button
+                key={value}
+                type="button"
+                className={buttonClasses}
+                onClick={() => onSelect(value)}
+                aria-pressed={isActive}
+              >
+                <ChipSVG value={value} shadow={isActive} size={isActive ? 60 : 54} />
+                {isActive && (
+                  <span
+                    className="absolute inset-x-0 -bottom-5 text-center text-[10px] font-semibold uppercase tracking-[0.3em]"
+                    style={{ color: palette.gold }}
+                  >
+                    Active
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/table/TableLayout.tsx
+++ b/src/components/table/TableLayout.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import type { GameState } from "../../engine/types";
+import { TableSurfaceSVG, type SeatVisualState } from "./TableSurfaceSVG";
+import { defaultTableAnchors, type TableAnchors, mapSeatAnchors } from "./coords";
+import { BetSpotOverlay } from "./BetSpotOverlay";
+import { CardLayer } from "./CardLayer";
+import type { ChipDenomination } from "../../theme/palette";
+
+interface TableLayoutProps {
+  game: GameState;
+  activeChip: ChipDenomination;
+  onSetBet: (seatIndex: number, amount: number) => void;
+  onSit: (seatIndex: number) => void;
+  onLeave: (seatIndex: number) => void;
+  onInsurance: (seatIndex: number, handId: string, amount: number) => void;
+  onDeclineInsurance: (seatIndex: number, handId: string) => void;
+  onHit: () => void;
+  onStand: () => void;
+  onDouble: () => void;
+  onSplit: () => void;
+  onSurrender: () => void;
+}
+
+export const TableLayout: React.FC<TableLayoutProps> = ({
+  game,
+  activeChip,
+  onSetBet,
+  onSit,
+  onLeave,
+  onInsurance,
+  onDeclineInsurance,
+  onHit,
+  onStand,
+  onDouble,
+  onSplit,
+  onSurrender
+}) => {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const [dimensions, setDimensions] = React.useState({
+    width: defaultTableAnchors.viewBox.width,
+    height: defaultTableAnchors.viewBox.height
+  });
+  const [, setLayout] = React.useState<TableAnchors>(defaultTableAnchors);
+
+  React.useLayoutEffect(() => {
+    const element = containerRef.current;
+    if (!element || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      setDimensions({ width: entry.contentRect.width, height: entry.contentRect.height });
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  const seatStates = React.useMemo<SeatVisualState[]>(
+    () =>
+      mapSeatAnchors(game.seats, (seat, anchor) => ({
+        index: seat.index,
+        occupied: seat.occupied,
+        hasBet: seat.baseBet > 0,
+        isActive: game.activeSeatIndex === seat.index,
+        label: anchor.label
+      })),
+    [game]
+  );
+
+  return (
+    <div className="relative w-full">
+      <div
+        ref={containerRef}
+        className="relative w-full overflow-hidden rounded-[48px] border border-[#c8a24a]/40 bg-[#08261d] shadow-[0_25px_80px_rgba(0,0,0,0.55)]"
+        style={{ aspectRatio: "3 / 2" }}
+      >
+        <TableSurfaceSVG seats={seatStates} onLayout={setLayout} className="h-full w-full" />
+        <BetSpotOverlay
+          game={game}
+          dimensions={dimensions}
+          activeChip={activeChip}
+          onSetBet={onSetBet}
+          onSit={onSit}
+          onLeave={onLeave}
+          onInsurance={onInsurance}
+          onDeclineInsurance={onDeclineInsurance}
+        />
+        <CardLayer
+          game={game}
+          dimensions={dimensions}
+          onHit={onHit}
+          onStand={onStand}
+          onDouble={onDouble}
+          onSplit={onSplit}
+          onSurrender={onSurrender}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/table/TableSurfaceSVG.tsx
+++ b/src/components/table/TableSurfaceSVG.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { Icon } from "@iconify/react";
+import { palette } from "../../theme/palette";
+import { defaultTableAnchors, type SeatAnchor, type TableAnchors } from "./coords";
+
+export interface SeatVisualState {
+  index: number;
+  occupied: boolean;
+  hasBet: boolean;
+  isActive: boolean;
+  label: string;
+}
+
+interface TableSurfaceSVGProps {
+  className?: string;
+  seats: SeatVisualState[];
+  onLayout?: (layout: TableAnchors) => void;
+}
+
+const SEAT_RING_BASE = "rgba(234, 233, 225, 0.45)";
+
+export const TableSurfaceSVG: React.FC<TableSurfaceSVGProps> = ({ className, seats, onLayout }) => {
+  const outerTextId = React.useId();
+  const innerTextId = React.useId();
+
+  React.useEffect(() => {
+    onLayout?.(defaultTableAnchors);
+  }, [onLayout]);
+
+  const seatByIndex = React.useMemo(() => {
+    const map = new Map<number, SeatVisualState>();
+    for (const seat of seats) {
+      map.set(seat.index, seat);
+    }
+    return map;
+  }, [seats]);
+
+  const seatCircleStroke = (seat: SeatVisualState | undefined): string => {
+    if (!seat) {
+      return SEAT_RING_BASE;
+    }
+    if (seat.isActive) {
+      return palette.gold;
+    }
+    if (seat.hasBet) {
+      return "rgba(200, 162, 74, 0.7)";
+    }
+    if (seat.occupied) {
+      return "rgba(255, 255, 255, 0.4)";
+    }
+    return "rgba(255, 255, 255, 0.15)";
+  };
+
+  return (
+    <svg
+      viewBox={`0 0 ${defaultTableAnchors.viewBox.width} ${defaultTableAnchors.viewBox.height}`}
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <defs>
+        <radialGradient id="feltGradient" cx="50%" cy="40%" r="75%">
+          <stop offset="0%" stopColor={palette.felt.light} />
+          <stop offset="100%" stopColor={palette.felt.dark} />
+        </radialGradient>
+      </defs>
+
+      <rect
+        x={60}
+        y={50}
+        width={defaultTableAnchors.viewBox.width - 120}
+        height={defaultTableAnchors.viewBox.height - 120}
+        rx={220}
+        fill="url(#feltGradient)"
+        stroke={palette.gold}
+        strokeWidth={3}
+      />
+
+      <rect
+        x={defaultTableAnchors.dealerArea.x}
+        y={defaultTableAnchors.dealerArea.y}
+        width={defaultTableAnchors.dealerArea.width}
+        height={defaultTableAnchors.dealerArea.height}
+        rx={40}
+        fill="rgba(15, 45, 34, 0.6)"
+        stroke="rgba(200, 162, 74, 0.4)"
+        strokeWidth={2}
+      />
+
+      <path id={outerTextId} d={defaultTableAnchors.outerTextPath} fill="none" />
+      <path id={innerTextId} d={defaultTableAnchors.innerTextPath} fill="none" />
+
+      <text fill={palette.line} fontSize={32} fontWeight={600} letterSpacing={6} textAnchor="middle">
+        <textPath startOffset="50%" xlinkHref={`#${outerTextId}`}>BLACKJACK PAYS 3 TO 2</textPath>
+      </text>
+      <text fill={palette.line} fontSize={24} fontWeight={500} letterSpacing={8} textAnchor="middle">
+        <textPath startOffset="50%" xlinkHref={`#${innerTextId}`}>INSURANCE PAYS 2 TO 1</textPath>
+      </text>
+
+      {defaultTableAnchors.seats.map((anchor: SeatAnchor) => {
+        const seat = seatByIndex.get(anchor.index);
+        return (
+          <g key={anchor.index}>
+            <circle
+              cx={anchor.x}
+              cy={anchor.y}
+              r={defaultTableAnchors.seatRadius}
+              fill="rgba(15, 46, 36, 0.75)"
+              stroke={seatCircleStroke(seat)}
+              strokeWidth={seat?.isActive ? 4 : 2.5}
+            />
+            <circle
+              cx={anchor.x}
+              cy={anchor.y}
+              r={defaultTableAnchors.seatRadius - 10}
+              fill="rgba(11, 37, 32, 0.8)"
+              stroke="rgba(234, 233, 225, 0.08)"
+              strokeWidth={1.5}
+            />
+            <text
+              x={anchor.x}
+              y={anchor.y - defaultTableAnchors.seatLabelOffset}
+              fill={palette.line}
+              fontSize={18}
+              fontWeight={600}
+              textAnchor="middle"
+              letterSpacing={3}
+            >
+              {anchor.label.toUpperCase()}
+            </text>
+          </g>
+        );
+      })}
+
+      <g transform={`translate(${defaultTableAnchors.shoeAnchor.x - 30}, ${defaultTableAnchors.shoeAnchor.y - 30})`}>
+        <Icon icon="game-icons:card-pick" width={60} height={60} color={palette.line} />
+        <text x={30} y={70} fill={palette.line} fontSize={12} textAnchor="middle" letterSpacing={4}>
+          SHOE
+        </text>
+      </g>
+
+      <g transform={`translate(${defaultTableAnchors.discardAnchor.x - 30}, ${defaultTableAnchors.discardAnchor.y - 30})`}>
+        <Icon icon="game-icons:card-exchange" width={60} height={60} color={palette.line} />
+        <text x={30} y={70} fill={palette.line} fontSize={12} textAnchor="middle" letterSpacing={4}>
+          DISCARD
+        </text>
+      </g>
+    </svg>
+  );
+};

--- a/src/components/table/coords.ts
+++ b/src/components/table/coords.ts
@@ -1,0 +1,124 @@
+import type { Seat } from "../../engine/types";
+
+export interface SeatAnchor {
+  index: number;
+  label: string;
+  x: number;
+  y: number;
+}
+
+export interface TableAnchors {
+  viewBox: {
+    width: number;
+    height: number;
+  };
+  seatRadius: number;
+  seatLabelOffset: number;
+  seatArc: {
+    cx: number;
+    cy: number;
+    rx: number;
+    ry: number;
+    startDeg: number;
+    endDeg: number;
+  };
+  seats: SeatAnchor[];
+  dealerArea: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  shoeAnchor: { x: number; y: number };
+  discardAnchor: { x: number; y: number };
+  outerTextPath: string;
+  innerTextPath: string;
+}
+
+const VIEWBOX_WIDTH = 1200;
+const VIEWBOX_HEIGHT = 800;
+
+const SEAT_COUNT = 7;
+const START_DEG = -60;
+const END_DEG = 240;
+
+const computeSeatAnchors = (
+  cx: number,
+  cy: number,
+  rx: number,
+  ry: number
+): SeatAnchor[] => {
+  const step = (END_DEG - START_DEG) / (SEAT_COUNT - 1);
+  return Array.from({ length: SEAT_COUNT }, (_, index) => {
+    const theta = ((START_DEG + index * step) * Math.PI) / 180;
+    const x = cx + rx * Math.cos(theta);
+    const y = cy + ry * Math.sin(theta);
+    return {
+      index,
+      label: `Seat ${index + 1}`,
+      x,
+      y
+    };
+  });
+};
+
+const buildArcPath = (cx: number, cy: number, rx: number, ry: number): string => {
+  const startX = cx - rx;
+  const startY = cy;
+  const endX = cx + rx;
+  const endY = cy;
+  return `M ${startX} ${startY} A ${rx} ${ry} 0 0 1 ${endX} ${endY}`;
+};
+
+export const defaultTableAnchors: TableAnchors = {
+  viewBox: {
+    width: VIEWBOX_WIDTH,
+    height: VIEWBOX_HEIGHT
+  },
+  seatRadius: 60,
+  seatLabelOffset: 90,
+  seatArc: {
+    cx: VIEWBOX_WIDTH / 2,
+    cy: 540,
+    rx: 420,
+    ry: 250,
+    startDeg: START_DEG,
+    endDeg: END_DEG
+  },
+  seats: computeSeatAnchors(VIEWBOX_WIDTH / 2, 540, 420, 250),
+  dealerArea: {
+    x: 470,
+    y: 130,
+    width: 260,
+    height: 130
+  },
+  shoeAnchor: {
+    x: 940,
+    y: 190
+  },
+  discardAnchor: {
+    x: 260,
+    y: 190
+  },
+  outerTextPath: buildArcPath(VIEWBOX_WIDTH / 2, 210, 360, 180),
+  innerTextPath: buildArcPath(VIEWBOX_WIDTH / 2, 290, 300, 150)
+};
+
+export const mapSeatAnchors = <T>(seats: Seat[], mapper: (seat: Seat, anchor: SeatAnchor) => T): T[] =>
+  seats.map((seat) => {
+    const anchor = defaultTableAnchors.seats[seat.index];
+    return mapper(seat, anchor);
+  });
+
+export const toPixels = (
+  x: number,
+  y: number,
+  dimensions: { width: number; height: number }
+): { x: number; y: number } => {
+  const scaleX = dimensions.width / defaultTableAnchors.viewBox.width;
+  const scaleY = dimensions.height / defaultTableAnchors.viewBox.height;
+  return {
+    x: x * scaleX,
+    y: y * scaleY
+  };
+};

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,0 +1,24 @@
+export const palette = {
+  felt: {
+    light: "#0f3d2e",
+    dark: "#0b2d22"
+  },
+  feltHighlight: "#145941",
+  line: "#eae9e1",
+  gold: "#c8a24a",
+  cardBack: "#0d3a3a",
+  cardBackBorder: "#c8a24a",
+  cardFront: "#113c2d",
+  text: "#f6f5ef",
+  subtleText: "#c7d1c9"
+} as const;
+
+export const chipPalette: Record<number, { base: string; accent: string; text: string }> = {
+  1: { base: "#f5f5f2", accent: "#dad9d4", text: "#2f2f2f" },
+  5: { base: "#d54848", accent: "#b63d3d", text: "#f9f4f4" },
+  25: { base: "#2d6a4f", accent: "#24533d", text: "#f1f9f5" },
+  100: { base: "#1d1d1d", accent: "#3a3a3a", text: "#f0f0f0" },
+  500: { base: "#6a3ea1", accent: "#553281", text: "#f4eef9" }
+};
+
+export type ChipDenomination = keyof typeof chipPalette;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig({
@@ -9,6 +9,7 @@ export default defineConfig({
     setupFiles: [],
     include: ["tests/**/*.test.ts"],
     coverage: {
+      provider: "v8",
       reporter: ["text", "html"]
     }
   }


### PR DESCRIPTION
## Summary
- add a themed palette and table geometry helpers for the casino felt layout
- replace the table UI with SVG felt, betting overlays, chip tray, and card/card action layers
- update supporting components, configs, dependencies, and documentation for the new presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e29e4a120c8329a04025eb4450894f