### PR TITLE
Add CI workflow and verification script

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,6 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react-hooks/recommended",
-    "plugin:react-refresh/recommended",
     "prettier"
   ],
   parser: "@typescript-eslint/parser",
@@ -17,7 +16,7 @@ module.exports = {
     ecmaVersion: "latest",
     sourceType: "module"
   },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "react-refresh"],
   rules: {
     "react-refresh/only-export-components": ["warn", { allowConstantExport: true }]
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run verification suite
+        env:
+          CI: true
+        run: npm run verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Client code lives in `src`, with stateful game rules under `src/engine` and UI w
 ## Build, Test, and Development Commands
 Use `npm install` once to hydrate dependencies. `npm run dev` launches Vite with hot reload; prefer it while iterating on UI. Ship-ready bundles come from `npm run build`, which type-checks via `tsc -b` before bundling. `npm run preview` serves the build artifact for smoke-testing. `npm run lint` runs ESLint across `.ts/.tsx`, and `npm test` executes the Vitest suite headlessly.
 
+Run `npm run verify` before opening a PR or handing work back to Codex. It chains linting, unit tests, the production build, and the Playwright e2e suite exactly like CI. If the Playwright browsers are missing locally, bootstrap them first with `npx playwright install --with-deps`.
+
 ## Coding Style & Naming Conventions
 Write modern TypeScript with React function components. Follow the existing two-space indentation and favor named exports (`export const Table`). Derive Tailwind class strings through `src/utils/cn.ts` instead of ad hoc concatenation. ESLint (see `.eslintrc.cjs`) and Prettier alignment catch most formatting issues—run `npm run lint` or `npx prettier --check "src/**/*.ts*"` before pushing. Name state stores with the `useXStore` pattern and component files in PascalCase.
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "lint": "eslint . --ext .ts,.tsx"
+    "lint": "eslint . --ext .ts,.tsx",
+    "verify": "npm run lint && npm run test && npm run build && npm run test:e2e"
   },
   "dependencies": {
     "@iconify-json/game-icons": "^1.2.3",

--- a/src/components/hud/RoundActionBar.tsx
+++ b/src/components/hud/RoundActionBar.tsx
@@ -54,11 +54,12 @@ export const RoundActionBar: React.FC<RoundActionBarProps> = ({
   const activeHand = findActiveHand(game);
   const parentSeat = activeHand ? game.seats[activeHand.parentSeatIndex] : null;
 
-  const legal = React.useMemo(() => {
+  const actionContext = React.useMemo(() => {
     if (!activeHand || !parentSeat || game.phase !== "playerActions") {
       return null;
     }
     return {
+      hand: activeHand,
       hit: canHit(activeHand),
       stand: !activeHand.isResolved,
       double: canDouble(activeHand, game.rules) && game.bankroll >= activeHand.bet,
@@ -87,24 +88,24 @@ export const RoundActionBar: React.FC<RoundActionBarProps> = ({
         </Button>
       </div>
 
-      {legal && (
+      {actionContext && (
         <div className="ml-auto flex items-center gap-2">
           <span className="hidden text-[10px] uppercase tracking-[0.4em] text-emerald-200 md:inline">
-            Active Bet {formatCurrency(activeHand.bet)}
+            Active Bet {formatCurrency(actionContext.hand.bet)}
           </span>
-          <Button size="sm" onClick={onHit} disabled={!legal.hit}>
+          <Button size="sm" onClick={onHit} disabled={!actionContext.hit}>
             Hit
           </Button>
-          <Button size="sm" variant="outline" onClick={onStand} disabled={!legal.stand}>
+          <Button size="sm" variant="outline" onClick={onStand} disabled={!actionContext.stand}>
             Stand
           </Button>
-          <Button size="sm" variant="outline" onClick={onDouble} disabled={!legal.double}>
+          <Button size="sm" variant="outline" onClick={onDouble} disabled={!actionContext.double}>
             Double
           </Button>
-          <Button size="sm" variant="outline" onClick={onSplit} disabled={!legal.split}>
+          <Button size="sm" variant="outline" onClick={onSplit} disabled={!actionContext.split}>
             Split
           </Button>
-          <Button size="sm" variant="outline" onClick={onSurrender} disabled={!legal.surrender}>
+          <Button size="sm" variant="outline" onClick={onSurrender} disabled={!actionContext.surrender}>
             Surrender
           </Button>
         </div>

--- a/src/components/table/CardLayer.tsx
+++ b/src/components/table/CardLayer.tsx
@@ -4,17 +4,11 @@ import { palette } from "../../theme/palette";
 import { toPixels, defaultTableAnchors } from "./coords";
 import type { GameState, Hand, Seat } from "../../engine/types";
 import { getHandTotals, isBust } from "../../engine/totals";
-import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
 import { formatCurrency } from "../../utils/currency";
 
 interface CardLayerProps {
   game: GameState;
   dimensions: { width: number; height: number };
-  onHit: () => void;
-  onStand: () => void;
-  onDouble: () => void;
-  onSplit: () => void;
-  onSurrender: () => void;
 }
 
 const cardStyle = {
@@ -87,15 +81,7 @@ const SeatHandCluster = (
   );
 };
 
-export const CardLayer: React.FC<CardLayerProps> = ({
-  game,
-  dimensions,
-  onHit,
-  onStand,
-  onDouble,
-  onSplit,
-  onSurrender
-}) => {
+export const CardLayer: React.FC<CardLayerProps> = ({ game, dimensions }) => {
   const revealHole =
     game.phase === "dealerPlay" || game.phase === "settlement" || game.dealer.hand.isBlackjack;
   const dealerCards = game.dealer.hand.cards;

--- a/src/components/table/TableLayout.tsx
+++ b/src/components/table/TableLayout.tsx
@@ -129,15 +129,7 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
               onInsurance={onInsurance}
               onDeclineInsurance={onDeclineInsurance}
             />
-            <CardLayer
-              game={game}
-              dimensions={{ width: BASE_W, height: BASE_H }}
-              onHit={onHit}
-              onStand={onStand}
-              onDouble={onDouble}
-              onSplit={onSplit}
-              onSurrender={onSurrender}
-            />
+            <CardLayer game={game} dimensions={{ width: BASE_W, height: BASE_H }} />
           </div>
         </div>
       </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
     "jsx": "react-jsx",
     "types": ["vitest/globals", "vite/client"]
   },


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that caches npm dependencies and runs the verification suite on pushes and pull requests
- provide an `npm run verify` helper so Codex can lint, test, build, and execute Playwright e2e locally just like CI
- resolve lint/type issues surfaced by the stricter pipeline and prevent `tsc -b` from emitting stray JavaScript artifacts

## Testing
- npm run verify

------
https://chatgpt.com/codex/tasks/task_e_68e40753c298832990e679d2d6f63694