### PR TITLE
feat: add single-seat table mode

### DIFF
--- a/src/components/hud/RoundActionBar.tsx
+++ b/src/components/hud/RoundActionBar.tsx
@@ -5,6 +5,7 @@ import type { GameState, Hand } from "../../engine/types";
 import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
 import { formatCurrency } from "../../utils/currency";
 import { ANIM, REDUCED } from "../../utils/animConstants";
+import { filterSeatsForMode } from "../../ui/config";
 
 interface RoundActionBarProps {
   game: GameState;
@@ -20,7 +21,8 @@ interface RoundActionBarProps {
 }
 
 const hasReadySeat = (game: GameState): boolean => {
-  const readySeats = game.seats.filter((seat) => seat.occupied && seat.baseBet >= game.rules.minBet);
+  const seats = filterSeatsForMode(game.seats);
+  const readySeats = seats.filter((seat) => seat.occupied && seat.baseBet >= game.rules.minBet);
   if (readySeats.length === 0) {
     return false;
   }
@@ -32,7 +34,7 @@ const findActiveHand = (game: GameState): Hand | null => {
   if (!game.activeHandId) {
     return null;
   }
-  for (const seat of game.seats) {
+  for (const seat of filterSeatsForMode(game.seats)) {
     const hand = seat.hands.find((candidate) => candidate.id === game.activeHandId);
     if (hand) {
       return hand;

--- a/src/components/table/BetSpotOverlay.tsx
+++ b/src/components/table/BetSpotOverlay.tsx
@@ -9,6 +9,7 @@ import type { GameState, Seat } from "../../engine/types";
 import { formatCurrency } from "../../utils/currency";
 import { AnimatedChip } from "../animation/AnimatedChip";
 import { ANIM, REDUCED } from "../../utils/animConstants";
+import { filterSeatsForMode, isSingleSeatMode } from "../../ui/config";
 
 interface BetSpotOverlayProps {
   game: GameState;
@@ -34,7 +35,7 @@ export const BetSpotOverlay: React.FC<BetSpotOverlayProps> = ({
   onRemoveTopChip
 }) => {
   const isBettingPhase = game.phase === "betting";
-  const seats = game.seats;
+  const seats = filterSeatsForMode(game.seats);
   const totalBets = seats.reduce((sum, seat) => sum + seat.baseBet, 0);
 
   const handleAddChip = (seat: Seat): void => {
@@ -77,8 +78,8 @@ export const BetSpotOverlay: React.FC<BetSpotOverlayProps> = ({
         const scaleX = dimensions.width / defaultTableAnchors.viewBox.width;
         const circleSize = defaultTableAnchors.seatRadius * 2 * scaleX;
         const chipStack = Array.isArray(seat.chips) ? seat.chips : [];
-        const showSit = isBettingPhase && !seat.occupied;
-        const showLeave = seat.occupied && isBettingPhase;
+        const showSit = !isSingleSeatMode && isBettingPhase && !seat.occupied;
+        const showLeave = !isSingleSeatMode && seat.occupied && isBettingPhase;
         const visibleStart = Math.max(0, chipStack.length - MAX_VISIBLE_CHIPS);
         const visibleChips = chipStack.slice(visibleStart);
         const overflow = chipStack.length - visibleChips.length;
@@ -95,7 +96,7 @@ export const BetSpotOverlay: React.FC<BetSpotOverlayProps> = ({
                 onClick={() => handleAddChip(seat)}
                 onContextMenu={(event) => handleContextMenu(event, seat)}
                 disabled={!isBettingPhase}
-                aria-label={`Bet spot for seat ${seat.index + 1}`}
+                aria-label={isSingleSeatMode ? "Your bet spot" : `Bet spot for seat ${seat.index + 1}`}
               />
               <motion.div
                 aria-hidden

--- a/src/components/table/CardLayer.tsx
+++ b/src/components/table/CardLayer.tsx
@@ -9,6 +9,7 @@ import { Button } from "../ui/button";
 import { AnimatedCard } from "../animation/AnimatedCard";
 import { FlipCard } from "../animation/FlipCard";
 import { DEAL_STAGGER } from "../../utils/animConstants";
+import { filterSeatsForMode } from "../../ui/config";
 
 interface CardLayerProps {
   game: GameState;
@@ -277,9 +278,11 @@ export const CardLayer: React.FC<CardLayerProps> = ({
     []
   );
 
+  const seatsForMode = React.useMemo(() => filterSeatsForMode(game.seats), [game.seats]);
+
   const seatLayouts = React.useMemo(
-    () => resolveSeatLayouts(game.seats, dimensions, clusterSizes),
-    [game.seats, dimensions, clusterSizes]
+    () => resolveSeatLayouts(seatsForMode, dimensions, clusterSizes),
+    [seatsForMode, dimensions, clusterSizes]
   );
 
   const anchorPoints = React.useMemo(() => getTableAnchorPoints(dimensions), [dimensions]);

--- a/src/components/table/TableLayout.tsx
+++ b/src/components/table/TableLayout.tsx
@@ -7,6 +7,7 @@ import { CardLayer } from "./CardLayer";
 import type { ChipDenomination } from "../../theme/palette";
 import { ChipTray } from "../hud/ChipTray";
 import { RoundActionBar } from "../hud/RoundActionBar";
+import { filterSeatsForMode, isSingleSeatMode } from "../../ui/config";
 
 const BASE_W = 1850;
 const BASE_H = 780;
@@ -98,16 +99,23 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
   const scaledHeight = BASE_H * scale;
   const hudWidth = Math.max(scaledWidth, containerWidth - STAGE_PADDING * 2);
 
+  const seatsForMode = React.useMemo(() => filterSeatsForMode(game.seats), [game.seats]);
+
   const seatStates = React.useMemo<SeatVisualState[]>(
     () =>
-      mapSeatAnchors(game.seats, (seat, anchor) => ({
+      mapSeatAnchors(seatsForMode, (seat, anchor) => ({
         index: seat.index,
         occupied: seat.occupied,
         hasBet: seat.baseBet > 0,
         isActive: game.activeSeatIndex === seat.index,
-        label: seat.occupied || seat.baseBet > 0 ? "" : anchor.label
+        label:
+          seat.occupied || seat.baseBet > 0
+            ? ""
+            : isSingleSeatMode
+              ? "You"
+              : anchor.label
       })),
-    [game]
+    [game.activeSeatIndex, seatsForMode]
   );
 
   return (
@@ -144,13 +152,13 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
               onAddChip={onAddChip}
               onRemoveChipValue={onRemoveChipValue}
               onRemoveTopChip={onRemoveTopChip}
-        />
-        <CardLayer
-          game={game}
-          dimensions={{ width: BASE_W, height: BASE_H }}
-          onInsurance={onInsurance}
-          onDeclineInsurance={onDeclineInsurance}
-        />
+            />
+            <CardLayer
+              game={game}
+              dimensions={{ width: BASE_W, height: BASE_H }}
+              onInsurance={onInsurance}
+              onDeclineInsurance={onDeclineInsurance}
+            />
           </div>
         </div>
       </div>

--- a/src/components/table/TableSurfaceSVG.tsx
+++ b/src/components/table/TableSurfaceSVG.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Icon } from "@iconify/react";
 import { palette } from "../../theme/palette";
 import { defaultTableAnchors, type SeatAnchor, type TableAnchors } from "./coords";
+import { isSingleSeatMode, visibleSeatIndexes } from "../../ui/config";
 
 export interface SeatVisualState {
   index: number;
@@ -97,42 +98,44 @@ export const TableSurfaceSVG: React.FC<TableSurfaceSVGProps> = ({ className, sea
         <textPath startOffset="50%" xlinkHref={`#${innerTextId}`}>INSURANCE PAYS 2 TO 1</textPath>
       </text>
 
-      {defaultTableAnchors.seats.map((anchor: SeatAnchor) => {
-        const seat = seatByIndex.get(anchor.index);
-        return (
-          <g key={anchor.index}>
-            <circle
-              cx={anchor.x}
-              cy={anchor.y}
-              r={defaultTableAnchors.seatRadius}
-              fill="rgba(15, 46, 36, 0.75)"
-              stroke={seatCircleStroke(seat)}
-              strokeWidth={seat?.isActive ? 4 : 2.5}
-            />
-            <circle
-              cx={anchor.x}
-              cy={anchor.y}
-              r={defaultTableAnchors.seatRadius - 10}
-              fill="rgba(11, 37, 32, 0.8)"
-              stroke="rgba(234, 233, 225, 0.08)"
-              strokeWidth={1.5}
-            />
-            {seat?.label ? (
-              <text
-                x={anchor.x}
-                y={anchor.y - defaultTableAnchors.seatLabelOffset}
-                fill={palette.line}
-                fontSize={18}
-                fontWeight={600}
-                textAnchor="middle"
-                letterSpacing={3}
-              >
-                {seat.label.toUpperCase()}
-              </text>
-            ) : null}
-          </g>
-        );
-      })}
+      {defaultTableAnchors.seats
+        .filter((anchor) => !isSingleSeatMode || visibleSeatIndexes.includes(anchor.index))
+        .map((anchor: SeatAnchor) => {
+          const seat = seatByIndex.get(anchor.index);
+          return (
+            <g key={anchor.index}>
+              <circle
+                cx={anchor.x}
+                cy={anchor.y}
+                r={defaultTableAnchors.seatRadius}
+                fill="rgba(15, 46, 36, 0.75)"
+                stroke={seatCircleStroke(seat)}
+                strokeWidth={seat?.isActive ? 4 : 2.5}
+              />
+              <circle
+                cx={anchor.x}
+                cy={anchor.y}
+                r={defaultTableAnchors.seatRadius - 10}
+                fill="rgba(11, 37, 32, 0.8)"
+                stroke="rgba(234, 233, 225, 0.08)"
+                strokeWidth={1.5}
+              />
+              {seat?.label ? (
+                <text
+                  x={anchor.x}
+                  y={anchor.y - defaultTableAnchors.seatLabelOffset}
+                  fill={palette.line}
+                  fontSize={18}
+                  fontWeight={600}
+                  textAnchor="middle"
+                  letterSpacing={3}
+                >
+                  {seat.label.toUpperCase()}
+                </text>
+              ) : null}
+            </g>
+          );
+        })}
 
       <g transform={`translate(${defaultTableAnchors.shoeAnchor.x - 30}, ${defaultTableAnchors.shoeAnchor.y - 30})`}>
         <Icon icon="game-icons:card-pick" width={60} height={60} color={palette.line} />

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Table } from "../components/Table";
 import { useGameStore } from "../store/useGameStore";
 import { Button } from "../components/ui/button";
+import { isSingleSeatMode, PRIMARY_SEAT_INDEX } from "../ui/config";
 
 export const App: React.FC = () => {
   const {
@@ -26,6 +27,21 @@ export const App: React.FC = () => {
     nextRound
   } = useGameStore();
 
+  React.useEffect(() => {
+    if (!isSingleSeatMode) {
+      return;
+    }
+    game.seats.forEach((seat) => {
+      if (seat.index !== PRIMARY_SEAT_INDEX && (seat.occupied || seat.baseBet > 0 || (seat.chips?.length ?? 0) > 0)) {
+        leave(seat.index);
+      }
+    });
+    const primarySeat = game.seats[PRIMARY_SEAT_INDEX];
+    if (primarySeat && !primarySeat.occupied) {
+      sit(PRIMARY_SEAT_INDEX);
+    }
+  }, [game.seats, leave, sit]);
+
   return (
     <main className="min-h-screen bg-gradient-to-b from-emerald-950 via-emerald-900 to-emerald-950 p-6 text-emerald-50">
       <div className="mx-auto flex min-h-[calc(100vh-3rem)] w-full max-w-[1400px] flex-col gap-4">
@@ -38,7 +54,7 @@ export const App: React.FC = () => {
           </div>
         )}
         <Table
-            game={game}
+          game={game}
           actions={{
             sit,
             leave,

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -19,6 +19,7 @@ import {
   takeInsurance
 } from "../engine/engine";
 import type { GameState, Seat } from "../engine/types";
+import { isSingleSeatMode, PRIMARY_SEAT_INDEX } from "../ui/config";
 
 const BANKROLL_KEY = "blackjack_bankroll";
 const SEATS_KEY = "blackjack_seats";
@@ -76,6 +77,14 @@ const hydrateGame = (): GameState => {
     } catch {
       // ignore hydration failures
     }
+  }
+  if (isSingleSeatMode) {
+    base.seats = base.seats.map((seat) => {
+      if (seat.index === PRIMARY_SEAT_INDEX) {
+        return seat;
+      }
+      return { ...seat, occupied: false, baseBet: 0, chips: [], hands: [] };
+    });
   }
   return base;
 };

--- a/src/ui/config.ts
+++ b/src/ui/config.ts
@@ -1,0 +1,79 @@
+export type UIMode = "single" | "multi";
+
+const DEFAULT_UI_MODE: UIMode = "single";
+const STORAGE_KEY = "ui.mode";
+const QUERY_KEY = "mode";
+
+const isValidMode = (value: string | null): value is UIMode => value === "single" || value === "multi";
+
+const readStoredMode = (): UIMode | null => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return isValidMode(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+const persistMode = (mode: UIMode): void => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // ignore persistence errors
+  }
+};
+
+const resolveMode = (): UIMode => {
+  if (typeof window === "undefined") {
+    return DEFAULT_UI_MODE;
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const queryMode = params.get(QUERY_KEY);
+    if (isValidMode(queryMode)) {
+      persistMode(queryMode);
+      return queryMode;
+    }
+  } catch {
+    // ignore query parsing issues
+  }
+  const stored = readStoredMode();
+  if (stored) {
+    return stored;
+  }
+  persistMode(DEFAULT_UI_MODE);
+  return DEFAULT_UI_MODE;
+};
+
+export const UI_MODE: UIMode = resolveMode();
+export const PRIMARY_SEAT_ID = "seat-3" as const;
+export const ALL_SEATS = ["seat-1", "seat-2", "seat-3", "seat-4", "seat-5"] as const;
+
+export type SeatId = (typeof ALL_SEATS)[number];
+
+const seatIndexMap = new Map<SeatId, number>(ALL_SEATS.map((id, index) => [id, index] as const));
+
+export const seatIndexFromId = (seatId: SeatId): number => seatIndexMap.get(seatId) ?? 0;
+export const seatIdFromIndex = (index: number): SeatId => ALL_SEATS[index] ?? PRIMARY_SEAT_ID;
+
+export const PRIMARY_SEAT_INDEX = seatIndexFromId(PRIMARY_SEAT_ID);
+export const isSingleSeatMode = UI_MODE === "single";
+
+export const visibleSeatIds: SeatId[] = isSingleSeatMode ? [PRIMARY_SEAT_ID] : [...ALL_SEATS];
+export const visibleSeatIndexes: number[] = visibleSeatIds.map((seatId) => seatIndexFromId(seatId));
+
+export const restrictSeatIndex = (seatIndex: number): number =>
+  isSingleSeatMode ? PRIMARY_SEAT_INDEX : seatIndex;
+
+export const filterSeatsForMode = <T extends { index: number }>(seats: T[]): T[] => {
+  if (!isSingleSeatMode) {
+    return seats;
+  }
+  return seats.filter((seat) => seat.index === PRIMARY_SEAT_INDEX);
+};


### PR DESCRIPTION
## Summary
- add a UI config module to resolve `single` vs `multi` modes with query/localStorage overrides and primary seat metadata
- gate all table rendering, controls, and store hydration behind the single-seat mode so only the center seat renders and the player auto-sits
- streamline bet overlays, action routing, and seat visuals to hide additional seats while preserving multi-seat behavior when re-enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4375241708329b64dfa1abb2cdb37