### PR TITLE
feat: add solo blackjack theme

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
+import "./theme/registerThemes";
 import { App } from "./pages/App";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,7 +1,24 @@
 import React from "react";
-import { Table } from "../components/Table";
 import { useGameStore } from "../store/useGameStore";
 import { Button } from "../components/ui/button";
+import { themes, DEFAULT_THEME_ID, THEME_STORAGE_KEY } from "../theme/registry";
+import { ThemeSwitcher } from "../theme/ThemeSwitcher";
+
+const resolveInitialTheme = (): string => {
+  if (typeof window === "undefined") {
+    return DEFAULT_THEME_ID;
+  }
+  const params = new URLSearchParams(window.location.search);
+  const fromQuery = params.get("theme");
+  if (fromQuery && themes.get(fromQuery)) {
+    return fromQuery;
+  }
+  const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored && themes.get(stored)) {
+    return stored;
+  }
+  return DEFAULT_THEME_ID;
+};
 
 export const App: React.FC = () => {
   const {
@@ -10,6 +27,7 @@ export const App: React.FC = () => {
     clearError,
     sit,
     leave,
+    setBet,
     addChip,
     removeChipValue,
     removeTopChip,
@@ -26,9 +44,42 @@ export const App: React.FC = () => {
     nextRound
   } = useGameStore();
 
+  const [themeId, setThemeId] = React.useState(resolveInitialTheme);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const fromQuery = params.get("theme");
+    if (fromQuery && themes.get(fromQuery)) {
+      setThemeId(fromQuery);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.setAttribute("data-theme", themeId);
+    }
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(THEME_STORAGE_KEY, themeId);
+    }
+  }, [themeId]);
+
+  const theme = React.useMemo(() => themes.get(themeId) ?? themes.get(DEFAULT_THEME_ID)!, [themeId]);
+  const Layout = theme.Layout;
+
+  const mainClass =
+    theme.id === "multiplayer"
+      ? "min-h-screen bg-gradient-to-b from-emerald-950 via-emerald-900 to-emerald-950 text-emerald-50"
+      : "min-h-screen bg-[var(--bg,#03120d)] text-[var(--text-hi,#e2fdf3)]";
+
   return (
-    <main className="min-h-screen bg-gradient-to-b from-emerald-950 via-emerald-900 to-emerald-950 p-6 text-emerald-50">
-      <div className="mx-auto flex min-h-[calc(100vh-3rem)] w-full max-w-[1400px] flex-col gap-4">
+    <main className={mainClass}>
+      <div className="mx-auto flex min-h-screen w-full max-w-[1500px] flex-col gap-4 p-6">
+        <div className="flex items-center justify-end">
+          <ThemeSwitcher currentTheme={theme.id} onChange={setThemeId} />
+        </div>
         {error && (
           <div className="flex items-center justify-between rounded-md border border-rose-600 bg-rose-900/60 px-4 py-2 text-sm">
             <span>{error}</span>
@@ -37,11 +88,12 @@ export const App: React.FC = () => {
             </Button>
           </div>
         )}
-        <Table
-            game={game}
+        <Layout
+          game={game}
           actions={{
             sit,
             leave,
+            setBet,
             addChip,
             removeChipValue,
             removeTopChip,

--- a/src/theme/ThemeSwitcher.tsx
+++ b/src/theme/ThemeSwitcher.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { themes } from "./registry";
+
+interface ThemeSwitcherProps {
+  currentTheme: string;
+  onChange: (id: string) => void;
+}
+
+export const ThemeSwitcher: React.FC<ThemeSwitcherProps> = ({ currentTheme, onChange }) => {
+  const allThemes = themes.all();
+
+  if (allThemes.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-slate-300">
+      <span>Theme</span>
+      <div className="flex gap-2">
+        {allThemes.map((theme) => {
+          const active = theme.id === currentTheme;
+          return (
+            <button
+              key={theme.id}
+              type="button"
+              className={`h-9 rounded-full border px-3 text-[10px] font-semibold uppercase tracking-[0.3em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                active
+                  ? "bg-[var(--accent,#c8a24a)] text-slate-900"
+                  : "bg-transparent text-current border-[rgba(255,255,255,0.25)] hover:bg-[rgba(255,255,255,0.08)]"
+              }`}
+              onClick={() => onChange(theme.id)}
+              aria-pressed={active}
+            >
+              {theme.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/theme/multiplayer/MultiplayerLayout.tsx
+++ b/src/theme/multiplayer/MultiplayerLayout.tsx
@@ -1,15 +1,16 @@
 import React from "react";
-import type { GameState } from "../engine/types";
-import { formatCurrency } from "../utils/currency";
-import { RuleBadges } from "./RuleBadges";
-import { TableLayout } from "./table/TableLayout";
-import type { ChipDenomination } from "../theme/palette";
+import type { GameState } from "../../engine/types";
+import { formatCurrency } from "../../utils/currency";
+import { RuleBadges } from "../../components/RuleBadges";
+import { TableLayout } from "../../components/table/TableLayout";
+import type { ChipDenomination } from "../../theme/palette";
 
-interface TableProps {
+interface MultiplayerLayoutProps {
   game: GameState;
   actions: {
     sit: (seatIndex: number) => void;
     leave: (seatIndex: number) => void;
+    setBet: (seatIndex: number, amount: number) => void;
     addChip: (seatIndex: number, denom: number) => void;
     removeChipValue: (seatIndex: number, denom: number) => void;
     removeTopChip: (seatIndex: number) => void;
@@ -36,7 +37,7 @@ const penetrationPercentage = (game: GameState): string => {
   return `${Math.round(penetration * 100)}%`;
 };
 
-export const Table: React.FC<TableProps> = ({ game, actions }) => {
+export const MultiplayerLayout: React.FC<MultiplayerLayoutProps> = ({ game, actions }) => {
   const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
   const headerRef = React.useRef<HTMLDivElement | null>(null);
   const [viewportHeight, setViewportHeight] = React.useState(

--- a/src/theme/multiplayer/index.ts
+++ b/src/theme/multiplayer/index.ts
@@ -1,0 +1,10 @@
+import { themes } from "../registry";
+import { MultiplayerLayout } from "./MultiplayerLayout";
+
+themes.register({
+  id: "multiplayer",
+  name: "Multiplayer Table",
+  Layout: MultiplayerLayout
+});
+
+export { MultiplayerLayout };

--- a/src/theme/registerThemes.ts
+++ b/src/theme/registerThemes.ts
@@ -1,0 +1,2 @@
+import "./solo";
+import "./multiplayer";

--- a/src/theme/registry.ts
+++ b/src/theme/registry.ts
@@ -1,0 +1,61 @@
+import React from "react";
+import type { GameState } from "../engine/types";
+
+type ThemeActionMap = {
+  sit: (seatIndex: number) => void;
+  leave: (seatIndex: number) => void;
+  setBet: (seatIndex: number, amount: number) => void;
+  addChip: (seatIndex: number, denom: number) => void;
+  removeChipValue: (seatIndex: number, denom: number) => void;
+  removeTopChip: (seatIndex: number) => void;
+  deal: () => void;
+  playerHit: () => void;
+  playerStand: () => void;
+  playerDouble: () => void;
+  playerSplit: () => void;
+  playerSurrender: () => void;
+  takeInsurance: (seatIndex: number, handId: string, amount: number) => void;
+  declineInsurance: (seatIndex: number, handId: string) => void;
+  finishInsurance: () => void;
+  playDealer: () => void;
+  nextRound: () => void;
+};
+
+export interface ThemeLayoutProps {
+  game: GameState;
+  actions: ThemeActionMap;
+}
+
+export interface ThemeDefinition {
+  id: string;
+  name: string;
+  Layout: React.ComponentType<ThemeLayoutProps>;
+}
+
+const registry = new Map<string, ThemeDefinition>();
+
+const listeners = new Set<() => void>();
+
+const notify = (): void => {
+  listeners.forEach((listener) => listener());
+};
+
+export const themes = {
+  register(definition: ThemeDefinition): void {
+    registry.set(definition.id, definition);
+    notify();
+  },
+  get(id: string): ThemeDefinition | undefined {
+    return registry.get(id);
+  },
+  all(): ThemeDefinition[] {
+    return Array.from(registry.values());
+  },
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  }
+};
+
+export const DEFAULT_THEME_ID = "solo";
+export const THEME_STORAGE_KEY = "ui.theme";

--- a/src/theme/solo/SoloLayout.tsx
+++ b/src/theme/solo/SoloLayout.tsx
@@ -1,0 +1,307 @@
+import React from "react";
+import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
+import type { Hand, Phase, Seat } from "../../engine/types";
+import type { ChipDenomination } from "../../theme/palette";
+import { ThemeLayoutProps } from "../registry";
+import { SoloHUD } from "./components/SoloHUD";
+import { DealerArea } from "./components/DealerArea";
+import { PlayerArea } from "./components/PlayerArea";
+import { BetChipsBar } from "./components/BetChipsBar";
+import { ActionBar, type SoloAction } from "./components/ActionBar";
+import { InsuranceStrip } from "./components/InsuranceStrip";
+import { StatsDrawer } from "./components/StatsDrawer";
+import { Toast } from "./components/Toast";
+
+const SOLO_SEAT_INDEX = 0;
+const CHIP_DEFAULT: ChipDenomination = 25;
+
+const findPrimarySeat = (seats: Seat[]): Seat => seats[SOLO_SEAT_INDEX] ?? seats[0];
+
+const findActiveHand = (handId: string | null, seat: Seat): Hand | null => {
+  if (!handId) return null;
+  return seat.hands.find((hand) => hand.id === handId) ?? null;
+};
+
+const computeAvailableActions = (
+  phase: Phase,
+  seat: Seat,
+  activeHand: Hand | null,
+  bankroll: number,
+  rules: ThemeLayoutProps["game"]["rules"],
+  lastBet: number
+): Set<SoloAction> => {
+  const actions = new Set<SoloAction>();
+  if (phase === "betting") {
+    if (seat.baseBet > 0) {
+      actions.add("deal");
+      actions.add("clear");
+    }
+    if (lastBet > 0 && bankroll + seat.baseBet >= lastBet) {
+      actions.add("rebet");
+    }
+  }
+
+  if (phase === "playerActions" && activeHand) {
+    if (canHit(activeHand)) {
+      actions.add("hit");
+    }
+    if (!activeHand.isResolved) {
+      actions.add("stand");
+    }
+    if (canDouble(activeHand, rules) && bankroll >= activeHand.bet) {
+      actions.add("double");
+    }
+    if (canSplit(activeHand, seat, rules) && bankroll >= activeHand.bet) {
+      actions.add("split");
+    }
+    if (canSurrender(activeHand, rules)) {
+      actions.add("surrender");
+    }
+  }
+
+  if (phase === "dealerPlay") {
+    actions.add("play-dealer");
+  }
+
+  if (phase === "settlement") {
+    actions.add("next-round");
+    if (lastBet > 0 && bankroll >= lastBet) {
+      actions.add("rebet");
+    }
+  }
+
+  return actions;
+};
+
+const primaryActionForPhase = (phase: Phase, available: Set<SoloAction>): SoloAction | null => {
+  if (phase === "betting" && available.has("deal")) return "deal";
+  if (phase === "playerActions" && available.has("hit")) return "hit";
+  if (phase === "dealerPlay" && available.has("play-dealer")) return "play-dealer";
+  if (phase === "settlement" && available.has("next-round")) return "next-round";
+  return null;
+};
+
+const insuranceCandidates = (seat: Seat): Hand[] =>
+  seat.hands.filter((hand) => hand.insuranceBet === undefined && !hand.isResolved);
+
+export const SoloLayout: React.FC<ThemeLayoutProps> = ({ game, actions }) => {
+  const seat = findPrimarySeat(game.seats);
+  const [activeChip, setActiveChip] = React.useState<ChipDenomination>(CHIP_DEFAULT);
+  const [statsOpen, setStatsOpen] = React.useState(false);
+  const [lastBet, setLastBet] = React.useState(() => seat.baseBet);
+  const [toastMessage, setToastMessage] = React.useState<string | null>(null);
+  const toastTimer = React.useRef<number | null>(null);
+  const activeHand = findActiveHand(game.activeHandId, seat);
+
+  const availableActions = React.useMemo(
+    () => computeAvailableActions(game.phase, seat, activeHand, game.bankroll, game.rules, lastBet),
+    [activeHand, game.bankroll, game.phase, game.rules, lastBet, seat]
+  );
+
+  const primaryAction = React.useMemo(
+    () => primaryActionForPhase(game.phase, availableActions),
+    [game.phase, availableActions]
+  );
+
+  const hudCollapsed = game.phase !== "betting";
+
+  React.useEffect(() => {
+    if (toastTimer.current) {
+      window.clearTimeout(toastTimer.current);
+    }
+    const last = game.messageLog[game.messageLog.length - 1] ?? null;
+    if (last) {
+      setToastMessage(last);
+      toastTimer.current = window.setTimeout(() => setToastMessage(null), 3000);
+    }
+    return () => {
+      if (toastTimer.current) {
+        window.clearTimeout(toastTimer.current);
+      }
+    };
+  }, [game.messageLog]);
+
+  const prevPhaseRef = React.useRef<Phase>(game.phase);
+  React.useEffect(() => {
+    const prev = prevPhaseRef.current;
+    if (prev === "betting" && game.phase !== "betting" && seat.baseBet > 0) {
+      setLastBet(seat.baseBet);
+    }
+    if (!seat.occupied) {
+      setLastBet(0);
+    }
+    prevPhaseRef.current = game.phase;
+  }, [game.phase, seat.baseBet, seat.occupied]);
+
+  React.useEffect(() => {
+    if (game.phase === "betting" && seat.baseBet > 0) {
+      setLastBet((current) => (current === 0 ? seat.baseBet : current));
+    }
+  }, [game.phase, seat.baseBet]);
+
+  const handleAction = (action: SoloAction) => {
+    switch (action) {
+      case "deal":
+        actions.deal();
+        break;
+      case "clear":
+        actions.setBet(seat.index, 0);
+        break;
+      case "rebet":
+        actions.setBet(seat.index, lastBet);
+        break;
+      case "hit":
+        actions.playerHit();
+        break;
+      case "stand":
+        actions.playerStand();
+        break;
+      case "double":
+        actions.playerDouble();
+        break;
+      case "split":
+        actions.playerSplit();
+        break;
+      case "surrender":
+        actions.playerSurrender();
+        break;
+      case "play-dealer":
+        actions.playDealer();
+        break;
+      case "next-round":
+        actions.nextRound();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const keyboardHandler = React.useCallback(
+    (event: KeyboardEvent) => {
+      const tagName = (event.target as HTMLElement | null)?.tagName;
+      if (tagName === "INPUT" || tagName === "TEXTAREA") {
+        return;
+      }
+      const key = event.key.toLowerCase();
+      if (key === " " || key === "enter") {
+        if (primaryAction) {
+          event.preventDefault();
+          handleAction(primaryAction);
+        }
+        return;
+      }
+      if (key === "h" && availableActions.has("hit")) handleAction("hit");
+      if (key === "s" && availableActions.has("stand")) handleAction("stand");
+      if (key === "d" && availableActions.has("double")) handleAction("double");
+      if (key === "p" && availableActions.has("split")) handleAction("split");
+      if (key === "r" && availableActions.has("surrender")) handleAction("surrender");
+      if (key === "c" && availableActions.has("clear")) handleAction("clear");
+      if (key === "i" && game.phase === "insurance") {
+        const hands = insuranceCandidates(seat);
+        if (hands.length > 0) {
+          const amount = Math.min(Math.floor(hands[0].bet / 2), Math.floor(game.bankroll));
+          actions.takeInsurance(seat.index, hands[0].id, amount);
+        }
+      }
+    },
+    [availableActions, game.bankroll, game.phase, handleAction, primaryAction, seat, actions]
+  );
+
+  React.useEffect(() => {
+    window.addEventListener("keydown", keyboardHandler);
+    return () => window.removeEventListener("keydown", keyboardHandler);
+  }, [keyboardHandler]);
+
+  const handleAddChip = (value: ChipDenomination) => {
+    if (game.phase !== "betting") return;
+    if (!seat.occupied) {
+      actions.sit(seat.index);
+    }
+    const totalBets = game.seats.reduce((sum, seatState) => sum + seatState.baseBet, 0);
+    const remainingBankroll = Math.max(0, Math.floor(game.bankroll - (totalBets - seat.baseBet)));
+    const nextBet = seat.baseBet + value;
+    if (remainingBankroll <= 0 || nextBet > game.rules.maxBet) {
+      return;
+    }
+    const denom = Math.min(value, remainingBankroll);
+    if (denom > 0) {
+      actions.addChip(seat.index, denom);
+    }
+  };
+
+  const insuranceHands = React.useMemo(() => insuranceCandidates(seat), [seat]);
+  const revealHole =
+    game.phase === "dealerPlay" || game.phase === "settlement" || game.dealer.hand.isBlackjack;
+
+  const handleInsurance = (handId: string, amount: number) => {
+    actions.takeInsurance(seat.index, handId, amount);
+  };
+
+  const handleDeclineInsurance = (handId: string) => {
+    actions.declineInsurance(seat.index, handId);
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col gap-6 bg-[var(--bg)] px-4 py-6 text-[var(--text-hi)]">
+      <SoloHUD
+        bankroll={game.bankroll}
+        bet={seat.baseBet}
+        round={game.roundCount}
+        phase={game.phase}
+        shoe={game.shoe}
+        statsOpen={statsOpen}
+        collapsed={hudCollapsed}
+        onToggleStats={() => setStatsOpen((value) => !value)}
+      />
+
+      <main className="flex flex-1 flex-col items-center gap-6">
+        <DealerArea hand={game.dealer.hand} revealHole={revealHole} phase={game.phase} rules={game.rules} />
+        <PlayerArea
+          seat={seat}
+          activeHandId={game.activeHandId}
+          phase={game.phase}
+          minBet={game.rules.minBet}
+          bankroll={game.bankroll}
+          availableActions={availableActions}
+          onSit={() => actions.sit(seat.index)}
+          onLeave={() => actions.leave(seat.index)}
+          gestureHandlers={{
+            onHit: availableActions.has("hit") ? () => handleAction("hit") : undefined,
+            onStand: availableActions.has("stand") ? () => handleAction("stand") : undefined,
+            onDouble: availableActions.has("double") ? () => handleAction("double") : undefined
+          }}
+        />
+      </main>
+
+      {game.phase === "insurance" && seat.occupied && (
+        <InsuranceStrip
+          seatIndex={seat.index}
+          hands={insuranceHands}
+          bankroll={game.bankroll}
+          onInsurance={handleInsurance}
+          onDecline={handleDeclineInsurance}
+        />
+      )}
+
+      <footer className="flex w-full flex-col gap-3 pb-6">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <BetChipsBar
+            activeChip={activeChip}
+            currentBet={seat.baseBet}
+            disabled={game.phase !== "betting" || !seat.occupied}
+            canClear={seat.baseBet > 0 && game.phase === "betting"}
+            canRebet={availableActions.has("rebet")}
+            onSelectChip={setActiveChip}
+            onAddChip={handleAddChip}
+            onClear={() => handleAction("clear")}
+            onRebet={() => handleAction("rebet")}
+          />
+          <ActionBar available={availableActions} primary={primaryAction} onInvoke={handleAction} />
+        </div>
+      </footer>
+
+      <StatsDrawer game={game} open={statsOpen} onClose={() => setStatsOpen(false)} />
+      <Toast message={toastMessage} />
+    </div>
+  );
+};

--- a/src/theme/solo/components/ActionBar.tsx
+++ b/src/theme/solo/components/ActionBar.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+
+type SoloAction =
+  | "deal"
+  | "clear"
+  | "rebet"
+  | "hit"
+  | "stand"
+  | "double"
+  | "split"
+  | "surrender"
+  | "play-dealer"
+  | "next-round";
+
+const LABELS: Record<SoloAction, string> = {
+  deal: "Deal",
+  clear: "Clear",
+  rebet: "Rebet",
+  hit: "Hit",
+  stand: "Stand",
+  double: "Double",
+  split: "Split",
+  surrender: "Surrender",
+  "play-dealer": "Play Dealer",
+  "next-round": "Next Round"
+};
+
+const KEY_HINT: Partial<Record<SoloAction, string>> = {
+  deal: "Space",
+  hit: "H",
+  stand: "S",
+  double: "D",
+  split: "P",
+  surrender: "R",
+  clear: "C"
+};
+
+interface ActionBarProps {
+  available: Set<SoloAction>;
+  primary: SoloAction | null;
+  onInvoke: (action: SoloAction) => void;
+}
+
+export const ActionBar: React.FC<ActionBarProps> = ({ available, primary, onInvoke }) => {
+  const renderButton = (action: SoloAction) => {
+    const isAvailable = available.has(action);
+    const isPrimary = primary === action;
+    const label = LABELS[action];
+    const hint = KEY_HINT[action];
+    const className = `solo-control ${isPrimary ? "solo-primary" : "solo-secondary"}`;
+    return (
+      <button
+        key={action}
+        type="button"
+        className={`${className} flex min-w-[120px] flex-col items-center justify-center gap-0.5 text-[12px]`}
+        onClick={() => onInvoke(action)}
+        disabled={!isAvailable}
+      >
+        <span>{label}</span>
+        {hint && <span className="text-[9px] uppercase tracking-[0.35em] text-[var(--text-lo)]">{hint}</span>}
+      </button>
+    );
+  };
+
+  const order: SoloAction[] = [
+    "deal",
+    "hit",
+    "stand",
+    "double",
+    "split",
+    "surrender",
+    "play-dealer",
+    "next-round",
+    "clear",
+    "rebet"
+  ];
+
+  const visible = order.filter((action) => available.has(action));
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="solo-action-bar flex flex-wrap justify-end gap-2 px-4 py-3">
+      {visible.map((action) => renderButton(action))}
+    </div>
+  );
+};
+
+export type { SoloAction };

--- a/src/theme/solo/components/BetChipsBar.tsx
+++ b/src/theme/solo/components/BetChipsBar.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import type { ChipDenomination } from "../../../theme/palette";
+import { formatCurrency } from "../../../utils/currency";
+
+const CHIP_VALUES: ChipDenomination[] = [1, 5, 25, 100, 500];
+
+interface BetChipsBarProps {
+  activeChip: ChipDenomination;
+  currentBet: number;
+  disabled: boolean;
+  canClear: boolean;
+  canRebet: boolean;
+  onSelectChip: (value: ChipDenomination) => void;
+  onAddChip: (value: ChipDenomination) => void;
+  onClear: () => void;
+  onRebet: () => void;
+}
+
+export const BetChipsBar: React.FC<BetChipsBarProps> = ({
+  activeChip,
+  currentBet,
+  disabled,
+  canClear,
+  canRebet,
+  onSelectChip,
+  onAddChip,
+  onClear,
+  onRebet
+}) => {
+  return (
+    <div className="flex flex-1 flex-wrap items-center gap-4">
+      <div className="flex items-center gap-3">
+        {CHIP_VALUES.map((value) => {
+          const active = activeChip === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              className="solo-chip-button flex items-center justify-center text-sm font-semibold"
+              data-active={active}
+              onClick={() => {
+                onSelectChip(value);
+                if (!disabled) {
+                  onAddChip(value);
+                }
+              }}
+              disabled={disabled}
+              aria-pressed={active}
+              aria-label={`Jeton ${value}`}
+            >
+              {value}
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[var(--caps-track)] text-[var(--text-lo)]">
+        <span>Mise : {formatCurrency(currentBet)}</span>
+        <button
+          type="button"
+          className="solo-control solo-secondary h-10 px-4 text-[11px]"
+          onClick={onClear}
+          disabled={!canClear}
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          className="solo-control solo-secondary h-10 px-4 text-[11px]"
+          onClick={onRebet}
+          disabled={!canRebet}
+        >
+          Rebet
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/theme/solo/components/DealerArea.tsx
+++ b/src/theme/solo/components/DealerArea.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import type { Hand, Phase, RuleConfig } from "../../../engine/types";
+import { getHandTotals } from "../../../engine/totals";
+import { AnimatedCard } from "../../../components/animation/AnimatedCard";
+import { FlipCard } from "../../../components/animation/FlipCard";
+import { PlayingCard } from "../../../components/table/PlayingCard";
+import { DEAL_STAGGER } from "../../../utils/animConstants";
+
+interface DealerAreaProps {
+  hand: Hand;
+  revealHole: boolean;
+  phase: Phase;
+  rules: RuleConfig;
+}
+
+const CARD_WIDTH = 92;
+const CARD_GAP = 18;
+
+export const DealerArea: React.FC<DealerAreaProps> = ({ hand, revealHole, phase, rules }) => {
+  const totals = getHandTotals(hand);
+  const cards = hand.cards;
+
+  return (
+    <section className="flex w-full flex-col items-center gap-4 text-center">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.4em] text-[rgba(216,182,76,0.75)]">
+        Blackjack pays {rules.blackjackPayout} · Insurance 2:1
+      </div>
+      <div className="solo-surface flex w-full max-w-3xl flex-col items-center gap-3 px-6 py-5">
+        <span className="text-xs font-semibold uppercase tracking-[0.5em] text-[var(--text-lo)]">Dealer</span>
+        <div className="relative flex h-[160px] w-full items-center justify-center">
+          {cards.map((card, index) => {
+            const offsetX = index * (CARD_WIDTH + CARD_GAP);
+            const startX = -80 + index * 12;
+            const content =
+              index === 1 ? (
+                <FlipCard
+                  isRevealed={revealHole}
+                  back={<PlayingCard rank={card.rank} suit={card.suit} faceDown />}
+                  front={<PlayingCard rank={card.rank} suit={card.suit} />}
+                />
+              ) : (
+                <PlayingCard rank={card.rank} suit={card.suit} />
+              );
+            return (
+              <AnimatedCard
+                key={`${hand.id}-${card.rank}${card.suit}-${index}`}
+                id={`${hand.id}-${index}`}
+                from={{ x: startX, y: -140 }}
+                to={{ x: offsetX - ((cards.length - 1) * (CARD_WIDTH + CARD_GAP)) / 2, y: 0 }}
+                rotation={index * 2 - 4}
+                delay={index * DEAL_STAGGER}
+                z={index}
+              >
+                {content}
+              </AnimatedCard>
+            );
+          })}
+        </div>
+        <div className="rounded-full bg-[rgba(12,31,24,0.85)] px-4 py-1 text-xs uppercase tracking-[0.35em] text-[var(--text-hi)]">
+          {revealHole
+            ? totals.soft && totals.soft !== totals.hard
+              ? `Total ${totals.hard} / ${totals.soft}`
+              : `Total ${totals.hard}`
+            : phase === "betting"
+            ? "En attente"
+            : "Carte visible"}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/theme/solo/components/InsuranceStrip.tsx
+++ b/src/theme/solo/components/InsuranceStrip.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import type { Hand } from "../../../engine/types";
+import { formatCurrency } from "../../../utils/currency";
+
+interface InsuranceRowProps {
+  seatIndex: number;
+  hand: Hand;
+  bankroll: number;
+  onInsurance: (handId: string, amount: number) => void;
+  onDecline: (handId: string) => void;
+}
+
+const InsuranceRow: React.FC<InsuranceRowProps> = ({ seatIndex, hand, bankroll, onInsurance, onDecline }) => {
+  const maxInsurance = Math.floor(hand.bet / 2);
+  const capped = Math.min(maxInsurance, Math.floor(bankroll));
+  const [value, setValue] = React.useState(capped);
+
+  React.useEffect(() => {
+    setValue(capped);
+  }, [capped]);
+
+  return (
+    <div className="solo-surface flex w-full flex-col gap-3 px-4 py-3 text-sm text-[var(--text-hi)]">
+      <div className="flex items-center justify-between text-xs uppercase tracking-[var(--caps-track)] text-[var(--text-lo)]">
+        <span>Assurance main {hand.id.split("-").pop()}</span>
+        <span>Max {formatCurrency(maxInsurance)}</span>
+      </div>
+      <input
+        type="range"
+        min={0}
+        max={maxInsurance}
+        step={1}
+        value={value}
+        className="w-full accent-[var(--accent)]"
+        onChange={(event) => setValue(Number(event.target.value))}
+      />
+      <div className="flex items-center justify-between text-xs uppercase tracking-[var(--caps-track)]">
+        <span>Assurance {formatCurrency(value)}</span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="solo-control solo-secondary h-10 px-4 text-[11px]"
+            onClick={() => onDecline(hand.id)}
+          >
+            Passer
+          </button>
+          <button
+            type="button"
+            className="solo-control solo-primary h-10 px-4 text-[11px]"
+            onClick={() => onInsurance(hand.id, Math.min(value, capped))}
+            disabled={capped <= 0}
+          >
+            Prendre
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface InsuranceStripProps {
+  seatIndex: number;
+  hands: Hand[];
+  bankroll: number;
+  onInsurance: (handId: string, amount: number) => void;
+  onDecline: (handId: string) => void;
+}
+
+export const InsuranceStrip: React.FC<InsuranceStripProps> = ({
+  seatIndex,
+  hands,
+  bankroll,
+  onInsurance,
+  onDecline
+}) => {
+  if (hands.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-2 px-4">
+      {hands.map((hand) => (
+        <InsuranceRow
+          key={`${seatIndex}-${hand.id}`}
+          seatIndex={seatIndex}
+          hand={hand}
+          bankroll={bankroll}
+          onInsurance={onInsurance}
+          onDecline={onDecline}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/theme/solo/components/PlayerArea.tsx
+++ b/src/theme/solo/components/PlayerArea.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+import type { Hand, Phase, Seat } from "../../../engine/types";
+import { getHandTotals, isBust } from "../../../engine/totals";
+import { AnimatedCard } from "../../../components/animation/AnimatedCard";
+import { PlayingCard } from "../../../components/table/PlayingCard";
+import { DEAL_STAGGER } from "../../../utils/animConstants";
+import { formatCurrency } from "../../../utils/currency";
+
+interface GestureHandlers {
+  onHit?: () => void;
+  onStand?: () => void;
+  onDouble?: () => void;
+}
+
+interface PlayerAreaProps {
+  seat: Seat;
+  activeHandId: string | null;
+  phase: Phase;
+  minBet: number;
+  bankroll: number;
+  availableActions: Set<string>;
+  onSit: () => void;
+  onLeave: () => void;
+  gestureHandlers: GestureHandlers;
+}
+
+const CARD_WIDTH = 92;
+const CARD_GAP = 18;
+
+const PlayerHand: React.FC<{ hand: Hand; active: boolean; index: number }> = ({ hand, active, index }) => {
+  const totals = getHandTotals(hand);
+  const labels: string[] = [];
+  if (hand.isBlackjack) labels.push("Blackjack");
+  if (hand.isDoubled) labels.push("Doubled");
+  if (hand.isSurrendered) labels.push("Surrendered");
+  if (hand.isSplitHand) labels.push("Split");
+  if (isBust(hand)) labels.push("Bust");
+
+  return (
+    <div
+      key={hand.id}
+      className="solo-player-hand relative flex min-w-[220px] flex-col items-center gap-3 rounded-2xl border border-[rgba(216,182,76,0.18)] bg-[rgba(15,38,30,0.85)] px-4 py-4 transition-transform"
+      data-active={active}
+      style={{ borderColor: active ? "rgba(216,182,76,0.45)" : "rgba(216,182,76,0.18)" }}
+    >
+      <div className="flex items-center justify-between gap-4 text-xs uppercase tracking-[0.35em] text-[var(--text-lo)]">
+        <span>Main {index + 1}</span>
+        <span className="rounded-full bg-[rgba(216,182,76,0.12)] px-3 py-1 text-[var(--text-hi)]">
+          {formatCurrency(hand.bet)}
+        </span>
+      </div>
+      <div className="relative flex h-[150px] w-full items-center justify-center">
+        {hand.cards.map((card, cardIndex) => (
+          <AnimatedCard
+            key={`${hand.id}-${cardIndex}`}
+            id={`${hand.id}-${cardIndex}`}
+            from={{ x: -60 + cardIndex * 8, y: 140 }}
+            to={{ x: cardIndex * (CARD_WIDTH + CARD_GAP) - ((hand.cards.length - 1) * (CARD_WIDTH + CARD_GAP)) / 2, y: 0 }}
+            rotation={cardIndex * 4 - 6}
+            delay={cardIndex * DEAL_STAGGER}
+            z={cardIndex}
+          >
+            <PlayingCard rank={card.rank} suit={card.suit} />
+          </AnimatedCard>
+        ))}
+      </div>
+      <div className="flex flex-col items-center gap-1 text-xs uppercase tracking-[0.4em] text-[var(--text-hi)]">
+        {totals.soft && totals.soft !== totals.hard ? (
+          <span>
+            Total {totals.hard} / {totals.soft}
+          </span>
+        ) : (
+          <span>Total {totals.hard}</span>
+        )}
+        <div className="flex flex-wrap justify-center gap-2 text-[10px] font-semibold">
+          {labels.map((label) => (
+            <span key={label} className="rounded-full bg-[rgba(216,182,76,0.14)] px-2 py-1">
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const PlayerArea: React.FC<PlayerAreaProps> = ({
+  seat,
+  activeHandId,
+  phase,
+  minBet,
+  bankroll,
+  availableActions,
+  onSit,
+  onLeave,
+  gestureHandlers
+}) => {
+  const hands = seat.hands;
+  const isBetting = phase === "betting";
+  const isActionPhase = phase === "playerActions";
+  const showHands = hands.length > 0;
+
+  const gestureAllowed = isActionPhase && availableActions.has("hit");
+  const touchRef = React.useRef<{ x: number; y: number; time: number; timeout?: number | null; longPress?: boolean } | null>(null);
+
+  React.useEffect(() => () => {
+    if (touchRef.current?.timeout) {
+      window.clearTimeout(touchRef.current.timeout);
+    }
+  }, []);
+
+  const trigger = (callback?: () => void) => {
+    if (!callback) return;
+    callback();
+    if (typeof window !== "undefined" && "vibrate" in navigator) {
+      try {
+        navigator.vibrate?.(20);
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  const handleTouchStart: React.TouchEventHandler<HTMLDivElement> = (event) => {
+    if (!gestureAllowed) return;
+    const touch = event.touches[0];
+    const data = { x: touch.clientX, y: touch.clientY, time: Date.now(), timeout: null as number | null, longPress: false };
+    if (gestureHandlers.onDouble) {
+      data.timeout = window.setTimeout(() => {
+        data.longPress = true;
+        trigger(gestureHandlers.onDouble);
+      }, 650);
+    }
+    touchRef.current = data;
+  };
+
+  const handleTouchMove: React.TouchEventHandler<HTMLDivElement> = (event) => {
+    if (!gestureAllowed) return;
+    const ref = touchRef.current;
+    if (!ref) return;
+    const touch = event.touches[0];
+    const dx = Math.abs(touch.clientX - ref.x);
+    const dy = Math.abs(touch.clientY - ref.y);
+    if (dx > 30 || dy > 30) {
+      if (ref.timeout) {
+        window.clearTimeout(ref.timeout);
+        ref.timeout = null;
+      }
+    }
+  };
+
+  const handleTouchEnd: React.TouchEventHandler<HTMLDivElement> = (event) => {
+    if (!gestureAllowed) return;
+    const ref = touchRef.current;
+    if (!ref) return;
+    if (ref.timeout) {
+      window.clearTimeout(ref.timeout);
+    }
+    const touch = event.changedTouches[0];
+    const dx = touch.clientX - ref.x;
+    const dy = touch.clientY - ref.y;
+    const duration = Date.now() - ref.time;
+    if (ref.longPress) {
+      touchRef.current = null;
+      return;
+    }
+    if (Math.abs(dy) > Math.abs(dx) && dy < -50) {
+      trigger(gestureHandlers.onHit);
+    } else if (dx > 60) {
+      trigger(gestureHandlers.onStand);
+    } else if (duration < 300 && Math.abs(dx) < 30 && Math.abs(dy) < 30) {
+      trigger(gestureHandlers.onHit);
+    }
+    touchRef.current = null;
+  };
+
+  return (
+    <section
+      className="flex w-full flex-col items-center gap-4"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className="flex w-full max-w-3xl items-center justify-between px-2">
+        <div>
+          <span className="text-xs uppercase tracking-[0.4em] text-[var(--text-lo)]">Vous</span>
+          <h2 className="text-2xl font-semibold text-[var(--text-hi)]">Main du joueur</h2>
+        </div>
+        {seat.occupied ? (
+          <button type="button" className="solo-control solo-secondary h-10 px-4 text-[11px]" onClick={onLeave}>
+            Quitter
+          </button>
+        ) : null}
+      </div>
+      <div className="solo-surface flex w-full max-w-3xl flex-col items-center gap-5 px-6 py-6">
+        {!seat.occupied && (
+          <div className="flex flex-col items-center gap-3 text-center">
+            <p className="text-sm uppercase tracking-[0.35em] text-[var(--text-lo)]">Une seule place disponible</p>
+            <button type="button" className="solo-control solo-primary" onClick={onSit}>
+              Prendre le siège
+            </button>
+          </div>
+        )}
+        {seat.occupied && !showHands && (
+          <div className="flex flex-col items-center gap-2 text-center text-sm text-[var(--text-lo)]">
+            <p className="uppercase tracking-[0.35em]">Placez votre mise</p>
+            <p className="text-xs text-[rgba(168,179,167,0.75)]">Minimum {formatCurrency(minBet)} · Bankroll {formatCurrency(bankroll)}</p>
+          </div>
+        )}
+        {seat.occupied && showHands && (
+          <div
+            className="flex w-full flex-wrap items-start justify-center gap-4 md:flex-nowrap"
+            style={{ gap: "20px" }}
+          >
+            {hands.map((hand, index) => (
+              <PlayerHand key={hand.id} hand={hand} index={index} active={hand.id === activeHandId} />
+            ))}
+          </div>
+        )}
+      </div>
+      {isBetting && seat.baseBet > 0 && (
+        <div className="rounded-full bg-[rgba(12,31,24,0.9)] px-4 py-1 text-xs uppercase tracking-[0.4em] text-[var(--text-hi)]">
+          Mise actuelle {formatCurrency(seat.baseBet)}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/theme/solo/components/SoloHUD.tsx
+++ b/src/theme/solo/components/SoloHUD.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import type { Phase, Shoe } from "../../../engine/types";
+import { formatCurrency } from "../../../utils/currency";
+
+interface SoloHUDProps {
+  bankroll: number;
+  bet: number;
+  round: number;
+  phase: Phase;
+  shoe: Shoe;
+  statsOpen: boolean;
+  collapsed: boolean;
+  onToggleStats: () => void;
+}
+
+const penetrationLabel = (shoe: Shoe): string => {
+  const total = shoe.cards.length + shoe.discard.length;
+  if (total === 0) {
+    return "0%";
+  }
+  return `${Math.round((shoe.discard.length / total) * 100)}%`;
+};
+
+export const SoloHUD: React.FC<SoloHUDProps> = ({
+  bankroll,
+  bet,
+  round,
+  phase,
+  shoe,
+  statsOpen,
+  collapsed,
+  onToggleStats
+}) => {
+  const cardsRemaining = shoe.cards.length;
+  const penetration = penetrationLabel(shoe);
+  const hudStateClass = collapsed ? "solo-hud solo-hud-reduced" : "solo-hud solo-hud-expanded";
+
+  return (
+    <header className={`${hudStateClass} flex w-full items-center justify-between gap-4 px-4 py-3 transition-[opacity,filter]`}
+      aria-live="polite"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-6">
+        <div className="flex flex-col gap-1">
+          <span className="text-[10px] font-semibold uppercase tracking-[var(--caps-track)] text-[var(--text-lo)]">Bankroll</span>
+          <span className="text-lg font-semibold text-[var(--text-hi)]">{formatCurrency(bankroll)}</span>
+        </div>
+        <div className="hidden flex-col gap-1 sm:flex">
+          <span className="text-[10px] font-semibold uppercase tracking-[var(--caps-track)] text-[var(--text-lo)]">
+            Mise
+          </span>
+          <span className="text-lg font-semibold text-[var(--text-hi)]">{formatCurrency(bet)}</span>
+        </div>
+      </div>
+      <div className="flex flex-1 justify-center gap-6 text-center text-xs uppercase tracking-[var(--caps-track)] text-[var(--text-lo)] sm:text-sm">
+        <div className="flex flex-col gap-0.5">
+          <span>Round</span>
+          <span className="text-base font-semibold text-[var(--text-hi)]">{round}</span>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <span>Phase</span>
+          <span className="text-base font-semibold text-[var(--text-hi)]">{phase}</span>
+        </div>
+        <div className="hidden flex-col gap-0.5 md:flex">
+          <span>Cartes</span>
+          <span className="text-base font-semibold text-[var(--text-hi)]">{cardsRemaining}</span>
+        </div>
+        <div className="hidden flex-col gap-0.5 md:flex">
+          <span>Pénétration</span>
+          <span className="text-base font-semibold text-[var(--text-hi)]">{penetration}</span>
+        </div>
+      </div>
+      <div className="flex flex-1 items-center justify-end gap-3">
+        <div className="flex flex-col items-end gap-1 text-right text-[11px] uppercase tracking-[var(--caps-track)] text-[var(--text-lo)]">
+          <span>Sabot</span>
+          <span className="text-base font-semibold text-[var(--text-hi)]">{cardsRemaining} cartes</span>
+        </div>
+        <button
+          type="button"
+          className="solo-control solo-secondary h-10 px-3 text-[11px]"
+          aria-pressed={statsOpen}
+          onClick={onToggleStats}
+        >
+          Stats
+        </button>
+      </div>
+    </header>
+  );
+};

--- a/src/theme/solo/components/StatsDrawer.tsx
+++ b/src/theme/solo/components/StatsDrawer.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { GameState } from "../../../engine/types";
+import { formatCurrency } from "../../../utils/currency";
+
+interface StatsDrawerProps {
+  game: GameState;
+  open: boolean;
+  onClose: () => void;
+}
+
+const variants = {
+  hidden: { x: "100%" },
+  visible: { x: 0 }
+};
+
+export const StatsDrawer: React.FC<StatsDrawerProps> = ({ game, open, onClose }) => {
+  const totalCards = game.shoe.cards.length + game.shoe.discard.length;
+  const penetration = totalCards === 0 ? 0 : (game.shoe.discard.length / totalCards) * 100;
+  const recentMessages = game.messageLog.slice(-5).reverse();
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.aside
+          key="stats"
+          className="solo-stats-drawer fixed inset-y-0 right-0 z-50 flex w-full max-w-sm flex-col gap-4 px-6 py-6 text-[var(--text-hi)]"
+          initial="hidden"
+          animate="visible"
+          exit="hidden"
+          variants={variants}
+          transition={{ type: "spring", stiffness: 160, damping: 22 }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Statistiques"
+        >
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold uppercase tracking-[var(--caps-track)]">Stats & Sabot</h3>
+            <button type="button" className="solo-control solo-secondary h-10 px-3 text-[11px]" onClick={onClose}>
+              Fermer
+            </button>
+          </div>
+          <section className="space-y-2 text-sm text-[var(--text-lo)]">
+            <h4 className="text-xs uppercase tracking-[var(--caps-track)] text-[var(--text-hi)]">Shoe</h4>
+            <p>Cartes restantes : {game.shoe.cards.length}</p>
+            <p>Défausse : {game.shoe.discard.length}</p>
+            <p>Pénétration : {penetration.toFixed(0)}%</p>
+            <p>Cut card : {game.shoe.cutIndex}</p>
+          </section>
+          <section className="space-y-2 text-sm text-[var(--text-lo)]">
+            <h4 className="text-xs uppercase tracking-[var(--caps-track)] text-[var(--text-hi)]">Règles</h4>
+            <p>Blackjack {game.rules.blackjackPayout}</p>
+            <p>Double : {game.rules.doubleAllowed}</p>
+            <p>Surrender : {game.rules.surrender}</p>
+            <p>Decks : {game.rules.numberOfDecks}</p>
+            <p>Banque sur soft 17 : {game.rules.dealerStandsOnSoft17 ? "Stand" : "Hit"}</p>
+          </section>
+          <section className="space-y-2 text-sm text-[var(--text-lo)]">
+            <h4 className="text-xs uppercase tracking-[var(--caps-track)] text-[var(--text-hi)]">Score</h4>
+            <p>Bankroll : {formatCurrency(game.bankroll)}</p>
+            <p>Round : {game.roundCount}</p>
+            <p>Phase : {game.phase}</p>
+          </section>
+          <section className="space-y-2 text-sm text-[var(--text-lo)]">
+            <h4 className="text-xs uppercase tracking-[var(--caps-track)] text-[var(--text-hi)]">Historique</h4>
+            {recentMessages.length === 0 ? (
+              <p>Aucun évènement récent.</p>
+            ) : (
+              <ul className="space-y-1">
+                {recentMessages.map((message, index) => (
+                  <li key={`${message}-${index}`} className="text-xs uppercase tracking-[0.2em] text-[var(--text-hi)]/80">
+                    {message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </motion.aside>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/theme/solo/components/Toast.tsx
+++ b/src/theme/solo/components/Toast.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+interface ToastProps {
+  message: string | null;
+}
+
+export const Toast: React.FC<ToastProps> = ({ message }) => {
+  return (
+    <AnimatePresence>
+      {message && (
+        <motion.div
+          key={message}
+          className="solo-toast fixed bottom-6 right-6 z-50 px-4 py-3 text-sm uppercase tracking-[0.3em]"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          transition={{ duration: 0.25 }}
+          role="status"
+          aria-live="assertive"
+        >
+          {message}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/theme/solo/index.ts
+++ b/src/theme/solo/index.ts
@@ -1,0 +1,11 @@
+import "./tokens.css";
+import { themes } from "../registry";
+import { SoloLayout } from "./SoloLayout";
+
+themes.register({
+  id: "solo",
+  name: "Solo Table",
+  Layout: SoloLayout
+});
+
+export { SoloLayout };

--- a/src/theme/solo/tokens.css
+++ b/src/theme/solo/tokens.css
@@ -1,0 +1,140 @@
+:root[data-theme="solo"] {
+  --bg: #0c1f18;
+  --bg-elev: #0f261e;
+  --line: #b8952a;
+  --text-hi: #f3efe3;
+  --text-lo: #a8b3a7;
+  --accent: #d8b64c;
+  --chip-green: #1e3a2f;
+  --danger: #d75a5a;
+  --radius: 16px;
+  --radius-lg: 24px;
+  --shadow-1: 0 6px 24px rgba(0, 0, 0, 0.35);
+  --glow: 0 0 0 1px rgba(184, 149, 42, 0.35), 0 0 18px rgba(184, 149, 42, 0.25);
+  --gap: 12px;
+  --gap-lg: 20px;
+  --btn-h: 48px;
+  --chip-size: 48px;
+  --font-ui: ui-sans-serif, system-ui, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  --caps-track: 0.08em;
+}
+
+[data-theme="solo"] body {
+  background: radial-gradient(circle at top, #123327 0%, #0c1f18 60%, #07140f 100%);
+  color: var(--text-hi);
+  font-family: var(--font-ui);
+}
+
+[data-theme="solo"] .solo-surface {
+  background: linear-gradient(180deg, rgba(18, 51, 39, 0.75) 0%, rgba(12, 31, 24, 0.95) 100%);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-1);
+  border: 1px solid rgba(216, 182, 76, 0.15);
+}
+
+[data-theme="solo"] .solo-hud {
+  backdrop-filter: blur(10px);
+  background: rgba(12, 31, 24, 0.85);
+  border-radius: var(--radius);
+  border: 1px solid rgba(184, 149, 42, 0.25);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="solo"] .solo-action-bar {
+  background: rgba(12, 31, 24, 0.9);
+  border: 1px solid rgba(216, 182, 76, 0.2);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
+}
+
+[data-theme="solo"] .solo-chip-button {
+  width: var(--chip-size);
+  height: var(--chip-size);
+  border-radius: 9999px;
+  border: 2px solid rgba(216, 182, 76, 0.35);
+  background: var(--chip-green);
+  color: var(--text-hi);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+[data-theme="solo"] .solo-chip-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="solo"] .solo-chip-button[data-active="true"] {
+  box-shadow: 0 0 0 2px rgba(216, 182, 76, 0.65), 0 12px 36px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="solo"] .solo-primary {
+  background: var(--accent);
+  color: #0b150f;
+}
+
+[data-theme="solo"] .solo-primary:hover {
+  background: #e8cb74;
+}
+
+[data-theme="solo"] .solo-secondary {
+  background: rgba(216, 182, 76, 0.12);
+  color: var(--text-hi);
+  border: 1px solid rgba(216, 182, 76, 0.32);
+}
+
+[data-theme="solo"] .solo-secondary:hover {
+  background: rgba(216, 182, 76, 0.2);
+}
+
+[data-theme="solo"] .solo-secondary[disabled] {
+  opacity: 0.35;
+}
+
+[data-theme="solo"] .solo-control {
+  height: var(--btn-h);
+  padding: 0 22px;
+  border-radius: var(--radius);
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: var(--caps-track);
+  text-transform: uppercase;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+[data-theme="solo"] .solo-control:focus-visible {
+  outline: 2px solid rgba(216, 182, 76, 0.65);
+  outline-offset: 2px;
+}
+
+[data-theme="solo"] .solo-control:disabled {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+[data-theme="solo"] .solo-player-hand[data-active="true"] {
+  box-shadow: var(--glow);
+  transform: translateY(-8px);
+}
+
+[data-theme="solo"] .solo-toast {
+  background: rgba(12, 31, 24, 0.9);
+  border: 1px solid rgba(216, 182, 76, 0.25);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
+  color: var(--text-hi);
+}
+
+[data-theme="solo"] .solo-stats-drawer {
+  background: rgba(12, 31, 24, 0.98);
+  border-left: 1px solid rgba(216, 182, 76, 0.2);
+  box-shadow: -18px 0 45px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="solo"] .solo-hud-reduced {
+  opacity: 0.65;
+  transition: opacity 0.3s ease;
+}
+
+[data-theme="solo"] .solo-hud-expanded {
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}

--- a/src/types/framer-motion.d.ts
+++ b/src/types/framer-motion.d.ts
@@ -1,0 +1,1 @@
+declare module "framer-motion";


### PR DESCRIPTION
## Summary
- add a theme registry and switcher so the solo layout can become the default while keeping the multiplayer table
- implement the solo theme layout, HUD, player area, betting controls, stats drawer, and toast styling
- move the legacy table into a multiplayer theme module and register it alongside the solo theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e42fc14b788329af497953fe23df39