### PR TITLE
feat: tidy seat overlays and card layout collisions

### DIFF
--- a/src/components/table/CardLayer.tsx
+++ b/src/components/table/CardLayer.tsx
@@ -1,15 +1,48 @@
 import React from "react";
 import { palette } from "../../theme/palette";
-import { toPixels, defaultTableAnchors } from "./coords";
+import { defaultTableAnchors, toPixels } from "./coords";
 import type { GameState, Hand, Seat } from "../../engine/types";
 import { getHandTotals, isBust } from "../../engine/totals";
 import { formatCurrency } from "../../utils/currency";
 import { PlayingCard } from "./PlayingCard";
+import { Button } from "../ui/button";
 
 interface CardLayerProps {
   game: GameState;
   dimensions: { width: number; height: number };
+  onInsurance: (seatIndex: number, handId: string, amount: number) => void;
+  onDeclineInsurance: (seatIndex: number, handId: string) => void;
 }
+
+interface SeatClusterSize {
+  width: number;
+  height: number;
+}
+
+interface SeatClusterLayout {
+  seat: Seat;
+  orientation: "up" | "down";
+  direction: { x: number; y: number };
+  position: { x: number; y: number };
+  size: SeatClusterSize;
+}
+
+const MIN_CLUSTER_GAP = 24;
+const SHIFT_LIMIT_BASE = 140;
+
+const normalizeVector = (vector: { x: number; y: number }): { x: number; y: number } => {
+  const magnitude = Math.hypot(vector.x, vector.y);
+  if (!Number.isFinite(magnitude) || magnitude === 0) {
+    return { x: 0, y: -1 };
+  }
+  return { x: vector.x / magnitude, y: vector.y / magnitude };
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
 
 const renderCard = (
   card: { rank: string; suit: string },
@@ -29,7 +62,7 @@ const renderHandBadges = (hand: Hand): React.ReactNode => {
     return null;
   }
   return (
-    <div className="flex flex-wrap gap-2 text-[12px] uppercase tracking-[0.25em]" style={{ color: palette.subtleText }}>
+    <div className="flex flex-wrap justify-center gap-2 text-[12px] uppercase tracking-[0.25em]" style={{ color: palette.subtleText }}>
       {badges.map((badge) => (
         <span key={badge} className="rounded-full bg-[#123428]/75 px-2 py-1 font-semibold">
           {badge}
@@ -39,33 +72,238 @@ const renderHandBadges = (hand: Hand): React.ReactNode => {
   );
 };
 
-const SeatHandCluster = (
+const renderInsurancePrompt = (
   seat: Seat,
-  seatIndex: number,
-  dimensions: { width: number; height: number },
-  children: React.ReactNode,
-  isActive: boolean
+  hand: Hand,
+  game: GameState,
+  onInsurance: CardLayerProps["onInsurance"],
+  onDeclineInsurance: CardLayerProps["onDeclineInsurance"]
 ): React.ReactNode => {
-  const anchor = defaultTableAnchors.seats[seatIndex];
-  const { x, y } = toPixels(anchor.x, anchor.y - defaultTableAnchors.seatRadius - 96, dimensions);
+  const alreadyResolved = hand.insuranceBet !== undefined;
+  if (!seat.occupied || game.phase !== "insurance" || alreadyResolved || hand.isResolved) {
+    return null;
+  }
+  const maxInsurance = Math.floor(hand.bet / 2);
+  const cappedAmount = Math.min(maxInsurance, Math.floor(game.bankroll));
+  const disabled = cappedAmount <= 0;
   return (
     <div
-      key={`${seat.index}-cluster`}
-      className="absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-4"
-      style={{
-        left: x,
-        top: y,
-        boxShadow: isActive
-          ? "0 0 0 2px rgba(200, 162, 74, 0.65), 0 18px 45px rgba(0,0,0,0.45)"
-          : "0 12px 35px rgba(0,0,0,0.35)"
-      }}
+      key={hand.id}
+      className="pointer-events-auto flex w-max min-w-[180px] flex-col items-center gap-2 rounded-lg border border-[#c8a24a]/60 bg-[#0d3024]/95 px-3 py-2 text-xs shadow-lg"
     >
-      {children}
+      <p className="font-semibold tracking-wide" style={{ color: palette.gold }}>
+        Insurance?
+      </p>
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          className="h-7 px-3 text-[11px] font-semibold uppercase tracking-[0.3em]"
+          onClick={() => onInsurance(seat.index, hand.id, cappedAmount)}
+          disabled={disabled}
+        >
+          Take {formatCurrency(cappedAmount)}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 px-3 text-[11px] font-semibold uppercase tracking-[0.3em]"
+          onClick={() => onDeclineInsurance(seat.index, hand.id)}
+        >
+          Skip
+        </Button>
+      </div>
     </div>
   );
 };
 
-export const CardLayer: React.FC<CardLayerProps> = ({ game, dimensions }) => {
+interface MutableCluster extends SeatClusterLayout {
+  basePosition: { x: number; y: number };
+  minX: number;
+  maxX: number;
+}
+
+const resolveSeatLayouts = (
+  seats: Seat[],
+  dimensions: { width: number; height: number },
+  clusterSizes: Record<number, SeatClusterSize>
+): SeatClusterLayout[] => {
+  const scaleX = dimensions.width / defaultTableAnchors.viewBox.width;
+  const scaleY = dimensions.height / defaultTableAnchors.viewBox.height;
+  const averageScale = (scaleX + scaleY) / 2;
+  const seatRadiusPx = defaultTableAnchors.seatRadius * scaleX;
+  const center = toPixels(defaultTableAnchors.seatArc.cx, defaultTableAnchors.seatArc.cy, dimensions);
+  const fallbackSize: SeatClusterSize = {
+    width: 220 * scaleX,
+    height: 220 * scaleY
+  };
+  const shiftLimit = SHIFT_LIMIT_BASE * averageScale;
+  const boundaryPadding = 40 * averageScale;
+  const clusters: MutableCluster[] = seats
+    .filter((seat) => seat.occupied || seat.baseBet > 0 || seat.hands.length > 0)
+    .map((seat) => {
+      const anchor = defaultTableAnchors.seats[seat.index];
+      const seatPosition = toPixels(anchor.x, anchor.y, dimensions);
+      const direction = normalizeVector({
+        x: center.x - seatPosition.x,
+        y: center.y - seatPosition.y
+      });
+      const orientation: "up" | "down" = direction.y < 0 ? "up" : "down";
+      const offset = seatRadiusPx + (orientation === "up" ? 120 * averageScale : 96 * averageScale);
+      const basePosition = {
+        x: seatPosition.x + direction.x * offset,
+        y: seatPosition.y + direction.y * offset
+      };
+      const size = clusterSizes[seat.index] ?? fallbackSize;
+      const minBoundary = size.width / 2 + boundaryPadding;
+      const maxBoundary = dimensions.width - size.width / 2 - boundaryPadding;
+      return {
+        seat,
+        orientation,
+        direction,
+        position: { ...basePosition },
+        size,
+        basePosition,
+        minX: Math.max(basePosition.x - shiftLimit, minBoundary),
+        maxX: Math.min(basePosition.x + shiftLimit, maxBoundary)
+      };
+    });
+
+  const grouped = new Map<"up" | "down", MutableCluster[]>();
+  clusters.forEach((cluster) => {
+    const key = cluster.orientation;
+    const bucket = grouped.get(key);
+    if (bucket) {
+      bucket.push(cluster);
+    } else {
+      grouped.set(key, [cluster]);
+    }
+  });
+
+  const gap = MIN_CLUSTER_GAP * averageScale;
+  grouped.forEach((group) => {
+    group.sort((a, b) => a.basePosition.x - b.basePosition.x);
+    for (let index = 1; index < group.length; index += 1) {
+      const previous = group[index - 1];
+      const current = group[index];
+      const minX = previous.position.x + previous.size.width / 2 + current.size.width / 2 + gap;
+      if (current.position.x < minX) {
+        current.position.x = Math.max(minX, current.minX);
+      }
+    }
+    for (let index = group.length - 2; index >= 0; index -= 1) {
+      const next = group[index + 1];
+      const current = group[index];
+      const maxX = next.position.x - next.size.width / 2 - current.size.width / 2 - gap;
+      if (current.position.x > maxX) {
+        current.position.x = Math.min(maxX, current.maxX);
+      }
+    }
+    for (let index = 1; index < group.length; index += 1) {
+      const previous = group[index - 1];
+      const current = group[index];
+      const minX = previous.position.x + previous.size.width / 2 + current.size.width / 2 + gap;
+      if (current.position.x < minX) {
+        current.position.x = minX;
+      }
+    }
+    group.forEach((cluster) => {
+      cluster.position.x = clamp(cluster.position.x, cluster.minX, cluster.maxX);
+    });
+  });
+
+  return clusters.map(({ seat, orientation, direction, position, size }) => ({
+    seat,
+    orientation,
+    direction,
+    position,
+    size
+  }));
+};
+
+export const CardLayer: React.FC<CardLayerProps> = ({
+  game,
+  dimensions,
+  onInsurance,
+  onDeclineInsurance
+}) => {
+  const clusterRefs = React.useRef(new Map<number, HTMLDivElement | null>());
+  const clusterRefCallbacks = React.useRef(new Map<number, (node: HTMLDivElement | null) => void>());
+  const [clusterSizes, setClusterSizes] = React.useState<Record<number, SeatClusterSize>>({});
+
+  const getClusterRef = React.useCallback(
+    (seatIndex: number) => {
+      if (!clusterRefCallbacks.current.has(seatIndex)) {
+        clusterRefCallbacks.current.set(seatIndex, (node: HTMLDivElement | null) => {
+          if (node) {
+            clusterRefs.current.set(seatIndex, node);
+            const rect = node.getBoundingClientRect();
+            setClusterSizes((previous) => {
+              const nextSize = { width: rect.width, height: rect.height };
+              const existing = previous[seatIndex];
+              if (
+                existing &&
+                Math.abs(existing.width - nextSize.width) < 0.5 &&
+                Math.abs(existing.height - nextSize.height) < 0.5
+              ) {
+                return previous;
+              }
+              return { ...previous, [seatIndex]: nextSize };
+            });
+          } else {
+            clusterRefs.current.delete(seatIndex);
+            setClusterSizes((previous) => {
+              if (!(seatIndex in previous)) {
+                return previous;
+              }
+              const next = { ...previous };
+              delete next[seatIndex];
+              return next;
+            });
+          }
+        });
+      }
+      return clusterRefCallbacks.current.get(seatIndex)!;
+    },
+    []
+  );
+
+  const seatLayouts = React.useMemo(
+    () => resolveSeatLayouts(game.seats, dimensions, clusterSizes),
+    [game.seats, dimensions, clusterSizes]
+  );
+
+  const layoutSignature = React.useMemo(
+    () => seatLayouts.map((layout) => layout.seat.index).join("-"),
+    [seatLayouts]
+  );
+
+  React.useLayoutEffect(() => {
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observers: ResizeObserver[] = [];
+    clusterRefs.current.forEach((node, seatIndex) => {
+      if (!node) {
+        return;
+      }
+      const observer = new ResizeObserver(([entry]) => {
+        const { width, height } = entry.contentRect;
+        setClusterSizes((previous) => {
+          const existing = previous[seatIndex];
+          if (existing && Math.abs(existing.width - width) < 0.5 && Math.abs(existing.height - height) < 0.5) {
+            return previous;
+          }
+          return { ...previous, [seatIndex]: { width, height } };
+        });
+      });
+      observer.observe(node);
+      observers.push(observer);
+    });
+    return () => {
+      observers.forEach((observer) => observer.disconnect());
+    };
+  }, [layoutSignature]);
+
   const revealHole =
     game.phase === "dealerPlay" || game.phase === "settlement" || game.dealer.hand.isBlackjack;
   const dealerCards = game.dealer.hand.cards;
@@ -111,31 +349,24 @@ export const CardLayer: React.FC<CardLayerProps> = ({ game, dimensions }) => {
         </div>
       </div>
 
-      {game.seats.map((seat) => {
+      {seatLayouts.map((layout) => {
+        const { seat, orientation, position } = layout;
         const isActiveSeat = game.activeSeatIndex === seat.index;
-        if (!seat.occupied && seat.baseBet === 0) {
-          return null;
-        }
         const hands = seat.hands.length > 0 ? seat.hands : [];
-        const clusterChildren: React.ReactNode[] = [];
-
-        if (hands.length === 0 && seat.baseBet > 0) {
-          clusterChildren.push(
+        const readyBadge =
+          hands.length === 0 && seat.baseBet > 0 ? (
             <span
               key="pending"
               className="rounded-full bg-[#0d3124]/75 px-4 py-1 text-sm uppercase tracking-[0.25em]"
             >
               Ready with {formatCurrency(seat.baseBet)}
             </span>
-          );
-        }
+          ) : null;
 
-        hands.forEach((hand, handIndex) => {
-          const cards = hand.cards.map((card, index) => {
-            return renderCard(card, `${hand.id}-${index}`);
-          });
+        const handNodes = hands.map((hand, handIndex) => {
+          const cards = hand.cards.map((card, cardIndex) => renderCard(card, `${hand.id}-${cardIndex}`));
           const handTotals = getHandTotals(hand);
-          clusterChildren.push(
+          return (
             <div key={hand.id} className="flex flex-col items-center gap-2">
               <div className="flex gap-3" style={{ transform: `translateX(${handIndex * 18}px)` }}>
                 {cards}
@@ -163,11 +394,44 @@ export const CardLayer: React.FC<CardLayerProps> = ({ game, dimensions }) => {
           );
         });
 
-        if (clusterChildren.length === 0) {
-          return null;
-        }
+        const promptElements = hands
+          .map((hand) => renderInsurancePrompt(seat, hand, game, onInsurance, onDeclineInsurance))
+          .filter(Boolean) as React.ReactNode[];
 
-        return SeatHandCluster(seat, seat.index, dimensions, clusterChildren, isActiveSeat);
+        const promptStack =
+          promptElements.length > 0 ? (
+            <div className="pointer-events-auto flex flex-col items-center gap-2">{promptElements}</div>
+          ) : null;
+
+        const clusterRef = getClusterRef(seat.index);
+        const boxShadow = isActiveSeat
+          ? "0 0 0 2px rgba(200, 162, 74, 0.65), 0 18px 45px rgba(0,0,0,0.45)"
+          : "0 12px 35px rgba(0,0,0,0.35)";
+
+        return (
+          <div
+            key={seat.index}
+            className="absolute flex -translate-x-1/2 -translate-y-1/2"
+            style={{ left: position.x, top: position.y }}
+          >
+            <div
+              ref={clusterRef}
+              className="pointer-events-none flex max-w-[280px] flex-col items-center gap-3 rounded-2xl px-4 py-3"
+              style={{
+                boxShadow,
+                backgroundColor: "rgba(4, 24, 18, 0.65)",
+                border: "1px solid rgba(21, 74, 58, 0.35)"
+              }}
+            >
+              {orientation === "up" && promptStack}
+              <div className="pointer-events-none flex flex-col items-center gap-3">
+                {readyBadge}
+                {handNodes}
+              </div>
+              {orientation === "down" && promptStack}
+            </div>
+          </div>
+        );
       })}
     </div>
   );

--- a/src/components/table/TableLayout.tsx
+++ b/src/components/table/TableLayout.tsx
@@ -8,8 +8,8 @@ import type { ChipDenomination } from "../../theme/palette";
 import { ChipTray } from "../hud/ChipTray";
 import { RoundActionBar } from "../hud/RoundActionBar";
 
-const BASE_W = 1320;
-const BASE_H = 760;
+const BASE_W = 1850;
+const BASE_H = 780;
 const HUD_HEIGHT = 120;
 const STAGE_PADDING = 16;
 
@@ -105,7 +105,7 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
         occupied: seat.occupied,
         hasBet: seat.baseBet > 0,
         isActive: game.activeSeatIndex === seat.index,
-        label: anchor.label
+        label: seat.occupied || seat.baseBet > 0 ? "" : anchor.label
       })),
     [game]
   );
@@ -144,10 +144,13 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
               onAddChip={onAddChip}
               onRemoveChipValue={onRemoveChipValue}
               onRemoveTopChip={onRemoveTopChip}
-              onInsurance={onInsurance}
-              onDeclineInsurance={onDeclineInsurance}
-            />
-            <CardLayer game={game} dimensions={{ width: BASE_W, height: BASE_H }} />
+        />
+        <CardLayer
+          game={game}
+          dimensions={{ width: BASE_W, height: BASE_H }}
+          onInsurance={onInsurance}
+          onDeclineInsurance={onDeclineInsurance}
+        />
           </div>
         </div>
       </div>

--- a/src/components/table/TableSurfaceSVG.tsx
+++ b/src/components/table/TableSurfaceSVG.tsx
@@ -117,17 +117,19 @@ export const TableSurfaceSVG: React.FC<TableSurfaceSVGProps> = ({ className, sea
               stroke="rgba(234, 233, 225, 0.08)"
               strokeWidth={1.5}
             />
-            <text
-              x={anchor.x}
-              y={anchor.y - defaultTableAnchors.seatLabelOffset}
-              fill={palette.line}
-              fontSize={18}
-              fontWeight={600}
-              textAnchor="middle"
-              letterSpacing={3}
-            >
-              {anchor.label.toUpperCase()}
-            </text>
+            {seat?.label ? (
+              <text
+                x={anchor.x}
+                y={anchor.y - defaultTableAnchors.seatLabelOffset}
+                fill={palette.line}
+                fontSize={18}
+                fontWeight={600}
+                textAnchor="middle"
+                letterSpacing={3}
+              >
+                {seat.label.toUpperCase()}
+              </text>
+            ) : null}
           </g>
         );
       })}

--- a/src/components/table/coords.ts
+++ b/src/components/table/coords.ts
@@ -35,7 +35,7 @@ export interface TableAnchors {
   innerTextPath: string;
 }
 
-const VIEWBOX_WIDTH = 1200;
+const VIEWBOX_WIDTH = 1500;
 const VIEWBOX_HEIGHT = 800;
 
 const SEAT_COUNT = 5;
@@ -77,36 +77,36 @@ export const defaultTableAnchors: TableAnchors = {
     height: VIEWBOX_HEIGHT
   },
   seatRadius: 56,
-  seatLabelOffset: 96,
+  seatLabelOffset: 104,
   seatArc: {
     cx: VIEWBOX_WIDTH / 2,
     cy: 492,
-    rx: 400,
+    rx: 500,
     ry: 220,
     startDeg: START_DEG,
     endDeg: END_DEG
   },
-  seats: computeSeatAnchors(VIEWBOX_WIDTH / 2, 492, 400, 220, SEAT_COUNT).map((anchor, index) => ({
+  seats: computeSeatAnchors(VIEWBOX_WIDTH / 2, 492, 500, 220, SEAT_COUNT).map((anchor, index) => ({
     ...anchor,
     index,
     label: `Seat ${index + 1}`
   })),
   dealerArea: {
-    x: 470,
+    x: 588,
     y: 138,
-    width: 260,
+    width: 325,
     height: 130
   },
   shoeAnchor: {
-    x: 930,
+    x: 1165,
     y: 200
   },
   discardAnchor: {
-    x: 270,
+    x: 338,
     y: 200
   },
-  outerTextPath: buildArcPath(VIEWBOX_WIDTH / 2, 210, 350, 180),
-  innerTextPath: buildArcPath(VIEWBOX_WIDTH / 2, 288, 288, 150)
+  outerTextPath: buildArcPath(VIEWBOX_WIDTH / 2, 202, 438, 180),
+  innerTextPath: buildArcPath(VIEWBOX_WIDTH / 2, 248, 360, 150)
 };
 
 export const mapSeatAnchors = <T>(seats: Seat[], mapper: (seat: Seat, anchor: SeatAnchor) => T): T[] =>


### PR DESCRIPTION
## Summary
- reposition the sit/leave controls within each seat circle and clean up the betting overlay
- add a measured seat-cluster layout so hands, prompts, and insurance modals avoid overlapping while staying near their seats
- further broaden the felt stage and update table anchors so the wider layout feels proportional

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e41dc4723c83298eb757095a202006