### PR TITLE
feat: add single seat ui mode

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -4,6 +4,7 @@ import { formatCurrency } from "../utils/currency";
 import { RuleBadges } from "./RuleBadges";
 import { TableLayout } from "./table/TableLayout";
 import type { ChipDenomination } from "../theme/palette";
+import { PRIMARY_SEAT_INDEX, isSingleSeatMode } from "../ui/config";
 
 interface TableProps {
   game: GameState;
@@ -88,6 +89,8 @@ export const Table: React.FC<TableProps> = ({ game, actions }) => {
 
   const totalPendingBets = game.seats.reduce((sum, seat) => sum + seat.baseBet, 0);
 
+  const ensureSeatIndex = (seatIndex: number): number => (isSingleSeatMode ? PRIMARY_SEAT_INDEX : seatIndex);
+
   return (
     <div className="flex flex-1 flex-col gap-3 text-emerald-50">
       <header
@@ -147,13 +150,22 @@ export const Table: React.FC<TableProps> = ({ game, actions }) => {
           game={game}
           activeChip={activeChip}
           onSelectChip={handleSelectChip}
-          onSit={actions.sit}
-          onLeave={actions.leave}
-          onAddChip={actions.addChip}
-          onRemoveChipValue={actions.removeChipValue}
-          onRemoveTopChip={actions.removeTopChip}
-          onInsurance={actions.takeInsurance}
-          onDeclineInsurance={actions.declineInsurance}
+          onSit={(seatIndex) => actions.sit(ensureSeatIndex(seatIndex))}
+          onLeave={(seatIndex) => {
+            if (isSingleSeatMode) {
+              return;
+            }
+            actions.leave(ensureSeatIndex(seatIndex));
+          }}
+          onAddChip={(seatIndex, denom) => actions.addChip(ensureSeatIndex(seatIndex), denom)}
+          onRemoveChipValue={(seatIndex, denom) => actions.removeChipValue(ensureSeatIndex(seatIndex), denom)}
+          onRemoveTopChip={(seatIndex) => actions.removeTopChip(ensureSeatIndex(seatIndex))}
+          onInsurance={(seatIndex, handId, amount) =>
+            actions.takeInsurance(ensureSeatIndex(seatIndex), handId, amount)
+          }
+          onDeclineInsurance={(seatIndex, handId) =>
+            actions.declineInsurance(ensureSeatIndex(seatIndex), handId)
+          }
           onHit={actions.playerHit}
           onStand={actions.playerStand}
           onDouble={actions.playerDouble}

--- a/src/components/table/CardLayer.tsx
+++ b/src/components/table/CardLayer.tsx
@@ -9,6 +9,7 @@ import { Button } from "../ui/button";
 import { AnimatedCard } from "../animation/AnimatedCard";
 import { FlipCard } from "../animation/FlipCard";
 import { DEAL_STAGGER } from "../../utils/animConstants";
+import { PRIMARY_SEAT_INDEX, isSingleSeatMode } from "../../ui/config";
 
 interface CardLayerProps {
   game: GameState;
@@ -108,7 +109,7 @@ const renderInsurancePrompt = (
         <Button
           size="sm"
           className="h-7 px-3 text-[11px] font-semibold uppercase tracking-[0.3em]"
-          onClick={() => onInsurance(seat.index, hand.id, cappedAmount)}
+          onClick={() => onInsurance(isSingleSeatMode ? PRIMARY_SEAT_INDEX : seat.index, hand.id, cappedAmount)}
           disabled={disabled}
         >
           Take {formatCurrency(cappedAmount)}
@@ -117,7 +118,7 @@ const renderInsurancePrompt = (
           size="sm"
           variant="outline"
           className="h-7 px-3 text-[11px] font-semibold uppercase tracking-[0.3em]"
-          onClick={() => onDeclineInsurance(seat.index, hand.id)}
+          onClick={() => onDeclineInsurance(isSingleSeatMode ? PRIMARY_SEAT_INDEX : seat.index, hand.id)}
         >
           Skip
         </Button>
@@ -240,6 +241,14 @@ export const CardLayer: React.FC<CardLayerProps> = ({
   const clusterRefCallbacks = React.useRef(new Map<number, (node: HTMLDivElement | null) => void>());
   const [clusterSizes, setClusterSizes] = React.useState<Record<number, SeatClusterSize>>({});
 
+  const seats = React.useMemo(() => {
+    if (!isSingleSeatMode) {
+      return game.seats;
+    }
+    const primarySeat = game.seats[PRIMARY_SEAT_INDEX];
+    return primarySeat ? [primarySeat] : [];
+  }, [game.seats]);
+
   const getClusterRef = React.useCallback(
     (seatIndex: number) => {
       if (!clusterRefCallbacks.current.has(seatIndex)) {
@@ -278,8 +287,8 @@ export const CardLayer: React.FC<CardLayerProps> = ({
   );
 
   const seatLayouts = React.useMemo(
-    () => resolveSeatLayouts(game.seats, dimensions, clusterSizes),
-    [game.seats, dimensions, clusterSizes]
+    () => resolveSeatLayouts(seats, dimensions, clusterSizes),
+    [seats, dimensions, clusterSizes]
   );
 
   const anchorPoints = React.useMemo(() => getTableAnchorPoints(dimensions), [dimensions]);

--- a/src/components/table/TableLayout.tsx
+++ b/src/components/table/TableLayout.tsx
@@ -7,6 +7,7 @@ import { CardLayer } from "./CardLayer";
 import type { ChipDenomination } from "../../theme/palette";
 import { ChipTray } from "../hud/ChipTray";
 import { RoundActionBar } from "../hud/RoundActionBar";
+import { PRIMARY_SEAT_INDEX, isSingleSeatMode } from "../../ui/config";
 
 const BASE_W = 1850;
 const BASE_H = 780;
@@ -98,16 +99,24 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
   const scaledHeight = BASE_H * scale;
   const hudWidth = Math.max(scaledWidth, containerWidth - STAGE_PADDING * 2);
 
+  const seatsToDisplay = React.useMemo(() => {
+    if (!isSingleSeatMode) {
+      return game.seats;
+    }
+    const primarySeat = game.seats[PRIMARY_SEAT_INDEX];
+    return primarySeat ? [primarySeat] : [];
+  }, [game.seats]);
+
   const seatStates = React.useMemo<SeatVisualState[]>(
     () =>
-      mapSeatAnchors(game.seats, (seat, anchor) => ({
+      mapSeatAnchors(seatsToDisplay, (seat, anchor) => ({
         index: seat.index,
         occupied: seat.occupied,
         hasBet: seat.baseBet > 0,
         isActive: game.activeSeatIndex === seat.index,
-        label: seat.occupied || seat.baseBet > 0 ? "" : anchor.label
+        label: isSingleSeatMode ? "" : seat.occupied || seat.baseBet > 0 ? "" : anchor.label
       })),
-    [game]
+    [game.activeSeatIndex, seatsToDisplay]
   );
 
   return (

--- a/src/components/table/TableSurfaceSVG.tsx
+++ b/src/components/table/TableSurfaceSVG.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Icon } from "@iconify/react";
 import { palette } from "../../theme/palette";
 import { defaultTableAnchors, type SeatAnchor, type TableAnchors } from "./coords";
+import { PRIMARY_SEAT_INDEX, isSingleSeatMode } from "../../ui/config";
 
 export interface SeatVisualState {
   index: number;
@@ -97,7 +98,10 @@ export const TableSurfaceSVG: React.FC<TableSurfaceSVGProps> = ({ className, sea
         <textPath startOffset="50%" xlinkHref={`#${innerTextId}`}>INSURANCE PAYS 2 TO 1</textPath>
       </text>
 
-      {defaultTableAnchors.seats.map((anchor: SeatAnchor) => {
+      {(isSingleSeatMode
+        ? defaultTableAnchors.seats.filter((anchor) => anchor.index === PRIMARY_SEAT_INDEX)
+        : defaultTableAnchors.seats
+      ).map((anchor: SeatAnchor) => {
         const seat = seatByIndex.get(anchor.index);
         return (
           <g key={anchor.index}>

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Table } from "../components/Table";
 import { useGameStore } from "../store/useGameStore";
 import { Button } from "../components/ui/button";
+import { PRIMARY_SEAT_INDEX, isSingleSeatMode } from "../ui/config";
 
 export const App: React.FC = () => {
   const {
@@ -25,6 +26,26 @@ export const App: React.FC = () => {
     playDealer,
     nextRound
   } = useGameStore();
+
+  React.useEffect(() => {
+    if (!isSingleSeatMode) {
+      return;
+    }
+
+    const primarySeat = game.seats[PRIMARY_SEAT_INDEX];
+    if (primarySeat && !primarySeat.occupied) {
+      sit(PRIMARY_SEAT_INDEX);
+    }
+
+    game.seats.forEach((seat) => {
+      if (
+        seat.index !== PRIMARY_SEAT_INDEX &&
+        (seat.occupied || seat.baseBet > 0 || (Array.isArray(seat.chips) && seat.chips.length > 0))
+      ) {
+        leave(seat.index);
+      }
+    });
+  }, [game.seats, leave, sit]);
 
   return (
     <main className="min-h-screen bg-gradient-to-b from-emerald-950 via-emerald-900 to-emerald-950 p-6 text-emerald-50">

--- a/src/ui/config.ts
+++ b/src/ui/config.ts
@@ -1,0 +1,65 @@
+export type UiMode = "single" | "multi";
+
+export const PRIMARY_SEAT_ID = "seat-3";
+export const ALL_SEATS = ["seat-1", "seat-2", "seat-3", "seat-4", "seat-5"] as const;
+
+const DEFAULT_UI_MODE: UiMode = "single";
+const MODE_QUERY_KEY = "mode";
+const MODE_STORAGE_KEY = "ui.mode";
+
+const isUiMode = (value: string | null): value is UiMode => value === "single" || value === "multi";
+
+const readModeFromQuery = (): UiMode | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const param = params.get(MODE_QUERY_KEY);
+    return isUiMode(param) ? param : null;
+  } catch {
+    return null;
+  }
+};
+
+const readModeFromStorage = (): UiMode | null => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(MODE_STORAGE_KEY);
+    return isUiMode(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+const persistMode = (mode: UiMode): void => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(MODE_STORAGE_KEY, mode);
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const resolveUiMode = (): UiMode => {
+  const fromQuery = readModeFromQuery();
+  if (fromQuery) {
+    persistMode(fromQuery);
+    return fromQuery;
+  }
+  const fromStorage = readModeFromStorage();
+  if (fromStorage) {
+    return fromStorage;
+  }
+  return DEFAULT_UI_MODE;
+};
+
+export const UI_MODE: UiMode = resolveUiMode();
+
+export const PRIMARY_SEAT_INDEX = Math.max(0, ALL_SEATS.indexOf(PRIMARY_SEAT_ID));
+
+export const isSingleSeatMode = UI_MODE === "single";


### PR DESCRIPTION
## Summary
- add a UI configuration module that resolves single or multi-seat mode from query params or stored preferences
- lock the React UI to the primary seat when in single mode, auto-sitting the player and filtering rendering to a single bet spot and hand cluster
- ensure table surface, bet overlay, and card layer only render the center seat while routing all actions through the primary seat index

## Testing
- npm run build *(fails: TypeScript cannot resolve framer-motion module types in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4375241708329b64dfa1abb2cdb37