### PR TITLE
Add settlement result banner and modernize chips

### DIFF
--- a/src/components/hud/Chip.tsx
+++ b/src/components/hud/Chip.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { chipPalette } from "../../theme/palette";
+import { cn } from "../../utils/cn";
+
+type ChipProps = {
+  value: number;
+  selected?: boolean;
+  disabled?: boolean;
+  size?: number;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "type">;
+
+const DEFAULT_COLORS = { base: "#3a6b57", ring: "#325c4b", core: "#427c64", notch: "#2c5143" };
+
+const formatChip = (value: number): string => {
+  if (value >= 1000) {
+    return `${value / 1000}K`;
+  }
+  return `${value}`;
+};
+
+const getChipColors = (value: number) => chipPalette[value] ?? DEFAULT_COLORS;
+
+export const Chip: React.FC<ChipProps> = ({
+  value,
+  selected = false,
+  disabled = false,
+  onClick,
+  size = 56,
+  className,
+  style,
+  ...rest
+}) => {
+  const colors = getChipColors(value);
+  const gradientId = React.useId();
+
+  return (
+    <button
+      type="button"
+      className={cn("chip", selected && "is-selected", disabled && "is-disabled", className)}
+      style={{ width: size, height: size, ...style }}
+      onClick={onClick}
+      aria-pressed={selected}
+      disabled={disabled}
+      {...rest}
+    >
+      <svg viewBox="0 0 100 100" aria-hidden="true">
+        <defs>
+          <radialGradient id={`${gradientId}-gloss`} cx="50%" cy="45%" r="70%">
+            <stop offset="0%" stopColor="#ffffff" stopOpacity="0.06" />
+            <stop offset="100%" stopColor="#000000" stopOpacity="0.25" />
+          </radialGradient>
+        </defs>
+        <circle cx="50" cy="50" r="48" fill={colors.base} />
+        <circle cx="50" cy="50" r="48" fill={`url(#${gradientId}-gloss)`} />
+        <circle cx="50" cy="50" r="37" fill={colors.ring} />
+        <circle cx="50" cy="50" r="31" fill={colors.core} />
+        <g fill={colors.notch} opacity="0.9">
+          {Array.from({ length: 6 }).map((_, index) => {
+            const angle = (index * 360) / 6;
+            const radians = (angle * Math.PI) / 180;
+            const x = 50 + Math.cos(radians) * 43;
+            const y = 50 + Math.sin(radians) * 43;
+            return <circle key={angle} cx={x} cy={y} r="4" />;
+          })}
+        </g>
+      </svg>
+      <span className="chip-value">{formatChip(value)}</span>
+    </button>
+  );
+};

--- a/src/components/hud/ChipTray.tsx
+++ b/src/components/hud/ChipTray.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { ChipDenomination } from "../../theme/palette";
 import { palette } from "../../theme/palette";
-import { ChipSVG } from "../table/ChipSVG";
+import { Chip } from "./Chip";
 
 const CHIP_VALUES: ChipDenomination[] = [1, 5, 25, 100, 500];
 
@@ -22,26 +22,25 @@ export const ChipTray: React.FC<ChipTrayProps> = ({ activeChip, onSelect, disabl
         {CHIP_VALUES.map((value) => {
           const isActive = activeChip === value;
           return (
-            <button
-              key={value}
-              type="button"
-              data-testid={`chip-${value}`}
-              className="relative rounded-full transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a24a]"
-              disabled={disabled}
-              aria-pressed={isActive}
-              aria-label={`${value} chip`}
-              onClick={() => onSelect(value)}
-            >
-              <ChipSVG value={value} size={isActive ? 56 : 52} shadow={isActive} />
+            <div key={value} className="relative flex flex-col items-center">
+              <Chip
+                value={value}
+                size={isActive ? 58 : 54}
+                selected={isActive}
+                disabled={disabled}
+                data-testid={`chip-${value}`}
+                aria-label={`${value} chip`}
+                onClick={() => onSelect(value)}
+              />
               {isActive && (
                 <span
-                  className="absolute inset-x-0 -bottom-4 text-center text-[9px] font-semibold uppercase tracking-[0.4em]"
+                  className="mt-1 text-center text-[9px] font-semibold uppercase tracking-[0.4em]"
                   style={{ color: palette.gold }}
                 >
                   Active
                 </span>
               )}
-            </button>
+            </div>
           );
         })}
       </div>

--- a/src/components/table/ChipSVG.tsx
+++ b/src/components/table/ChipSVG.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { chipPalette, type ChipDenomination } from "../../theme/palette";
 
+const DEFAULT_COLORS = { base: "#3a6b57", ring: "#325c4b", core: "#427c64", notch: "#2c5143" };
+
 interface ChipSVGProps {
   value: ChipDenomination;
   size?: number;
@@ -10,7 +12,12 @@ interface ChipSVGProps {
 }
 
 export const ChipSVG: React.FC<ChipSVGProps> = ({ value, size = 56, shadow = false, className, style }) => {
-  const colors = chipPalette[value];
+  const colors = chipPalette[value] ?? DEFAULT_COLORS;
+  const gradientId = React.useId();
+  const notchCount = 6;
+
+  const textFill = value >= 100 ? "rgba(245,245,245,0.92)" : "rgba(0,0,0,0.82)";
+
   return (
     <svg
       viewBox="0 0 100 100"
@@ -18,27 +25,40 @@ export const ChipSVG: React.FC<ChipSVGProps> = ({ value, size = 56, shadow = fal
       height={size}
       className={className}
       style={{
-        filter: shadow ? "drop-shadow(0 6px 12px rgba(0,0,0,0.35))" : undefined,
+        filter: shadow ? "drop-shadow(0 6px 18px rgba(0,0,0,0.4))" : undefined,
         ...style
       }}
+      aria-hidden="true"
+      focusable="false"
     >
       <defs>
-        <linearGradient id={`chip-base-${value}`} x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor={colors.base} />
-          <stop offset="100%" stopColor={colors.accent} />
-        </linearGradient>
+        <radialGradient id={`${gradientId}-sheen`} cx="50%" cy="45%" r="70%">
+          <stop offset="0%" stopColor="#ffffff" stopOpacity="0.06" />
+          <stop offset="100%" stopColor="#000000" stopOpacity="0.25" />
+        </radialGradient>
       </defs>
-      <circle cx="50" cy="50" r="48" fill={`url(#chip-base-${value})`} stroke={colors.accent} strokeWidth="2" />
-      <circle cx="50" cy="50" r="34" fill={colors.base} stroke={colors.accent} strokeWidth="3" />
-      {Array.from({ length: 8 }).map((_, index) => {
-        const angle = (index * Math.PI) / 4;
-        const x1 = 50 + Math.cos(angle) * 40;
-        const y1 = 50 + Math.sin(angle) * 40;
-        const x2 = 50 + Math.cos(angle) * 48;
-        const y2 = 50 + Math.sin(angle) * 48;
-        return <line key={index} x1={x1} y1={y1} x2={x2} y2={y2} stroke={colors.accent} strokeWidth={4} strokeLinecap="round" />;
-      })}
-      <text x="50" y="58" fill={colors.text} fontSize="28" fontWeight="700" textAnchor="middle">
+      <circle cx="50" cy="50" r="48" fill={colors.base} />
+      <circle cx="50" cy="50" r="48" fill={`url(#${gradientId}-sheen)`} />
+      <circle cx="50" cy="50" r="37" fill={colors.ring} />
+      <circle cx="50" cy="50" r="31" fill={colors.core} />
+      <g fill={colors.notch} opacity="0.9">
+        {Array.from({ length: notchCount }).map((_, index) => {
+          const angle = (index * 360) / notchCount;
+          const radians = (angle * Math.PI) / 180;
+          const x = 50 + Math.cos(radians) * 43;
+          const y = 50 + Math.sin(radians) * 43;
+          return <circle key={angle} cx={x} cy={y} r="4" />;
+        })}
+      </g>
+      <text
+        x="50"
+        y="58"
+        textAnchor="middle"
+        fontSize="26"
+        fontWeight="700"
+        fill={textFill}
+        style={{ fontVariantNumeric: "tabular-nums" }}
+      >
         {value}
       </text>
     </svg>

--- a/src/components/table/ResultBanner.tsx
+++ b/src/components/table/ResultBanner.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+import { formatCurrency } from "../../utils/currency";
+
+export type ResultKind = "win" | "lose" | "push" | "blackjack" | "insurance";
+
+type ResultBannerProps = {
+  kind: ResultKind;
+  amount?: number;
+  phase?: "enter" | "exit";
+};
+
+const getLabel = (kind: ResultKind): string => {
+  switch (kind) {
+    case "blackjack":
+      return "BLACKJACK!";
+    case "insurance":
+      return "INSURANCE WIN";
+    case "push":
+      return "PUSH";
+    case "win":
+      return "WIN";
+    default:
+      return "LOSE";
+  }
+};
+
+export const ResultBanner: React.FC<ResultBannerProps> = ({ kind, amount, phase }) => {
+  const label = getLabel(kind);
+  const showAmount = typeof amount === "number" && Number.isFinite(amount) && amount > 0.004;
+  return (
+    <div
+      className={cn("result-banner", `is-${kind}`, phase === "enter" && "result-enter", phase === "exit" && "result-exit")}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="result-label">{label}</span>
+      {showAmount ? <span className="result-amount">{formatCurrency(amount)}</span> : null}
+    </div>
+  );
+};

--- a/src/components/table/TableLayout.tsx
+++ b/src/components/table/TableLayout.tsx
@@ -244,7 +244,7 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
         removeTimerRef.current = window.setTimeout(() => {
           setBannerState(null);
         }, 320);
-      }, 1200);
+      }, 3000);
     },
     [clearBannerTimers]
   );

--- a/src/components/table/TableLayout.tsx
+++ b/src/components/table/TableLayout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import type { GameState } from "../../engine/types";
+import type { GameState, Seat } from "../../engine/types";
+import { bestTotal, isBust } from "../../engine/totals";
 import { TableSurfaceSVG, type SeatVisualState } from "./TableSurfaceSVG";
 import { mapSeatAnchors } from "./coords";
 import { BetSpotOverlay } from "./BetSpotOverlay";
@@ -8,6 +9,9 @@ import type { ChipDenomination } from "../../theme/palette";
 import { ChipTray } from "../hud/ChipTray";
 import { RoundActionBar } from "../hud/RoundActionBar";
 import { filterSeatsForMode, isSingleSeatMode } from "../../ui/config";
+import { ResultBanner, type ResultKind } from "./ResultBanner";
+
+const MIN_AMOUNT = 0.005;
 
 const BASE_W = 1850;
 const BASE_H = 780;
@@ -48,6 +52,118 @@ const useStageMetrics = (containerRef: React.RefObject<HTMLDivElement>): StageMe
   }, [containerRef]);
 
   return metrics;
+};
+
+type BannerPhase = "enter" | "exit";
+
+type BannerState = {
+  key: number;
+  kind: ResultKind;
+  amount?: number;
+  phase: BannerPhase;
+};
+
+type OutcomeSummary = {
+  net: number;
+  baseNet: number;
+  insuranceNet: number;
+  hasBlackjackWin: boolean;
+};
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+const calculateOutcomeForSeats = (game: GameState, seats: Seat[]): OutcomeSummary | null => {
+  const dealerHand = game.dealer.hand;
+  const dealerBlackjack = dealerHand.isBlackjack;
+  const dealerBust = isBust(dealerHand);
+  const dealerTotal = bestTotal(dealerHand);
+
+  let totalBet = 0;
+  let totalInsurance = 0;
+  let basePayout = 0;
+  let insurancePayout = 0;
+  let hasBlackjackWin = false;
+
+  const relevantSeats = seats.filter((seat) =>
+    seat.hands.some((hand) => (hand.bet ?? 0) > 0 || (hand.insuranceBet ?? 0) > 0)
+  );
+
+  if (relevantSeats.length === 0) {
+    return null;
+  }
+
+  const blackjackMultiplier = game.rules.blackjackPayout === "6:5" ? 1.2 : 1.5;
+
+  for (const seat of relevantSeats) {
+    for (const hand of seat.hands) {
+      const bet = hand.bet ?? 0;
+      const insuranceBet = hand.insuranceBet ?? 0;
+
+      totalBet += bet;
+      totalInsurance += insuranceBet;
+
+      if (dealerBlackjack) {
+        if (insuranceBet > 0) {
+          insurancePayout += insuranceBet * 3;
+        }
+        if (hand.isBlackjack) {
+          basePayout += bet;
+        }
+        continue;
+      }
+
+      if (hand.isSurrendered) {
+        basePayout += bet / 2;
+        continue;
+      }
+
+      if (isBust(hand)) {
+        continue;
+      }
+
+      if (hand.isBlackjack) {
+        basePayout += bet * (1 + blackjackMultiplier);
+        hasBlackjackWin = true;
+        continue;
+      }
+
+      if (dealerBust) {
+        basePayout += bet * 2;
+        continue;
+      }
+
+      const playerTotal = bestTotal(hand);
+      if (playerTotal > dealerTotal) {
+        basePayout += bet * 2;
+      } else if (playerTotal === dealerTotal) {
+        basePayout += bet;
+      }
+    }
+  }
+
+  if (totalBet <= 0 && totalInsurance <= 0) {
+    return null;
+  }
+
+  const baseNet = roundToCents(basePayout - totalBet);
+  const insuranceNet = roundToCents(insurancePayout - totalInsurance);
+  const net = roundToCents(baseNet + insuranceNet);
+
+  return { net, baseNet, insuranceNet, hasBlackjackWin };
+};
+
+const resolveResultKind = (outcome: OutcomeSummary): ResultKind => {
+  const { net, baseNet, insuranceNet, hasBlackjackWin } = outcome;
+  if (net > MIN_AMOUNT) {
+    if (insuranceNet > MIN_AMOUNT && baseNet <= MIN_AMOUNT) {
+      return "insurance";
+    }
+    return hasBlackjackWin ? "blackjack" : "win";
+  }
+  if (net < -MIN_AMOUNT) {
+    return "lose";
+  }
+  return "push";
 };
 
 interface TableLayoutProps {
@@ -100,6 +216,53 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
   const hudWidth = Math.max(scaledWidth, containerWidth - STAGE_PADDING * 2);
 
   const seatsForMode = React.useMemo(() => filterSeatsForMode(game.seats), [game.seats]);
+
+  const [bannerState, setBannerState] = React.useState<BannerState | null>(null);
+  const exitTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const removeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const previousRoundRef = React.useRef(game.roundCount);
+
+  const clearBannerTimers = React.useCallback(() => {
+    if (exitTimerRef.current) {
+      clearTimeout(exitTimerRef.current);
+      exitTimerRef.current = null;
+    }
+    if (removeTimerRef.current) {
+      clearTimeout(removeTimerRef.current);
+      removeTimerRef.current = null;
+    }
+  }, []);
+
+  const showBanner = React.useCallback(
+    (next: { kind: ResultKind; amount?: number }) => {
+      clearBannerTimers();
+      const key = Date.now();
+      setBannerState({ key, phase: "enter", ...next });
+
+      exitTimerRef.current = window.setTimeout(() => {
+        setBannerState((current) => (current ? { ...current, phase: "exit" } : null));
+        removeTimerRef.current = window.setTimeout(() => {
+          setBannerState(null);
+        }, 320);
+      }, 1200);
+    },
+    [clearBannerTimers]
+  );
+
+  React.useEffect(() => () => clearBannerTimers(), [clearBannerTimers]);
+
+  React.useEffect(() => {
+    const previousRound = previousRoundRef.current;
+    if (game.phase === "settlement" && game.roundCount > previousRound) {
+      const outcome = calculateOutcomeForSeats(game, seatsForMode);
+      if (outcome) {
+        const kind = resolveResultKind(outcome);
+        const amount = Math.abs(outcome.net);
+        showBanner({ kind, amount: amount > MIN_AMOUNT ? amount : undefined });
+      }
+    }
+    previousRoundRef.current = game.roundCount;
+  }, [game, seatsForMode, showBanner]);
 
   const seatStates = React.useMemo<SeatVisualState[]>(
     () =>
@@ -159,6 +322,14 @@ export const TableLayout: React.FC<TableLayoutProps> = ({
               onInsurance={onInsurance}
               onDeclineInsurance={onDeclineInsurance}
             />
+            {bannerState ? (
+              <ResultBanner
+                key={bannerState.key}
+                kind={bannerState.kind}
+                amount={bannerState.amount}
+                phase={bannerState.phase}
+              />
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -173,11 +173,11 @@ button:disabled {
 }
 
 .result-banner .result-label {
-  font-size: 0.9rem;
+  font-size: 1.05rem;
 }
 
 .result-banner .result-amount {
-  font-size: 0.85rem;
+  font-size: 0.95rem;
   opacity: 0.9;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,12 @@
   --dealer-label-offset: calc(var(--stack-shadow-clearance) + var(--label-stack-gap));
   --player-meta-gap: clamp(12px, calc(var(--card-h) * 0.09), 24px);
   --player-meta-minh: clamp(28px, calc(var(--card-h) * 0.2), 44px);
+  --result-win: #2ddf80;
+  --result-lose: #ff6b6b;
+  --result-push: #d8b64c;
+  --result-fg: #0b1f19;
+  --result-bg: rgba(11, 31, 25, 0.75);
+  --result-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
 }
 
 .dealer-area {
@@ -86,4 +92,158 @@ body {
 button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+.chip {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  border: none;
+  border-radius: 999px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, outline-color 0.12s ease;
+  outline: 1px solid rgba(255, 255, 255, 0.08);
+  background: none;
+  padding: 0;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.chip svg {
+  width: 100%;
+  height: 100%;
+  border-radius: 999px;
+}
+
+.chip-value {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+  font-weight: 800;
+  color: rgba(0, 0, 0, 0.85);
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.3);
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
+
+.chip:hover:not(.is-disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+}
+
+.chip.is-selected {
+  outline: 2px solid #d8b64c;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(216, 182, 76, 0.22), 0 10px 24px rgba(0, 0, 0, 0.45);
+}
+
+.chip.is-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.chip:focus-visible {
+  outline: 2px solid #d8b64c;
+  outline-offset: 3px;
+}
+
+.result-banner {
+  position: absolute;
+  right: clamp(12px, 3vw, 28px);
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: var(--result-bg);
+  box-shadow: var(--result-shadow);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  backdrop-filter: blur(2px);
+  pointer-events: none;
+  opacity: 0;
+  color: var(--result-push);
+}
+
+.result-banner .result-label {
+  font-size: 0.9rem;
+}
+
+.result-banner .result-amount {
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.result-banner.is-win {
+  color: var(--result-win);
+  border: 1px solid rgba(45, 223, 128, 0.55);
+}
+
+.result-banner.is-blackjack {
+  color: var(--result-push);
+  border: 1px solid rgba(216, 182, 76, 0.55);
+}
+
+.result-banner.is-insurance {
+  color: var(--result-push);
+  border: 1px solid rgba(216, 182, 76, 0.55);
+}
+
+.result-banner.is-push {
+  color: var(--result-push);
+  border: 1px solid rgba(216, 182, 76, 0.55);
+}
+
+.result-banner.is-lose {
+  color: var(--result-lose);
+  border: 1px solid rgba(255, 107, 107, 0.55);
+}
+
+@keyframes resultIn {
+  from {
+    opacity: 0;
+    transform: translate(16px, -50%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, -50%);
+  }
+}
+
+@keyframes resultOut {
+  to {
+    opacity: 0;
+    transform: translate(16px, -50%);
+  }
+}
+
+.result-enter {
+  animation: resultIn 0.24s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.result-exit {
+  animation: resultOut 0.32s ease forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chip,
+  .chip:hover,
+  .result-enter,
+  .result-exit {
+    animation: none;
+    transform: none;
+    transition: none;
+  }
+
+  .result-enter,
+  .result-exit {
+    opacity: 1;
+  }
 }

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -17,12 +17,12 @@ export const palette = {
   subtleText: "#c7d1c9"
 } as const;
 
-export const chipPalette: Record<number, { base: string; accent: string; text: string }> = {
-  1: { base: "#f5f5f2", accent: "#dad9d4", text: "#2f2f2f" },
-  5: { base: "#d54848", accent: "#b63d3d", text: "#f9f4f4" },
-  25: { base: "#2d6a4f", accent: "#24533d", text: "#f1f9f5" },
-  100: { base: "#1d1d1d", accent: "#3a3a3a", text: "#f0f0f0" },
-  500: { base: "#6a3ea1", accent: "#553281", text: "#f4eef9" }
+export const chipPalette: Record<number, { base: string; ring: string; core: string; notch: string }> = {
+  1: { base: "#f2f2ee", ring: "#e8e6db", core: "#fffdf6", notch: "#d2cfbf" },
+  5: { base: "#d9534f", ring: "#c44b47", core: "#e76662", notch: "#b74440" },
+  25: { base: "#2d6a4f", ring: "#265a43", core: "#338f68", notch: "#244f3c" },
+  100: { base: "#303338", ring: "#282b2f", core: "#404349", notch: "#1f2125" },
+  500: { base: "#5b3ea8", ring: "#4e3593", core: "#6b50ba", notch: "#462f87" }
 };
 
 export type ChipDenomination = keyof typeof chipPalette;


### PR DESCRIPTION
## Summary
- add a settlement result banner that reacts to round outcomes with accessible animations
- refresh chip components, palette, and styling for cleaner SVG rendering
- update table layout logic to surface payouts and reduced-motion aware transitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e43ee4c4e08329b2debc0b410e122f