### PR TITLE
feat: add solo blackjack theme

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,170 +1,38 @@
 import React from "react";
 import type { GameState } from "../engine/types";
-import { formatCurrency } from "../utils/currency";
-import { RuleBadges } from "./RuleBadges";
-import { TableLayout } from "./table/TableLayout";
-import type { ChipDenomination } from "../theme/palette";
+import "../theme";
+import { DEFAULT_THEME_ID, getThemeDefinition, useThemePreference } from "../theme/registry";
+import type { TableActionHandlers } from "../theme/types";
 
 interface TableProps {
   game: GameState;
-  actions: {
-    sit: (seatIndex: number) => void;
-    leave: (seatIndex: number) => void;
-    addChip: (seatIndex: number, denom: number) => void;
-    removeChipValue: (seatIndex: number, denom: number) => void;
-    removeTopChip: (seatIndex: number) => void;
-    deal: () => void;
-    playerHit: () => void;
-    playerStand: () => void;
-    playerDouble: () => void;
-    playerSplit: () => void;
-    playerSurrender: () => void;
-    takeInsurance: (seatIndex: number, handId: string, amount: number) => void;
-    declineInsurance: (seatIndex: number, handId: string) => void;
-    finishInsurance: () => void;
-    playDealer: () => void;
-    nextRound: () => void;
-  };
+  actions: TableActionHandlers;
 }
 
-const penetrationPercentage = (game: GameState): string => {
-  const totalCards = game.shoe.cards.length + game.shoe.discard.length;
-  if (totalCards === 0) {
-    return "0%";
-  }
-  const penetration = game.shoe.discard.length / totalCards;
-  return `${Math.round(penetration * 100)}%`;
-};
-
 export const Table: React.FC<TableProps> = ({ game, actions }) => {
-  const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
-  const headerRef = React.useRef<HTMLDivElement | null>(null);
-  const [viewportHeight, setViewportHeight] = React.useState(
-    typeof window === "undefined" ? 0 : window.innerHeight
-  );
-  const layoutContainerRef = React.useRef<HTMLDivElement | null>(null);
-  const [layoutTop, setLayoutTop] = React.useState(0);
+  const { themeId, setThemeId, themes } = useThemePreference();
 
-  React.useLayoutEffect(() => {
-    if (typeof window === "undefined") {
-      return;
+  const definition = React.useMemo(() => {
+    const current = getThemeDefinition(themeId);
+    if (current) {
+      return current;
     }
-    const handleResize = () => {
-      setViewportHeight(window.innerHeight);
-    };
-    window.addEventListener("resize", handleResize);
-    handleResize();
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
+    return getThemeDefinition(DEFAULT_THEME_ID);
+  }, [themeId]);
 
-  const recalcLayoutTop = React.useCallback(() => {
-    if (layoutContainerRef.current) {
-      const rect = layoutContainerRef.current.getBoundingClientRect();
-      setLayoutTop(rect.top);
-    }
-  }, []);
+  const Layout = definition?.Layout;
 
-  React.useLayoutEffect(() => {
-    if (!headerRef.current || typeof ResizeObserver === "undefined") {
-      return;
-    }
-    const observer = new ResizeObserver(() => {
-      recalcLayoutTop();
-    });
-    observer.observe(headerRef.current);
-    return () => observer.disconnect();
-  }, [recalcLayoutTop]);
-
-  React.useLayoutEffect(() => {
-    recalcLayoutTop();
-  }, [recalcLayoutTop, viewportHeight]);
-
-  const MAIN_BOTTOM_PADDING = 12;
-  const availableHeight = Math.max(viewportHeight - layoutTop - MAIN_BOTTOM_PADDING, 320);
-
-  const handleSelectChip = (value: ChipDenomination) => {
-    setActiveChip(value);
-  };
-
-  const totalPendingBets = game.seats.reduce((sum, seat) => sum + seat.baseBet, 0);
+  if (!Layout) {
+    return null;
+  }
 
   return (
-    <div className="flex flex-1 flex-col gap-3 text-emerald-50">
-      <header
-        ref={headerRef}
-        className="rounded-3xl border border-[#c8a24a]/35 bg-[#0c2c22]/65 px-4 py-2 shadow-[0_16px_36px_rgba(0,0,0,0.4)] backdrop-blur"
-      >
-        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex flex-col gap-1.5">
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-200">
-              <span>Casino Blackjack</span>
-              <RuleBadges rules={game.rules} />
-            </div>
-            <div className="flex flex-wrap items-baseline gap-3">
-              <h1 className="text-lg font-semibold uppercase tracking-[0.24em] text-emerald-50">Blackjack</h1>
-              <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-emerald-200">
-                <span>
-                  Bankroll <span className="font-semibold text-emerald-50">{formatCurrency(game.bankroll)}</span>
-                </span>
-                <span>Pending {formatCurrency(totalPendingBets)}</span>
-                <span>
-                  Min {formatCurrency(game.rules.minBet)} · Max {formatCurrency(game.rules.maxBet)}
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-[10px] uppercase tracking-[0.18em] text-emerald-300 sm:grid-cols-5">
-            <div>
-              <p className="text-emerald-400/70">Round</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.roundCount}</p>
-            </div>
-            <div>
-              <p className="text-emerald-400/70">Phase</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.phase}</p>
-            </div>
-            <div>
-              <p className="text-emerald-400/70">Cards</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.shoe.cards.length}</p>
-            </div>
-            <div>
-              <p className="text-emerald-400/70">Discard</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.shoe.discard.length}</p>
-            </div>
-            <div>
-              <p className="text-emerald-400/70">Penetration</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{penetrationPercentage(game)}</p>
-            </div>
-          </div>
-        </div>
-      </header>
-
-      <div
-        ref={layoutContainerRef}
-        className="flex min-h-0 justify-center"
-        style={{ height: availableHeight }}
-      >
-        <TableLayout
-          game={game}
-          activeChip={activeChip}
-          onSelectChip={handleSelectChip}
-          onSit={actions.sit}
-          onLeave={actions.leave}
-          onAddChip={actions.addChip}
-          onRemoveChipValue={actions.removeChipValue}
-          onRemoveTopChip={actions.removeTopChip}
-          onInsurance={actions.takeInsurance}
-          onDeclineInsurance={actions.declineInsurance}
-          onHit={actions.playerHit}
-          onStand={actions.playerStand}
-          onDouble={actions.playerDouble}
-          onSplit={actions.playerSplit}
-          onSurrender={actions.playerSurrender}
-          onDeal={actions.deal}
-          onFinishInsurance={actions.finishInsurance}
-          onPlayDealer={actions.playDealer}
-          onNextRound={actions.nextRound}
-        />
-      </div>
-    </div>
+    <Layout
+      game={game}
+      actions={actions}
+      themeId={definition.id}
+      availableThemes={themes}
+      onThemeChange={setThemeId}
+    />
   );
 };

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -10,6 +10,7 @@ export const App: React.FC = () => {
     clearError,
     sit,
     leave,
+    setBet,
     addChip,
     removeChipValue,
     removeTopChip,
@@ -42,6 +43,7 @@ export const App: React.FC = () => {
           actions={{
             sit,
             leave,
+            setBet,
             addChip,
             removeChipValue,
             removeTopChip,

--- a/src/theme/ThemeSwitcher.tsx
+++ b/src/theme/ThemeSwitcher.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { cn } from "../utils/cn";
+import type { ThemeIdentity } from "./types";
+
+interface ThemeSwitcherProps {
+  themes: ThemeIdentity[];
+  value: string;
+  onChange: (themeId: string) => void;
+}
+
+export const ThemeSwitcher: React.FC<ThemeSwitcherProps> = ({ themes, value, onChange }) => {
+  if (themes.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="inline-flex rounded-full border border-[rgba(216,182,76,0.3)] bg-black/20 p-1 text-[10px] uppercase tracking-[0.25em]">
+      {themes.map((theme) => {
+        const isActive = theme.id === value;
+        return (
+          <button
+            key={theme.id}
+            type="button"
+            onClick={() => onChange(theme.id)}
+            className={cn(
+              "relative min-w-[88px] cursor-pointer rounded-full px-4 py-1 font-semibold transition",
+              isActive
+                ? "bg-[rgba(216,182,76,0.18)] text-[var(--text-hi,rgba(243,239,227,1))] shadow-[inset_0_0_0_1px_rgba(216,182,76,0.4)]"
+                : "text-[var(--text-lo,#a8b3a7)] hover:text-[var(--text-hi,rgba(243,239,227,1))]",
+            )}
+            aria-pressed={isActive}
+          >
+            {theme.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,15 @@
+import { registerTheme } from "./registry";
+import { MultiplayerLayout } from "./multiplayer/MultiplayerLayout";
+import { SoloLayout } from "./solo/SoloLayout";
+
+registerTheme({
+  id: "multiplayer",
+  label: "Multiplayer Table",
+  Layout: MultiplayerLayout,
+});
+
+registerTheme({
+  id: "solo",
+  label: "Solo Table",
+  Layout: SoloLayout,
+});

--- a/src/theme/multiplayer/MultiplayerLayout.tsx
+++ b/src/theme/multiplayer/MultiplayerLayout.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { formatCurrency } from "../../utils/currency";
+import { RuleBadges } from "../../components/RuleBadges";
+import { TableLayout } from "../../components/table/TableLayout";
+import { ThemeSwitcher } from "../ThemeSwitcher";
+import type { ChipDenomination } from "../../theme/palette";
+import type { ThemeLayoutProps } from "../types";
+
+const penetrationPercentage = (cards: number, discard: number): string => {
+  const totalCards = cards + discard;
+  if (totalCards === 0) {
+    return "0%";
+  }
+  const penetration = discard / totalCards;
+  return `${Math.round(penetration * 100)}%`;
+};
+
+export const MultiplayerLayout: React.FC<ThemeLayoutProps> = ({
+  game,
+  actions,
+  availableThemes,
+  onThemeChange,
+  themeId,
+}) => {
+  const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
+  const headerRef = React.useRef<HTMLDivElement | null>(null);
+  const [viewportHeight, setViewportHeight] = React.useState(
+    typeof window === "undefined" ? 0 : window.innerHeight,
+  );
+  const layoutContainerRef = React.useRef<HTMLDivElement | null>(null);
+  const [layoutTop, setLayoutTop] = React.useState(0);
+
+  React.useLayoutEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const handleResize = () => {
+      setViewportHeight(window.innerHeight);
+    };
+    window.addEventListener("resize", handleResize);
+    handleResize();
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const recalcLayoutTop = React.useCallback(() => {
+    if (layoutContainerRef.current) {
+      const rect = layoutContainerRef.current.getBoundingClientRect();
+      setLayoutTop(rect.top);
+    }
+  }, []);
+
+  React.useLayoutEffect(() => {
+    if (!headerRef.current || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      recalcLayoutTop();
+    });
+    observer.observe(headerRef.current);
+    return () => observer.disconnect();
+  }, [recalcLayoutTop]);
+
+  React.useLayoutEffect(() => {
+    recalcLayoutTop();
+  }, [recalcLayoutTop, viewportHeight]);
+
+  const MAIN_BOTTOM_PADDING = 12;
+  const availableHeight = Math.max(viewportHeight - layoutTop - MAIN_BOTTOM_PADDING, 320);
+
+  const handleSelectChip = (value: ChipDenomination) => {
+    setActiveChip(value);
+  };
+
+  const totalPendingBets = game.seats.reduce((sum, seat) => sum + seat.baseBet, 0);
+
+  return (
+    <div className="flex flex-1 flex-col gap-3 text-emerald-50">
+      <header
+        ref={headerRef}
+        className="rounded-3xl border border-[#c8a24a]/35 bg-[#0c2c22]/65 px-4 py-2 shadow-[0_16px_36px_rgba(0,0,0,0.4)] backdrop-blur"
+      >
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-col gap-1.5">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-200">
+              <span>Casino Blackjack</span>
+              <RuleBadges rules={game.rules} />
+            </div>
+            <div className="flex flex-wrap items-baseline gap-3">
+              <h1 className="text-lg font-semibold uppercase tracking-[0.24em] text-emerald-50">Blackjack</h1>
+              <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-emerald-200">
+                <span>
+                  Bankroll <span className="font-semibold text-emerald-50">{formatCurrency(game.bankroll)}</span>
+                </span>
+                <span>Pending {formatCurrency(totalPendingBets)}</span>
+                <span>
+                  Min {formatCurrency(game.rules.minBet)} · Max {formatCurrency(game.rules.maxBet)}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-[10px] uppercase tracking-[0.18em] text-emerald-300 sm:grid-cols-5">
+            <div>
+              <p className="text-emerald-400/70">Round</p>
+              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.roundCount}</p>
+            </div>
+            <div>
+              <p className="text-emerald-400/70">Phase</p>
+              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.phase}</p>
+            </div>
+            <div>
+              <p className="text-emerald-400/70">Cards</p>
+              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.shoe.cards.length}</p>
+            </div>
+            <div>
+              <p className="text-emerald-400/70">Discard</p>
+              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.shoe.discard.length}</p>
+            </div>
+            <div>
+              <p className="text-emerald-400/70">Penetration</p>
+              <p className="mt-0.5 text-base font-semibold text-emerald-50">
+                {penetrationPercentage(game.shoe.cards.length, game.shoe.discard.length)}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="mt-2 text-right">
+          <ThemeSwitcher themes={availableThemes} value={themeId} onChange={onThemeChange} />
+        </div>
+      </header>
+
+      <div ref={layoutContainerRef} className="flex min-h-0 justify-center" style={{ height: availableHeight }}>
+        <TableLayout
+          game={game}
+          activeChip={activeChip}
+          onSelectChip={handleSelectChip}
+          onSit={actions.sit}
+          onLeave={actions.leave}
+          onAddChip={actions.addChip}
+          onRemoveChipValue={actions.removeChipValue}
+          onRemoveTopChip={actions.removeTopChip}
+          onInsurance={actions.takeInsurance}
+          onDeclineInsurance={actions.declineInsurance}
+          onHit={actions.playerHit}
+          onStand={actions.playerStand}
+          onDouble={actions.playerDouble}
+          onSplit={actions.playerSplit}
+          onSurrender={actions.playerSurrender}
+          onDeal={actions.deal}
+          onFinishInsurance={actions.finishInsurance}
+          onPlayDealer={actions.playDealer}
+          onNextRound={actions.nextRound}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/theme/registry.ts
+++ b/src/theme/registry.ts
@@ -1,0 +1,75 @@
+import React from "react";
+import type { ThemeDefinition, ThemeIdentity } from "./types";
+
+const registry = new Map<string, ThemeDefinition>();
+
+export const DEFAULT_THEME_ID = "solo";
+const STORAGE_KEY = "ui.theme";
+
+export const registerTheme = (definition: ThemeDefinition): void => {
+  registry.set(definition.id, definition);
+};
+
+export const getRegisteredThemes = (): ThemeIdentity[] =>
+  Array.from(registry.values()).map(({ id, label }) => ({ id, label }));
+
+export const getThemeDefinition = (themeId: string): ThemeDefinition | undefined =>
+  registry.get(themeId);
+
+const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+
+const setDataTheme = (themeId: string): void => {
+  if (!isBrowser) {
+    return;
+  }
+  document.documentElement.dataset.theme = themeId;
+};
+
+export const resolveInitialThemeId = (): string => {
+  if (!isBrowser) {
+    return DEFAULT_THEME_ID;
+  }
+  const params = new URLSearchParams(window.location.search);
+  const queryTheme = params.get("theme");
+  if (queryTheme && registry.has(queryTheme)) {
+    return queryTheme;
+  }
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored && registry.has(stored)) {
+    return stored;
+  }
+  return DEFAULT_THEME_ID;
+};
+
+export const useThemePreference = (): {
+  themeId: string;
+  setThemeId: (themeId: string) => void;
+  themes: ThemeIdentity[];
+} => {
+  const [themeId, setThemeIdState] = React.useState(() => {
+    const initial = resolveInitialThemeId();
+    setDataTheme(initial);
+    return initial;
+  });
+
+  const setThemeId = React.useCallback((nextId: string) => {
+    const fallback = registry.has(nextId) ? nextId : DEFAULT_THEME_ID;
+    setThemeIdState(fallback);
+    setDataTheme(fallback);
+    if (isBrowser) {
+      window.localStorage.setItem(STORAGE_KEY, fallback);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    setDataTheme(themeId);
+  }, [themeId]);
+
+  const themeList = React.useMemo(() => getRegisteredThemes(), []);
+
+  return {
+    themeId,
+    setThemeId,
+    themes: themeList,
+  };
+};

--- a/src/theme/solo/ActionBar.tsx
+++ b/src/theme/solo/ActionBar.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import type { Phase } from "../../engine/types";
+import { cn } from "../../utils/cn";
+
+export type SoloAction =
+  | "deal"
+  | "clear"
+  | "rebet"
+  | "hit"
+  | "stand"
+  | "double"
+  | "split"
+  | "surrender"
+  | "playDealer"
+  | "nextRound";
+
+export type SoloActionAvailability = Record<SoloAction, boolean>;
+
+interface ActionDescriptor {
+  action: SoloAction;
+  label: string;
+  hotkey?: string;
+  variant: "primary" | "secondary";
+}
+
+const ACTION_DESCRIPTORS: ActionDescriptor[] = [
+  { action: "deal", label: "Deal", hotkey: "Space", variant: "primary" },
+  { action: "hit", label: "Hit", hotkey: "H", variant: "primary" },
+  { action: "stand", label: "Stand", hotkey: "S", variant: "primary" },
+  { action: "double", label: "Double", hotkey: "D", variant: "secondary" },
+  { action: "split", label: "Split", hotkey: "P", variant: "secondary" },
+  { action: "surrender", label: "Surrender", hotkey: "R", variant: "secondary" },
+  { action: "playDealer", label: "Play Dealer", hotkey: "Enter", variant: "primary" },
+  { action: "nextRound", label: "Next Round", hotkey: "Enter", variant: "primary" },
+  { action: "clear", label: "Clear", hotkey: "C", variant: "secondary" },
+  { action: "rebet", label: "Rebet", hotkey: "B", variant: "secondary" },
+];
+
+const ORDER: SoloAction[] = [
+  "deal",
+  "hit",
+  "stand",
+  "double",
+  "split",
+  "surrender",
+  "playDealer",
+  "nextRound",
+  "clear",
+  "rebet",
+];
+
+interface ActionBarProps {
+  availability: SoloActionAvailability;
+  primary: SoloAction | null;
+  onAction: (action: SoloAction) => void;
+  phase: Phase;
+}
+
+const visibleActions = (
+  availability: SoloActionAvailability,
+  phase: Phase,
+): ActionDescriptor[] => {
+  const isBetting = phase === "betting";
+  return ORDER
+    .map((action) => ACTION_DESCRIPTORS.find((descriptor) => descriptor.action === action)!)
+    .filter((descriptor) => {
+      if (descriptor.action === "clear") {
+        return availability.clear;
+      }
+      if (descriptor.action === "rebet") {
+        return availability.rebet;
+      }
+      if (descriptor.action === "deal") {
+        return isBetting;
+      }
+      return availability[descriptor.action];
+    });
+};
+
+export const ActionBar: React.FC<ActionBarProps> = ({ availability, primary, onAction, phase }) => {
+  const actions = visibleActions(availability, phase);
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap justify-end gap-2 text-[10px] uppercase tracking-[0.24em]">
+      {actions.map((descriptor) => {
+        const isPrimary = descriptor.variant === "primary" || descriptor.action === primary;
+        const isDisabled = !availability[descriptor.action];
+        return (
+          <button
+            key={descriptor.action}
+            type="button"
+            onClick={() => onAction(descriptor.action)}
+            disabled={isDisabled}
+            className={cn(
+              "flex min-w-[110px] items-center justify-center gap-2 rounded-full border px-4 py-2 text-[11px] font-semibold transition",
+              isPrimary
+                ? "solo-action-primary border-transparent"
+                : "border-[rgba(216,182,76,0.25)] bg-[rgba(12,31,24,0.65)] text-[var(--text-hi)]",
+              isDisabled && "opacity-40",
+            )}
+          >
+            <span>{descriptor.label}</span>
+            {descriptor.hotkey && (
+              <span className="text-[9px] uppercase tracking-[0.3em] text-[var(--text-lo)]">{descriptor.hotkey}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/theme/solo/BetChipsBar.tsx
+++ b/src/theme/solo/BetChipsBar.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import type { ChipDenomination } from "../../theme/palette";
+import { cn } from "../../utils/cn";
+
+interface BetChipsBarProps {
+  chips: ChipDenomination[];
+  activeChip: ChipDenomination;
+  onSelect: (value: ChipDenomination) => void;
+  onAdd: () => void;
+  onRemove: () => void;
+  onClear: () => void;
+  onRebet: () => void;
+  canInteract: boolean;
+  showRebet: boolean;
+}
+
+export const BetChipsBar: React.FC<BetChipsBarProps> = ({
+  chips,
+  activeChip,
+  onSelect,
+  onAdd,
+  onRemove,
+  onClear,
+  onRebet,
+  canInteract,
+  showRebet,
+}) => {
+  return (
+    <div className="flex w-full flex-col gap-3 text-[10px] uppercase tracking-[0.24em] text-[var(--text-lo)]">
+      <div className="flex flex-wrap items-center gap-2">
+        {chips.map((value) => {
+          const isActive = value === activeChip;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                if (value === activeChip && canInteract) {
+                  onAdd();
+                } else {
+                  onSelect(value);
+                }
+              }}
+              disabled={!canInteract}
+              className={cn(
+                "solo-chip flex h-[var(--chip-size)] w-[var(--chip-size)] items-center justify-center rounded-full text-sm font-semibold text-[var(--text-hi)] transition-transform",
+                isActive && "shadow-[0_0_0_2px_rgba(216,182,76,0.5)]",
+                !canInteract && "opacity-60",
+              )}
+              data-active={isActive}
+            >
+              {value}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-[var(--text-hi)]">
+        <button
+          type="button"
+          onClick={onAdd}
+          disabled={!canInteract}
+          className={cn(
+            "rounded-full border border-[rgba(216,182,76,0.35)] px-4 py-2 text-[11px] uppercase tracking-[0.28em] transition",
+            canInteract ? "hover:bg-[rgba(216,182,76,0.1)]" : "opacity-50",
+          )}
+        >
+          Add Chip
+        </button>
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={!canInteract}
+          className={cn(
+            "rounded-full border border-[rgba(216,182,76,0.18)] px-4 py-2 text-[11px] uppercase tracking-[0.28em] text-[var(--text-lo)] transition",
+            canInteract ? "hover:bg-[rgba(216,182,76,0.08)]" : "opacity-50",
+          )}
+        >
+          Undo
+        </button>
+        <button
+          type="button"
+          onClick={onClear}
+          disabled={!canInteract}
+          className={cn(
+            "rounded-full border border-[rgba(216,182,76,0.18)] px-4 py-2 text-[11px] uppercase tracking-[0.28em] text-[var(--danger)] transition",
+            canInteract ? "hover:bg-[rgba(215,90,90,0.12)]" : "opacity-50",
+          )}
+        >
+          Clear
+        </button>
+        {showRebet && (
+          <button
+            type="button"
+            onClick={onRebet}
+            className="rounded-full border border-[rgba(216,182,76,0.35)] px-4 py-2 text-[11px] uppercase tracking-[0.28em] text-[var(--text-hi)] transition hover:bg-[rgba(216,182,76,0.12)]"
+          >
+            Rebet
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/theme/solo/DealerArea.tsx
+++ b/src/theme/solo/DealerArea.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import type { Dealer, Phase, RuleConfig } from "../../engine/types";
+import { getHandTotals, isBust } from "../../engine/totals";
+import { cn } from "../../utils/cn";
+import { PlayingCard } from "../../components/table/PlayingCard";
+
+interface DealerAreaProps {
+  dealer: Dealer;
+  phase: Phase;
+  rules: RuleConfig;
+}
+
+const shouldRevealHole = (phase: Phase, dealerHasBlackjack: boolean): boolean =>
+  phase === "dealerPlay" || phase === "settlement" || dealerHasBlackjack;
+
+export const DealerArea: React.FC<DealerAreaProps> = ({ dealer, phase, rules }) => {
+  const revealHole = shouldRevealHole(phase, dealer.hand.isBlackjack);
+  const cards = dealer.hand.cards;
+  const totals = getHandTotals(dealer.hand);
+  const status = React.useMemo(() => {
+    if (!revealHole) {
+      return "Dealer showing";
+    }
+    if (dealer.hand.isBlackjack) {
+      return "Dealer blackjack";
+    }
+    if (isBust(dealer.hand)) {
+      return "Dealer bust";
+    }
+    if (totals.soft && totals.soft !== totals.hard) {
+      return `Dealer ${totals.hard} / ${totals.soft}`;
+    }
+    return `Dealer ${totals.hard}`;
+  }, [dealer.hand, revealHole, totals]);
+
+  return (
+    <section className="flex flex-col items-center gap-3 text-center text-[var(--text-lo)]" aria-label="Dealer">
+      <div className="text-[10px] uppercase tracking-[0.3em] text-[var(--text-lo)]">BLACKJACK PAYS {rules.blackjackPayout}</div>
+      <div className="text-[10px] uppercase tracking-[0.3em] text-[var(--text-lo)]">INSURANCE 2:1</div>
+
+      <div className="relative flex min-h-[180px] w-full flex-col items-center justify-center gap-3">
+        <div className="flex items-center gap-3">
+          <span className="rounded-full border border-[rgba(216,182,76,0.35)] bg-[rgba(10,27,21,0.6)] px-4 py-1 text-[11px] uppercase tracking-[0.28em] text-[var(--text-hi)]">
+            Dealer
+          </span>
+        </div>
+        <div className="flex items-center justify-center gap-3">
+          {cards.length === 0 && (
+            <div className="h-[132px] w-[92px] rounded-2xl border border-dashed border-[rgba(216,182,76,0.25)]" aria-hidden />
+          )}
+          {cards.map((card, index) => (
+            <div
+              key={`${card.rank}-${card.suit}-${index}`}
+              className={cn(
+                "transition-transform duration-200",
+                index === 0 ? "translate-y-0" : "-translate-y-1",
+                !revealHole && index === 1 && "shadow-[var(--shadow-1)]",
+              )}
+            >
+              <PlayingCard rank={card.rank} suit={card.suit} faceDown={!revealHole && index === 1} />
+            </div>
+          ))}
+        </div>
+        <div className="rounded-full bg-[rgba(10,27,21,0.75)] px-4 py-1 text-[10px] uppercase tracking-[0.24em] text-[var(--text-hi)]">
+          {status}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/theme/solo/InsuranceStrip.tsx
+++ b/src/theme/solo/InsuranceStrip.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import type { Hand } from "../../engine/types";
+import { formatCurrency } from "../../utils/currency";
+import { cn } from "../../utils/cn";
+
+interface InsuranceStripProps {
+  hand: Hand;
+  bankroll: number;
+  onConfirm: (amount: number) => void;
+  onSkip: () => void;
+}
+
+export const InsuranceStrip: React.FC<InsuranceStripProps> = ({ hand, bankroll, onConfirm, onSkip }) => {
+  const maxInsurance = Math.min(hand.bet / 2, bankroll);
+  const [value, setValue] = React.useState(maxInsurance);
+
+  React.useEffect(() => {
+    setValue(maxInsurance);
+  }, [maxInsurance]);
+
+  const handleSubmit = () => {
+    onConfirm(Number.parseFloat(value.toFixed(2)));
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-3xl border border-[rgba(216,182,76,0.2)] bg-[rgba(14,33,25,0.75)] px-4 py-3 text-[10px] uppercase tracking-[0.24em] text-[var(--text-lo)]">
+      <div className="flex flex-col gap-2 text-[var(--text-hi)] sm:flex-row sm:items-center sm:justify-between">
+        <span>Dealer shows Ace — Insurance?</span>
+        <div className="flex items-center gap-2 text-[11px]">
+          <span>{formatCurrency(0)}</span>
+          <input
+            type="range"
+            min={0}
+            max={maxInsurance}
+            step={0.5}
+            value={value}
+            onChange={(event) => setValue(Number(event.target.value))}
+            className="h-1 w-48 cursor-pointer appearance-none rounded-full bg-[rgba(216,182,76,0.25)]"
+          />
+          <span>{formatCurrency(maxInsurance)}</span>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-[var(--text-hi)]">
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="solo-action-primary rounded-full px-5 py-2 text-[11px] uppercase tracking-[0.24em]"
+        >
+          Take {formatCurrency(value)}
+        </button>
+        <button
+          type="button"
+          onClick={onSkip}
+          className={cn(
+            "rounded-full border border-[rgba(216,182,76,0.3)] px-5 py-2 text-[11px] uppercase tracking-[0.24em] text-[var(--text-hi)] transition",
+            "hover:bg-[rgba(216,182,76,0.08)]",
+          )}
+        >
+          Skip
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/theme/solo/PlayerArea.tsx
+++ b/src/theme/solo/PlayerArea.tsx
@@ -1,0 +1,212 @@
+import React from "react";
+import { getHandTotals, isBust } from "../../engine/totals";
+import type { Hand, Phase, Seat } from "../../engine/types";
+import { formatCurrency } from "../../utils/currency";
+import { cn } from "../../utils/cn";
+import { PlayingCard } from "../../components/table/PlayingCard";
+import type { SoloAction, SoloActionAvailability } from "./ActionBar";
+
+interface PlayerAreaProps {
+  seat: Seat | undefined;
+  activeHandId: string | null;
+  phase: Phase;
+  activeChip: number;
+  onPlaceBet: (value: number) => void;
+  onRemoveChip: () => void;
+  chipStack: number[];
+  availability: SoloActionAvailability;
+  onGesture: (gesture: Extract<SoloAction, "hit" | "stand" | "double">) => void;
+}
+
+const HAND_GAP = "gap-6 md:gap-8";
+
+const handStatus = (hand: Hand): string | null => {
+  if (hand.isBlackjack) {
+    return "Blackjack";
+  }
+  if (hand.isSurrendered) {
+    return "Surrendered";
+  }
+  if (isBust(hand)) {
+    return "Bust";
+  }
+  if (hand.isResolved) {
+    return "Stand";
+  }
+  return null;
+};
+
+const renderTotals = (hand: Hand): string => {
+  const totals = getHandTotals(hand);
+  if (isBust(hand)) {
+    return `${totals.hard}`;
+  }
+  if (totals.soft && totals.soft !== totals.hard) {
+    return `${totals.hard} / ${totals.soft}`;
+  }
+  return `${totals.hard}`;
+};
+
+const useTouchGestures = (
+  onGesture: PlayerAreaProps["onGesture"],
+  availability: SoloActionAvailability,
+): {
+  onTouchStart: React.TouchEventHandler<HTMLDivElement>;
+  onTouchEnd: React.TouchEventHandler<HTMLDivElement>;
+} => {
+  const startRef = React.useRef<{ x: number; y: number; time: number } | null>(null);
+
+  const handleTouchStart = React.useCallback<React.TouchEventHandler<HTMLDivElement>>((event) => {
+    const touch = event.touches[0];
+    startRef.current = { x: touch.clientX, y: touch.clientY, time: Date.now() };
+  }, []);
+
+  const handleTouchEnd = React.useCallback<React.TouchEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (!startRef.current) {
+        return;
+      }
+      const touch = event.changedTouches[0];
+      const dx = touch.clientX - startRef.current.x;
+      const dy = touch.clientY - startRef.current.y;
+      const duration = Date.now() - startRef.current.time;
+      startRef.current = null;
+
+      const absX = Math.abs(dx);
+      const absY = Math.abs(dy);
+
+      if (duration > 450 && absX < 16 && absY < 16 && availability.double) {
+        onGesture("double");
+        navigator?.vibrate?.(20);
+        return;
+      }
+
+      if (absY > absX && dy < -48 && availability.hit) {
+        onGesture("hit");
+        navigator?.vibrate?.(12);
+        return;
+      }
+
+      if (absX > absY && dx > 48 && availability.stand) {
+        onGesture("stand");
+        navigator?.vibrate?.(12);
+      }
+    },
+    [availability.double, availability.hit, availability.stand, onGesture],
+  );
+
+  return { onTouchStart: handleTouchStart, onTouchEnd: handleTouchEnd };
+};
+
+export const PlayerArea: React.FC<PlayerAreaProps> = ({
+  seat,
+  activeHandId,
+  phase,
+  activeChip,
+  onPlaceBet,
+  onRemoveChip,
+  chipStack,
+  availability,
+  onGesture,
+}) => {
+  const hands = seat?.hands ?? [];
+  const hasHands = hands.length > 0;
+  const gestureHandlers = useTouchGestures(onGesture, availability);
+  const betAmount = seat?.baseBet ?? 0;
+
+  return (
+    <section
+      className="relative flex flex-col items-center gap-6 text-center"
+      aria-label="Player area"
+      {...gestureHandlers}
+    >
+      <div className="flex items-center gap-3 text-[var(--text-lo)]">
+        <span className="rounded-full border border-[rgba(216,182,76,0.35)] bg-[rgba(12,33,25,0.6)] px-4 py-1 text-[11px] uppercase tracking-[0.28em] text-[var(--text-hi)]">
+          Player
+        </span>
+        <span className="rounded-full bg-[rgba(216,182,76,0.1)] px-3 py-1 text-[10px] uppercase tracking-[0.24em] text-[var(--text-lo)]">
+          Chip {activeChip}
+        </span>
+      </div>
+
+      <div className={cn("flex w-full flex-wrap justify-center", HAND_GAP)}>
+        {hasHands ? (
+          hands.map((hand, index) => {
+            const isActive = hand.id === activeHandId;
+            const status = handStatus(hand);
+            return (
+              <div
+                key={hand.id}
+                className={cn(
+                  "relative flex min-w-[180px] flex-col items-center gap-3 rounded-3xl border border-transparent px-3 py-4 transition",
+                  isActive && "-translate-y-1 shadow-[var(--glow)]",
+                )}
+              >
+                <div className={cn("flex items-end justify-center gap-3", hand.cards.length > 4 && "flex-wrap")}
+                     aria-label={`Hand ${index + 1}`}>
+                  {hand.cards.map((card, cardIndex) => (
+                    <PlayingCard key={`${hand.id}-${cardIndex}`} rank={card.rank} suit={card.suit} />
+                  ))}
+                </div>
+                <div className="flex flex-col items-center gap-1 text-[var(--text-hi)]">
+                  <span className="text-sm font-semibold tracking-[0.2em]">{renderTotals(hand)}</span>
+                  {status && (
+                    <span className="rounded-full bg-[rgba(216,182,76,0.12)] px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-[var(--text-hi)]">
+                      {status}
+                    </span>
+                  )}
+                  <span className="text-[10px] uppercase tracking-[0.24em] text-[var(--text-lo)]">
+                    Bet {formatCurrency(hand.bet)}
+                  </span>
+                  {hand.insuranceBet !== undefined && hand.insuranceBet > 0 && (
+                    <span className="text-[10px] uppercase tracking-[0.24em] text-[var(--accent)]">
+                      Insurance {formatCurrency(hand.insuranceBet)}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <div className="flex h-[160px] w-full flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-[rgba(216,182,76,0.25)] bg-[rgba(12,33,25,0.35)] text-[var(--text-lo)]">
+            <span className="text-[12px] uppercase tracking-[0.3em]">Place your bet to start</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onPlaceBet(activeChip)}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            onRemoveChip();
+          }}
+          className={cn(
+            "relative flex h-24 w-24 items-center justify-center rounded-full border-2 border-[rgba(216,182,76,0.4)] bg-[rgba(12,31,24,0.75)] text-center text-[12px] uppercase tracking-[0.3em] text-[var(--text-hi)] transition",
+            phase !== "betting" && "opacity-50",
+          )}
+          disabled={phase !== "betting"}
+        >
+          <div className="flex flex-col items-center gap-1">
+            <span>Bet</span>
+            <span className="text-base font-semibold tracking-[0.18em]">{formatCurrency(betAmount)}</span>
+          </div>
+        </button>
+        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.24em] text-[var(--text-lo)]">
+          <span>Chips</span>
+          <div className="flex gap-1">
+            {chipStack.slice(-5).map((value, index) => (
+              <div
+                key={`${value}-${index}`}
+                className="h-5 w-5 rounded-full border border-[rgba(216,182,76,0.3)] bg-[rgba(30,58,47,0.85)] text-[10px] text-[var(--text-hi)]"
+              >
+                {value}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/theme/solo/SoloHUD.tsx
+++ b/src/theme/solo/SoloHUD.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Icon } from "@iconify/react";
+import type { Phase, RuleConfig, Shoe } from "../../engine/types";
+import { formatCurrency } from "../../utils/currency";
+import { cn } from "../../utils/cn";
+
+interface SoloHUDProps {
+  bankroll: number;
+  currentBet: number;
+  round: number;
+  phase: Phase;
+  shoe: Shoe;
+  rules: RuleConfig;
+  collapsed: boolean;
+  onToggleStats: () => void;
+}
+
+const formatPhase = (phase: Phase): string => {
+  switch (phase) {
+    case "betting":
+      return "Betting";
+    case "insurance":
+      return "Insurance";
+    case "playerActions":
+      return "Decision";
+    case "dealerPlay":
+      return "Dealer";
+    case "settlement":
+      return "Payout";
+    default:
+      return phase;
+  }
+};
+
+const computePenetration = (shoe: Shoe): number => {
+  const total = shoe.cards.length + shoe.discard.length;
+  if (total === 0) {
+    return 0;
+  }
+  return (shoe.discard.length / total) * 100;
+};
+
+export const SoloHUD: React.FC<SoloHUDProps> = ({
+  bankroll,
+  currentBet,
+  round,
+  phase,
+  shoe,
+  rules,
+  collapsed,
+  onToggleStats,
+}) => {
+  const penetration = computePenetration(shoe);
+
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 items-center gap-4 text-[11px] font-semibold uppercase tracking-[var(--caps-track)] text-[var(--text-lo)] transition-all duration-300 sm:grid-cols-[1fr_auto_1fr]",
+        collapsed && "opacity-90",
+      )}
+      role="banner"
+    >
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-[var(--text-hi)]">
+        <div className="flex flex-col">
+          <span className="text-[10px] text-[var(--text-lo)]">Bankroll</span>
+          <span className="text-sm text-[var(--text-hi)]">{formatCurrency(bankroll)}</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-[10px] text-[var(--text-lo)]">Current Bet</span>
+          <span className="text-sm text-[var(--text-hi)]">{formatCurrency(currentBet)}</span>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center justify-center gap-2 text-center text-[var(--text-hi)] sm:flex-row sm:gap-6">
+        <div className="flex flex-col items-center">
+          <span className="text-[10px] text-[var(--text-lo)]">Round</span>
+          <span className="text-base tracking-[0.2em]">{round}</span>
+        </div>
+        <div className="flex flex-col items-center">
+          <span className="text-[10px] text-[var(--text-lo)]">Phase</span>
+          <span className="text-base tracking-[0.2em]">{formatPhase(phase)}</span>
+        </div>
+        <div className="flex items-center gap-2 rounded-full bg-black/20 px-3 py-1 text-[10px]">
+          <Icon icon="mdi:information-outline" className="text-[var(--text-lo)]" width={14} height={14} />
+          <span>
+            Count {rules.enableHiLoCounter ? "Live" : "N/A"}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-end gap-4 text-[var(--text-hi)]">
+        <div className="flex flex-col items-end">
+          <span className="text-[10px] text-[var(--text-lo)]">Cards Left</span>
+          <span className="text-sm">{shoe.cards.length}</span>
+        </div>
+        <div className="flex flex-col items-end">
+          <span className="text-[10px] text-[var(--text-lo)]">Penetration</span>
+          <span className="text-sm">{penetration.toFixed(0)}%</span>
+        </div>
+        <button
+          type="button"
+          onClick={onToggleStats}
+          className="inline-flex items-center gap-2 rounded-full border border-[rgba(216,182,76,0.35)] bg-[rgba(14,33,25,0.6)] px-4 py-1 text-[10px] uppercase tracking-[0.25em] text-[var(--text-hi)] transition hover:border-[rgba(216,182,76,0.6)] hover:bg-[rgba(14,33,25,0.85)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent)]"
+        >
+          <Icon icon="mdi:chart-areaspline" width={16} height={16} />
+          Stats
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/theme/solo/SoloLayout.tsx
+++ b/src/theme/solo/SoloLayout.tsx
@@ -1,0 +1,454 @@
+import React from "react";
+import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
+import type { Hand, Phase, RuleConfig, Seat } from "../../engine/types";
+import { cn } from "../../utils/cn";
+import type { ChipDenomination } from "../../theme/palette";
+import { ThemeSwitcher } from "../ThemeSwitcher";
+import type { ThemeLayoutProps } from "../types";
+import { SoloHUD } from "./SoloHUD";
+import { DealerArea } from "./DealerArea";
+import { PlayerArea } from "./PlayerArea";
+import { BetChipsBar } from "./BetChipsBar";
+import { ActionBar, type SoloAction, type SoloActionAvailability } from "./ActionBar";
+import { InsuranceStrip } from "./InsuranceStrip";
+import { StatsDrawer } from "./StatsDrawer";
+import { ToastHost, type ToastMessage } from "./Toast";
+import "./solo.css";
+
+const PLAYER_SEAT_INDEX = 0;
+const CHIP_SET: ChipDenomination[] = [1, 5, 25, 100, 500];
+
+const defaultAvailability: SoloActionAvailability = {
+  deal: false,
+  clear: false,
+  rebet: false,
+  hit: false,
+  stand: false,
+  double: false,
+  split: false,
+  surrender: false,
+  playDealer: false,
+  nextRound: false,
+};
+
+const classifyToast = (message: string): ToastMessage["tone"] => {
+  const text = message.toLowerCase();
+  if (text.includes("win") || text.includes("blackjack") || text.includes("pays")) {
+    return "success";
+  }
+  if (text.includes("lose") || text.includes("bust") || text.includes("surrender")) {
+    return "danger";
+  }
+  return "neutral";
+};
+
+const ensureChipArray = (seat: Seat | undefined): number[] => {
+  if (!seat) {
+    return [];
+  }
+  return Array.isArray(seat.chips) ? seat.chips : [];
+};
+
+const getPlayerSeat = (seats: Seat[]): Seat | undefined => seats[PLAYER_SEAT_INDEX];
+
+const getActiveHand = (seat: Seat | undefined, activeHandId: string | null): Hand | undefined => {
+  if (!seat || !activeHandId) {
+    return undefined;
+  }
+  return seat.hands.find((hand) => hand.id === activeHandId);
+};
+
+const computeAvailability = (
+  phase: Phase,
+  seat: Seat | undefined,
+  activeHand: Hand | undefined,
+  bankroll: number,
+  lastBet: number,
+  minBet: number,
+  rules: RuleConfig,
+): SoloActionAvailability => {
+  const availability: SoloActionAvailability = { ...defaultAvailability };
+  if (!seat) {
+    return availability;
+  }
+
+  if (phase === "betting") {
+    const bet = seat.baseBet;
+    availability.deal = bet >= minBet && bet <= bankroll;
+    availability.clear = bet > 0;
+    availability.rebet = lastBet > 0 && bet === 0 && lastBet <= bankroll;
+    return availability;
+  }
+
+  if (phase === "playerActions" && activeHand) {
+    availability.hit = canHit(activeHand);
+    availability.stand = !activeHand.isResolved;
+    availability.double = canDouble(activeHand, rules);
+    availability.split = canSplit(activeHand, seat, rules);
+    availability.surrender = canSurrender(activeHand, rules);
+    return availability;
+  }
+
+  if (phase === "dealerPlay") {
+    availability.playDealer = true;
+  }
+
+  if (phase === "settlement") {
+    availability.nextRound = true;
+    if (lastBet > 0 && lastBet <= bankroll) {
+      availability.rebet = true;
+    }
+  }
+
+  return availability;
+};
+
+const primaryActionForPhase = (phase: Phase, availability: SoloActionAvailability): SoloAction | null => {
+  if (phase === "betting" && availability.deal) {
+    return "deal";
+  }
+  if (phase === "playerActions") {
+    if (availability.hit) {
+      return "hit";
+    }
+    if (availability.stand) {
+      return "stand";
+    }
+  }
+  if (phase === "dealerPlay" && availability.playDealer) {
+    return "playDealer";
+  }
+  if (phase === "settlement" && availability.nextRound) {
+    return "nextRound";
+  }
+  return null;
+};
+
+const addToast = (
+  setToasts: React.Dispatch<React.SetStateAction<ToastMessage[]>>,
+  message: string,
+  tone: ToastMessage["tone"],
+  timeoutMs = 3200,
+) => {
+  const id =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  setToasts((previous) => [...previous.slice(-2), { id, message, tone }]);
+
+  if (typeof window !== "undefined") {
+    window.setTimeout(() => {
+      setToasts((current) => current.filter((toast) => toast.id !== id));
+    }, timeoutMs);
+  }
+};
+
+export const SoloLayout: React.FC<ThemeLayoutProps> = ({
+  game,
+  actions,
+  themeId,
+  availableThemes,
+  onThemeChange,
+}) => {
+  const seat = getPlayerSeat(game.seats);
+  const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
+  const [statsOpen, setStatsOpen] = React.useState(false);
+  const [toasts, setToasts] = React.useState<ToastMessage[]>([]);
+  const [lastBet, setLastBet] = React.useState(() => seat?.baseBet ?? 0);
+  const hudCollapsed = game.phase !== "betting";
+
+  const seatIndex = seat?.index ?? PLAYER_SEAT_INDEX;
+  const seatOccupied = seat?.occupied ?? false;
+  const seatBaseBet = seat?.baseBet ?? 0;
+
+  React.useEffect(() => {
+    if (seatOccupied) {
+      return;
+    }
+    actions.sit(seatIndex);
+  }, [actions, seatIndex, seatOccupied]);
+
+  React.useEffect(() => {
+    if (game.phase !== "betting" && seatBaseBet > 0) {
+      setLastBet(seatBaseBet);
+    }
+  }, [game.phase, seatBaseBet, seat]);
+
+  const activeHand = getActiveHand(seat, game.activeHandId);
+  const availability = computeAvailability(
+    game.phase,
+    seat,
+    activeHand,
+    game.bankroll,
+    lastBet,
+    game.rules.minBet,
+    game.rules,
+  );
+  const primaryAction = primaryActionForPhase(game.phase, availability);
+
+  const insuranceHand = React.useMemo(() => {
+    if (!seat || game.phase !== "insurance") {
+      return undefined;
+    }
+    return seat.hands.find((hand) => hand.insuranceBet === undefined && !hand.isResolved);
+  }, [game.phase, seat]);
+
+  const pushMessageToast = React.useCallback(
+    (message: string) => {
+      const tone = classifyToast(message);
+      addToast(setToasts, message, tone);
+    },
+    [setToasts],
+  );
+
+  const prevLogRef = React.useRef(game.messageLog);
+  React.useEffect(() => {
+    const previous = prevLogRef.current;
+    if (game.messageLog.length > previous.length) {
+      const delta = game.messageLog.slice(previous.length);
+      delta.forEach((message) => pushMessageToast(message));
+    }
+    prevLogRef.current = game.messageLog;
+  }, [game.messageLog, pushMessageToast]);
+
+  const handleAction = React.useCallback(
+    (action: SoloAction) => {
+      switch (action) {
+        case "deal":
+          actions.deal();
+          break;
+        case "clear":
+          if (seat) {
+            actions.setBet(seat.index, 0);
+          }
+          break;
+        case "rebet":
+          if (seat && lastBet > 0) {
+            actions.setBet(seat.index, lastBet);
+          }
+          break;
+        case "hit":
+          actions.playerHit();
+          break;
+        case "stand":
+          actions.playerStand();
+          break;
+        case "double":
+          actions.playerDouble();
+          break;
+        case "split":
+          actions.playerSplit();
+          break;
+        case "surrender":
+          actions.playerSurrender();
+          break;
+        case "playDealer":
+          actions.playDealer();
+          break;
+        case "nextRound":
+          actions.nextRound();
+          break;
+        default:
+          break;
+      }
+    },
+    [actions, lastBet, seat],
+  );
+
+  React.useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.repeat) {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) {
+        return;
+      }
+      const key = event.key.toLowerCase();
+      switch (key) {
+        case "h":
+          if (availability.hit) {
+            event.preventDefault();
+            actions.playerHit();
+          }
+          break;
+        case "s":
+          if (availability.stand) {
+            event.preventDefault();
+            actions.playerStand();
+          }
+          break;
+        case "d":
+          if (availability.double) {
+            event.preventDefault();
+            actions.playerDouble();
+          }
+          break;
+        case "p":
+          if (availability.split) {
+            event.preventDefault();
+            actions.playerSplit();
+          }
+          break;
+        case "r":
+          if (availability.surrender) {
+            event.preventDefault();
+            actions.playerSurrender();
+          }
+          break;
+        case "c":
+          if (availability.clear && seat) {
+            event.preventDefault();
+            actions.setBet(seat.index, 0);
+          }
+          break;
+        case "b":
+          if (availability.rebet) {
+            event.preventDefault();
+            handleAction("rebet");
+          }
+          break;
+        case " ":
+        case "enter":
+          if (primaryAction) {
+            event.preventDefault();
+            handleAction(primaryAction);
+          }
+          break;
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [actions, availability, handleAction, primaryAction, seat]);
+
+  const handleInsurance = React.useCallback(
+    (amount: number) => {
+      if (!seat || !insuranceHand) {
+        return;
+      }
+      actions.takeInsurance(seat.index, insuranceHand.id, amount);
+    },
+    [actions, insuranceHand, seat],
+  );
+
+  const handleDeclineInsurance = React.useCallback(() => {
+    if (!seat || !insuranceHand) {
+      return;
+    }
+    actions.declineInsurance(seat.index, insuranceHand.id);
+  }, [actions, insuranceHand, seat]);
+
+  const handlePlaceBet = React.useCallback(
+    (value: number) => {
+      if (!seat || game.phase !== "betting") {
+        return;
+      }
+      actions.addChip(seat.index, value);
+    },
+    [actions, game.phase, seat],
+  );
+
+  const handleRemoveChip = React.useCallback(() => {
+    if (!seat || game.phase !== "betting") {
+      return;
+    }
+    actions.removeTopChip(seat.index);
+  }, [actions, game.phase, seat]);
+
+  const handleRebet = React.useCallback(() => {
+    if (seat && lastBet > 0) {
+      actions.setBet(seat.index, lastBet);
+    }
+  }, [actions, lastBet, seat]);
+
+  const chipStack = ensureChipArray(seat);
+
+  return (
+    <div className="solo-layer">
+      <div className="flex min-h-screen flex-col gap-6 px-4 pb-8 pt-6 md:px-10">
+        <header className={cn("solo-hud transition-all duration-300", hudCollapsed && "opacity-70 backdrop-blur-sm")}>
+          <div className="flex flex-col gap-4 px-5 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <SoloHUD
+              bankroll={game.bankroll}
+              currentBet={seat?.baseBet ?? 0}
+              round={game.roundCount}
+              phase={game.phase}
+              shoe={game.shoe}
+              rules={game.rules}
+              collapsed={hudCollapsed}
+              onToggleStats={() => setStatsOpen((open) => !open)}
+            />
+            <ThemeSwitcher themes={availableThemes} value={themeId} onChange={onThemeChange} />
+          </div>
+        </header>
+
+        <main className="flex flex-1 flex-col gap-6">
+          <div className="flex flex-1 flex-col justify-between gap-8">
+            <DealerArea dealer={game.dealer} phase={game.phase} rules={game.rules} />
+            <PlayerArea
+              seat={seat}
+              activeHandId={game.activeHandId}
+              phase={game.phase}
+              activeChip={activeChip}
+              onPlaceBet={handlePlaceBet}
+              onRemoveChip={handleRemoveChip}
+              chipStack={chipStack}
+              availability={availability}
+              onGesture={(gesture) => {
+                if (gesture === "hit" && availability.hit) {
+                  actions.playerHit();
+                } else if (gesture === "stand" && availability.stand) {
+                  actions.playerStand();
+                } else if (gesture === "double" && availability.double) {
+                  actions.playerDouble();
+                }
+              }}
+            />
+          </div>
+
+          {insuranceHand && (
+            <InsuranceStrip
+              hand={insuranceHand}
+              onConfirm={handleInsurance}
+              onSkip={handleDeclineInsurance}
+              bankroll={game.bankroll}
+            />
+          )}
+
+          <div className="flex flex-col gap-4 rounded-3xl border border-[rgba(216,182,76,0.18)] bg-[rgba(12,31,24,0.65)] p-4 shadow-[var(--shadow-1)] lg:flex-row lg:items-center lg:justify-between">
+            <BetChipsBar
+              chips={CHIP_SET}
+              activeChip={activeChip}
+              onSelect={setActiveChip}
+              onAdd={() => handlePlaceBet(activeChip)}
+              onRemove={handleRemoveChip}
+              onClear={() => seat && actions.setBet(seat.index, 0)}
+              onRebet={handleRebet}
+              canInteract={game.phase === "betting"}
+              showRebet={availability.rebet}
+            />
+            <ActionBar
+              availability={availability}
+              primary={primaryAction}
+              onAction={handleAction}
+              phase={game.phase}
+            />
+          </div>
+        </main>
+      </div>
+      <ToastHost messages={toasts} />
+      <StatsDrawer
+        open={statsOpen}
+        onClose={() => setStatsOpen(false)}
+        shoe={game.shoe}
+        rules={game.rules}
+        messageLog={game.messageLog}
+      />
+    </div>
+  );
+};
+

--- a/src/theme/solo/StatsDrawer.tsx
+++ b/src/theme/solo/StatsDrawer.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import type { RuleConfig, Shoe } from "../../engine/types";
+import { formatCurrency } from "../../utils/currency";
+import { cn } from "../../utils/cn";
+
+interface StatsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  shoe: Shoe;
+  rules: RuleConfig;
+  messageLog: string[];
+}
+
+export const StatsDrawer: React.FC<StatsDrawerProps> = ({ open, onClose, shoe, rules, messageLog }) => {
+  const totalCards = shoe.cards.length + shoe.discard.length;
+  const penetration = totalCards === 0 ? 0 : (shoe.discard.length / totalCards) * 100;
+
+  return (
+    <>
+      <div
+        className={cn(
+          "fixed inset-0 z-40 bg-black/40 backdrop-blur-sm transition-opacity",
+          open ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+        onClick={onClose}
+        role="presentation"
+      />
+      <aside
+        className={cn(
+          "fixed inset-y-0 right-0 z-50 w-full max-w-md bg-[rgba(12,31,24,0.95)] p-6 text-[var(--text-hi)] shadow-[var(--shadow-1)] transition-transform duration-300",
+          open ? "translate-x-0" : "translate-x-full",
+        )}
+        aria-hidden={!open}
+        aria-label="Stats drawer"
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.24em]">Shoe & Stats</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-[rgba(216,182,76,0.3)] px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-[var(--text-hi)]"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-4 space-y-4 text-[12px] text-[var(--text-lo)]">
+          <section>
+            <h3 className="text-[11px] uppercase tracking-[0.24em] text-[var(--text-hi)]">Shoe</h3>
+            <ul className="mt-2 space-y-1">
+              <li>Decks {rules.numberOfDecks}</li>
+              <li>Cards remaining {shoe.cards.length}</li>
+              <li>Discard pile {shoe.discard.length}</li>
+              <li>Penetration {penetration.toFixed(0)}%</li>
+              <li>Cut card at {shoe.cutIndex}</li>
+              <li>{shoe.needsReshuffle ? "Needs reshuffle" : "Shoe active"}</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-[11px] uppercase tracking-[0.24em] text-[var(--text-hi)]">Rules</h3>
+            <ul className="mt-2 space-y-1">
+              <li>Blackjack pays {rules.blackjackPayout}</li>
+              <li>Double rule {rules.doubleAllowed}</li>
+              <li>Double after split {rules.doubleAfterSplit ? "Yes" : "No"}</li>
+              <li>Surrender {rules.surrender}</li>
+              <li>Min bet {formatCurrency(rules.minBet)}</li>
+              <li>Max bet {formatCurrency(rules.maxBet)}</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-[11px] uppercase tracking-[0.24em] text-[var(--text-hi)]">Recent Log</h3>
+            <ol className="mt-2 max-h-48 space-y-1 overflow-y-auto pr-2 text-[11px]">
+              {messageLog.slice(-10).reverse().map((entry, index) => (
+                <li key={`${entry}-${index}`} className="rounded border border-[rgba(216,182,76,0.15)] bg-[rgba(10,27,21,0.6)] px-3 py-2">
+                  {entry}
+                </li>
+              ))}
+            </ol>
+          </section>
+        </div>
+      </aside>
+    </>
+  );
+};

--- a/src/theme/solo/Toast.tsx
+++ b/src/theme/solo/Toast.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+
+export interface ToastMessage {
+  id: string;
+  message: string;
+  tone: "success" | "danger" | "neutral";
+}
+
+const toneStyles: Record<ToastMessage["tone"], string> = {
+  success: "border-[rgba(120,189,120,0.6)] bg-[rgba(32,66,46,0.9)] text-[#dff7df]",
+  danger: "border-[rgba(215,90,90,0.6)] bg-[rgba(74,23,23,0.85)] text-[#f9d7d7]",
+  neutral: "border-[rgba(216,182,76,0.4)] bg-[rgba(18,38,30,0.85)] text-[var(--text-hi)]",
+};
+
+interface ToastHostProps {
+  messages: ToastMessage[];
+}
+
+export const ToastHost: React.FC<ToastHostProps> = ({ messages }) => {
+  if (messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 right-6 z-[60] flex flex-col gap-2">
+      {messages.map((toast) => (
+        <div
+          key={toast.id}
+          className={cn(
+            "solo-toast-enter pointer-events-auto min-w-[220px] rounded-2xl border px-4 py-3 text-sm shadow-[var(--shadow-1)]",
+            toneStyles[toast.tone],
+          )}
+          role="status"
+        >
+          {toast.message}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/theme/solo/solo.css
+++ b/src/theme/solo/solo.css
@@ -1,0 +1,92 @@
+:root[data-theme="solo"] {
+  --bg: #0c1f18;
+  --bg-elev: #0f261e;
+  --line: #b8952a;
+  --text-hi: #f3efe3;
+  --text-lo: #a8b3a7;
+  --accent: #d8b64c;
+  --chip-green: #1e3a2f;
+  --danger: #d75a5a;
+  --radius: 16px;
+  --radius-lg: 24px;
+  --shadow-1: 0 6px 24px rgba(0, 0, 0, 0.35);
+  --glow: 0 0 0 1px rgba(184, 149, 42, 0.35), 0 0 18px rgba(184, 149, 42, 0.25);
+  --gap: 12px;
+  --gap-lg: 20px;
+  --btn-h: 48px;
+  --chip-size: 48px;
+  --font-ui: ui-sans-serif, system-ui, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  --caps-track: 0.08em;
+}
+
+[data-theme="solo"] body {
+  font-family: var(--font-ui);
+}
+
+.solo-layer {
+  background: radial-gradient(circle at 50% 0%, rgba(29, 55, 44, 0.75), transparent 60%),
+    radial-gradient(circle at 50% 120%, rgba(29, 55, 44, 0.85), transparent 60%),
+    linear-gradient(180deg, #07120d 0%, #0b1912 35%, #0d2118 100%);
+  color: var(--text-hi);
+  min-height: 100%;
+}
+
+.solo-hud {
+  background: linear-gradient(90deg, rgba(19, 44, 34, 0.85), rgba(14, 33, 25, 0.85));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(216, 182, 76, 0.2);
+  box-shadow: var(--shadow-1);
+}
+
+.solo-chip {
+  background: radial-gradient(circle at 50% 25%, rgba(255, 255, 255, 0.15), transparent 65%), var(--chip-green);
+  border: 1px solid rgba(216, 182, 76, 0.35);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+}
+
+.solo-chip[data-active="true"] {
+  box-shadow: 0 0 0 2px rgba(216, 182, 76, 0.5), 0 18px 28px rgba(0, 0, 0, 0.45);
+  transform: translateY(-2px);
+}
+
+.solo-action-primary {
+  background: linear-gradient(135deg, var(--accent), #f3d77a);
+  color: #0b140f;
+  box-shadow: 0 12px 22px rgba(216, 182, 76, 0.4);
+}
+
+.solo-action-primary:disabled {
+  background: linear-gradient(135deg, rgba(216, 182, 76, 0.45), rgba(216, 182, 76, 0.55));
+  color: rgba(11, 20, 15, 0.4);
+  box-shadow: none;
+}
+
+.solo-toast-enter {
+  animation: solo-toast-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.solo-toast-leave {
+  animation: solo-toast-out 180ms cubic-bezier(0.4, 0, 1, 1);
+}
+
+@keyframes solo-toast-in {
+  from {
+    transform: translateY(16px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes solo-toast-out {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(16px);
+    opacity: 0;
+  }
+}

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,0 +1,39 @@
+import type React from "react";
+import type { GameState } from "../engine/types";
+
+export interface TableActionHandlers {
+  sit: (seatIndex: number) => void;
+  leave: (seatIndex: number) => void;
+  setBet: (seatIndex: number, amount: number) => void;
+  addChip: (seatIndex: number, denom: number) => void;
+  removeChipValue: (seatIndex: number, denom: number) => void;
+  removeTopChip: (seatIndex: number) => void;
+  deal: () => void;
+  playerHit: () => void;
+  playerStand: () => void;
+  playerDouble: () => void;
+  playerSplit: () => void;
+  playerSurrender: () => void;
+  takeInsurance: (seatIndex: number, handId: string, amount: number) => void;
+  declineInsurance: (seatIndex: number, handId: string) => void;
+  finishInsurance: () => void;
+  playDealer: () => void;
+  nextRound: () => void;
+}
+
+export interface ThemeIdentity {
+  id: string;
+  label: string;
+}
+
+export interface ThemeLayoutProps {
+  game: GameState;
+  actions: TableActionHandlers;
+  themeId: string;
+  availableThemes: ThemeIdentity[];
+  onThemeChange: (themeId: string) => void;
+}
+
+export interface ThemeDefinition extends ThemeIdentity {
+  Layout: React.ComponentType<ThemeLayoutProps>;
+}


### PR DESCRIPTION
## Summary
- add a theme registry and swap the main table host to resolve layouts from the active theme
- introduce the solo gameplay layout with bespoke HUD, betting bar, player/dealer areas, stats drawer, and toast feedback
- preserve the multiplayer felt under the new registry and expose a reusable theme switcher control

## Testing
- npm run lint
- npm run build *(fails: missing optional framer-motion dependency in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42fc14b788329af497953fe23df39