### PR TITLE
Fix coach feedback visibility

### DIFF
--- a/src/components/CoachToggle.tsx
+++ b/src/components/CoachToggle.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import type { CoachMode } from "../store/useGameStore";
+import { Button } from "./ui/button";
+
+const COACH_LABELS: Record<CoachMode, string> = {
+  off: "Off",
+  feedback: "Feedback",
+  live: "Live"
+};
+
+const COACH_DESCRIPTIONS: Record<CoachMode, string> = {
+  off: "Coach disabled",
+  feedback: "Show verdicts after each move",
+  live: "Highlight best move before acting"
+};
+
+const CYCLE: CoachMode[] = ["off", "feedback", "live"];
+
+interface CoachToggleProps {
+  mode: CoachMode;
+  onChange: (mode: CoachMode) => void;
+}
+
+export const CoachToggle: React.FC<CoachToggleProps> = ({ mode, onChange }) => {
+  const handleClick = () => {
+    const currentIndex = CYCLE.indexOf(mode);
+    const nextIndex = (currentIndex + 1) % CYCLE.length;
+    onChange(CYCLE[nextIndex]);
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={handleClick}
+      aria-label={`Toggle coach mode (currently ${COACH_LABELS[mode]})`}
+      title={`${COACH_DESCRIPTIONS[mode]} — click to switch`}
+      className="flex items-center gap-2 text-[11px] uppercase tracking-[0.28em] text-emerald-100"
+    >
+      <span className="opacity-80">Coach</span>
+      <span className="rounded-full bg-[#123428]/80 px-2 py-0.5 text-[10px] font-semibold tracking-[0.2em] text-emerald-50">
+        {COACH_LABELS[mode]}
+      </span>
+    </Button>
+  );
+};

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -5,9 +5,12 @@ import { RuleBadges } from "./RuleBadges";
 import { TableLayout } from "./table/TableLayout";
 import type { ChipDenomination } from "../theme/palette";
 import { filterSeatsForMode, isSingleSeatMode, PRIMARY_SEAT_INDEX } from "../ui/config";
+import type { CoachMode } from "../store/useGameStore";
+import { CoachToggle } from "./CoachToggle";
 
 interface TableProps {
   game: GameState;
+  coachMode: CoachMode;
   actions: {
     sit: (seatIndex: number) => void;
     leave: (seatIndex: number) => void;
@@ -26,6 +29,7 @@ interface TableProps {
     playDealer: () => void;
     nextRound: () => void;
   };
+  onCoachModeChange: (mode: CoachMode) => void;
 }
 
 const penetrationPercentage = (game: GameState): string => {
@@ -37,7 +41,7 @@ const penetrationPercentage = (game: GameState): string => {
   return `${Math.round(penetration * 100)}%`;
 };
 
-export const Table: React.FC<TableProps> = ({ game, actions }) => {
+export const Table: React.FC<TableProps> = ({ game, coachMode, actions, onCoachModeChange }) => {
   const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
   const headerRef = React.useRef<HTMLDivElement | null>(null);
   const [viewportHeight, setViewportHeight] = React.useState(
@@ -118,7 +122,7 @@ export const Table: React.FC<TableProps> = ({ game, actions }) => {
         ref={headerRef}
         className="rounded-3xl border border-[#c8a24a]/35 bg-[#0c2c22]/65 px-4 py-2 shadow-[0_16px_36px_rgba(0,0,0,0.4)] backdrop-blur"
       >
-        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex flex-col gap-1.5">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-200">
               <span>Casino Blackjack</span>
@@ -137,26 +141,29 @@ export const Table: React.FC<TableProps> = ({ game, actions }) => {
               </div>
             </div>
           </div>
-          <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-[10px] uppercase tracking-[0.18em] text-emerald-300 sm:grid-cols-5">
-            <div>
-              <p className="text-emerald-400/70">Round</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.roundCount}</p>
-            </div>
-            <div>
-              <p className="text-emerald-400/70">Phase</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.phase}</p>
-            </div>
-            <div>
-              <p className="text-emerald-400/70">Cards</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.shoe.cards.length}</p>
-            </div>
-            <div>
-              <p className="text-emerald-400/70">Discard</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.shoe.discard.length}</p>
-            </div>
-            <div>
-              <p className="text-emerald-400/70">Penetration</p>
-              <p className="mt-0.5 text-base font-semibold text-emerald-50">{penetrationPercentage(game)}</p>
+          <div className="flex flex-col items-stretch gap-3 sm:items-end">
+            <CoachToggle mode={coachMode} onChange={onCoachModeChange} />
+            <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-[10px] uppercase tracking-[0.18em] text-emerald-300 sm:grid-cols-5">
+              <div>
+                <p className="text-emerald-400/70">Round</p>
+                <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.roundCount}</p>
+              </div>
+              <div>
+                <p className="text-emerald-400/70">Phase</p>
+                <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.phase}</p>
+              </div>
+              <div>
+                <p className="text-emerald-400/70">Cards</p>
+                <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.shoe.cards.length}</p>
+              </div>
+              <div>
+                <p className="text-emerald-400/70">Discard</p>
+                <p className="mt-0.5 text-base font-semibold text-emerald-50">{game.shoe.discard.length}</p>
+              </div>
+              <div>
+                <p className="text-emerald-400/70">Penetration</p>
+                <p className="mt-0.5 text-base font-semibold text-emerald-50">{penetrationPercentage(game)}</p>
+              </div>
             </div>
           </div>
         </div>
@@ -169,6 +176,7 @@ export const Table: React.FC<TableProps> = ({ game, actions }) => {
       >
         <TableLayout
           game={game}
+          coachMode={coachMode}
           activeChip={activeChip}
           onSelectChip={handleSelectChip}
           onSit={restrictedActions.sit}

--- a/src/components/hud/RoundActionBar.tsx
+++ b/src/components/hud/RoundActionBar.tsx
@@ -6,9 +6,21 @@ import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
 import { formatCurrency } from "../../utils/currency";
 import { ANIM, REDUCED } from "../../utils/animConstants";
 import { filterSeatsForMode } from "../../ui/config";
+import type { CoachMode } from "../../store/useGameStore";
+import { getRecommendation, type Action, type PlayerContext } from "../../utils/basicStrategy";
+import { cn } from "../../utils/cn";
+
+export type CoachFeedback = {
+  tone: "correct" | "better" | "info";
+  message: string;
+  highlightAction?: Action;
+};
 
 interface RoundActionBarProps {
   game: GameState;
+  coachMode: CoachMode;
+  feedback: CoachFeedback | null;
+  onCoachFeedback: (feedback: CoachFeedback) => void;
   onDeal: () => void;
   onFinishInsurance: () => void;
   onPlayDealer: () => void;
@@ -43,8 +55,36 @@ const findActiveHand = (game: GameState): Hand | null => {
   return null;
 };
 
+const formatAction = (action: Action): string => {
+  switch (action) {
+    case "hit":
+      return "Hit";
+    case "stand":
+      return "Stand";
+    case "double":
+      return "Double";
+    case "split":
+      return "Split";
+    case "surrender":
+      return "Surrender";
+    case "insurance-skip":
+      return "Skip Insurance";
+    default:
+      return action;
+  }
+};
+
+const FEEDBACK_STYLES: Record<CoachFeedback["tone"], string> = {
+  correct: "border-emerald-400/60 bg-emerald-900/70 text-emerald-100",
+  better: "border-[#c8a24a]/60 bg-[#36240c]/80 text-[#f4dba5]",
+  info: "border-emerald-300/50 bg-emerald-800/60 text-emerald-100"
+};
+
 export const RoundActionBar: React.FC<RoundActionBarProps> = ({
   game,
+  coachMode,
+  feedback,
+  onCoachFeedback,
   onDeal,
   onFinishInsurance,
   onPlayDealer,
@@ -71,6 +111,154 @@ export const RoundActionBar: React.FC<RoundActionBarProps> = ({
       surrender: canSurrender(activeHand, game.rules)
     };
   }, [activeHand, game.bankroll, game.phase, game.rules, parentSeat]);
+
+  const dealerUpcard = game.dealer.upcard;
+
+  const recommendation = React.useMemo(() => {
+    if (!actionContext || !dealerUpcard) {
+      return null;
+    }
+    const rank = dealerUpcard.rank as PlayerContext["dealerUpcard"]["rank"];
+    const context: PlayerContext = {
+      dealerUpcard: {
+        rank,
+        value10: dealerUpcard.rank === "10" || dealerUpcard.rank === "J" || dealerUpcard.rank === "Q" || dealerUpcard.rank === "K"
+      },
+      cards: actionContext.hand.cards.map((card) => ({ rank: card.rank })),
+      isInitialTwoCards:
+        actionContext.hand.cards.length === 2 && !Boolean(actionContext.hand.hasActed),
+      afterSplit: Boolean(actionContext.hand.isSplitHand),
+      legal: {
+        hit: actionContext.hit,
+        stand: actionContext.stand,
+        double: actionContext.double,
+        split: actionContext.split,
+        surrender: actionContext.surrender
+      }
+    };
+    return getRecommendation(context, game.rules);
+  }, [actionContext, dealerUpcard, game.rules]);
+
+  const recommendedAction = React.useMemo<Action | null>(() => {
+    if (!recommendation || !actionContext) {
+      return null;
+    }
+    const isLegal = (action: Action | undefined): boolean => {
+      if (!action) {
+        return false;
+      }
+      switch (action) {
+        case "hit":
+          return actionContext.hit;
+        case "stand":
+          return actionContext.stand;
+        case "double":
+          return actionContext.double;
+        case "split":
+          return actionContext.split;
+        case "surrender":
+          return actionContext.surrender;
+        default:
+          return false;
+      }
+    };
+    if (isLegal(recommendation.best)) {
+      return recommendation.best;
+    }
+    const fallbackAction = recommendation.fallback;
+    if (fallbackAction && isLegal(fallbackAction)) {
+      return fallbackAction;
+    }
+    return null;
+  }, [actionContext, recommendation]);
+
+  const liveTooltip = React.useMemo(() => {
+    if (!recommendation || !recommendedAction) {
+      return undefined;
+    }
+    return `Best move (Basic Strategy): ${formatAction(recommendedAction)}. ${recommendation.reasoning}`;
+  }, [recommendation, recommendedAction]);
+
+  const [flashAction, setFlashAction] = React.useState<Action | null>(null);
+  const flashTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    if (feedback?.tone === "better" && feedback.highlightAction) {
+      if (flashTimerRef.current) {
+        clearTimeout(flashTimerRef.current);
+      }
+      setFlashAction(feedback.highlightAction);
+      flashTimerRef.current = window.setTimeout(() => {
+        setFlashAction(null);
+        flashTimerRef.current = null;
+      }, 1000);
+    }
+  }, [feedback]);
+
+  React.useEffect(
+    () => () => {
+      if (flashTimerRef.current) {
+        clearTimeout(flashTimerRef.current);
+      }
+    },
+    []
+  );
+
+  const handleAction = React.useCallback(
+    (action: Action, callback: () => void) => {
+      if (coachMode === "feedback" && recommendation && recommendedAction) {
+        if (action === recommendedAction) {
+          onCoachFeedback({
+            tone: "correct",
+            message: `Good move — ${recommendation.reasoning}`,
+            highlightAction: recommendedAction
+          });
+        } else {
+          onCoachFeedback({
+            tone: "better",
+            message: `Better: ${formatAction(recommendedAction)} — ${recommendation.reasoning}`,
+            highlightAction: recommendedAction
+          });
+        }
+      }
+      callback();
+    },
+    [coachMode, onCoachFeedback, recommendation, recommendedAction]
+  );
+
+  const triggerHit = React.useCallback(() => handleAction("hit", onHit), [handleAction, onHit]);
+  const triggerStand = React.useCallback(() => handleAction("stand", onStand), [handleAction, onStand]);
+  const triggerDouble = React.useCallback(() => handleAction("double", onDouble), [handleAction, onDouble]);
+  const triggerSplit = React.useCallback(() => handleAction("split", onSplit), [handleAction, onSplit]);
+  const triggerSurrender = React.useCallback(
+    () => handleAction("surrender", onSurrender),
+    [handleAction, onSurrender]
+  );
+
+  const shouldHighlight = React.useCallback(
+    (action: Action) => {
+      if (flashAction === action) {
+        return true;
+      }
+      if (coachMode === "live" && recommendedAction === action) {
+        return true;
+      }
+      return false;
+    },
+    [coachMode, flashAction, recommendedAction]
+  );
+
+  const highlightAttr = (action: Action) => (shouldHighlight(action) ? "best" : undefined);
+
+  const tooltipForAction = (action: Action) => {
+    if (flashAction === action && feedback) {
+      return feedback.message;
+    }
+    if (coachMode === "live" && recommendedAction === action) {
+      return liveTooltip;
+    }
+    return undefined;
+  };
 
   const showActions = game.phase !== "betting" || hasReadySeat(game);
   const fadeDuration = REDUCED ? 0 : ANIM.fade.duration;
@@ -99,28 +287,75 @@ export const RoundActionBar: React.FC<RoundActionBarProps> = ({
         </Button>
       </div>
 
-      {actionContext && (
-        <div className="ml-auto flex items-center gap-2">
-          <span className="hidden text-[10px] uppercase tracking-[0.4em] text-emerald-200 md:inline">
-            Active Bet {formatCurrency(actionContext.hand.bet)}
-          </span>
-          <Button size="sm" onClick={onHit} disabled={!actionContext.hit}>
-            Hit
-          </Button>
-          <Button size="sm" variant="outline" onClick={onStand} disabled={!actionContext.stand}>
-            Stand
-          </Button>
-          <Button size="sm" variant="outline" onClick={onDouble} disabled={!actionContext.double}>
-            Double
-          </Button>
-          <Button size="sm" variant="outline" onClick={onSplit} disabled={!actionContext.split}>
-            Split
-          </Button>
-          <Button size="sm" variant="outline" onClick={onSurrender} disabled={!actionContext.surrender}>
-            Surrender
-          </Button>
-        </div>
-      )}
+      <div className="ml-auto flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+        {feedback && (
+          <div
+            role="status"
+            className={cn(
+              "inline-flex items-center rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em]",
+              FEEDBACK_STYLES[feedback.tone]
+            )}
+          >
+            {feedback.message}
+          </div>
+        )}
+        {actionContext && (
+          <div className="flex items-center gap-2">
+            <span className="hidden text-[10px] uppercase tracking-[0.4em] text-emerald-200 md:inline">
+              Active Bet {formatCurrency(actionContext.hand.bet)}
+            </span>
+            <Button
+              size="sm"
+              onClick={triggerHit}
+              disabled={!actionContext.hit}
+              data-coach={highlightAttr("hit")}
+              title={tooltipForAction("hit")}
+            >
+              Hit
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={triggerStand}
+              disabled={!actionContext.stand}
+              data-coach={highlightAttr("stand")}
+              title={tooltipForAction("stand")}
+            >
+              Stand
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={triggerDouble}
+              disabled={!actionContext.double}
+              data-coach={highlightAttr("double")}
+              title={tooltipForAction("double")}
+            >
+              Double
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={triggerSplit}
+              disabled={!actionContext.split}
+              data-coach={highlightAttr("split")}
+              title={tooltipForAction("split")}
+            >
+              Split
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={triggerSurrender}
+              disabled={!actionContext.surrender}
+              data-coach={highlightAttr("surrender")}
+              title={tooltipForAction("surrender")}
+            >
+              Surrender
+            </Button>
+          </div>
+        )}
+      </div>
     </motion.div>
   );
 };

--- a/src/components/table/CardLayer.tsx
+++ b/src/components/table/CardLayer.tsx
@@ -10,12 +10,16 @@ import { AnimatedCard } from "../animation/AnimatedCard";
 import { FlipCard } from "../animation/FlipCard";
 import { DEAL_STAGGER } from "../../utils/animConstants";
 import { filterSeatsForMode } from "../../ui/config";
+import type { CoachMode } from "../../store/useGameStore";
+import type { CoachFeedback } from "../hud/RoundActionBar";
 
 interface CardLayerProps {
   game: GameState;
   dimensions: { width: number; height: number };
   onInsurance: (seatIndex: number, handId: string, amount: number) => void;
   onDeclineInsurance: (seatIndex: number, handId: string) => void;
+  coachMode: CoachMode;
+  onCoachFeedback: (feedback: CoachFeedback) => void;
 }
 
 interface SeatClusterSize {
@@ -91,7 +95,9 @@ const renderInsurancePrompt = (
   hand: Hand,
   game: GameState,
   onInsurance: CardLayerProps["onInsurance"],
-  onDeclineInsurance: CardLayerProps["onDeclineInsurance"]
+  onDeclineInsurance: CardLayerProps["onDeclineInsurance"],
+  coachMode: CoachMode,
+  onCoachFeedback: CardLayerProps["onCoachFeedback"]
 ): React.ReactNode => {
   const alreadyResolved = hand.insuranceBet !== undefined;
   if (!seat.occupied || game.phase !== "insurance" || alreadyResolved || hand.isResolved) {
@@ -100,6 +106,29 @@ const renderInsurancePrompt = (
   const maxInsurance = Math.floor(hand.bet / 2);
   const cappedAmount = Math.min(maxInsurance, Math.floor(game.bankroll));
   const disabled = cappedAmount <= 0;
+  const liveHighlight = coachMode === "live";
+
+  const pushInsuranceFeedback = (tone: CoachFeedback["tone"]) => {
+    if (coachMode !== "feedback") {
+      return;
+    }
+    const text =
+      tone === "correct"
+        ? "Good move — Basic strategy: Skip insurance."
+        : "Better: Skip insurance — Basic strategy: Skip insurance.";
+    onCoachFeedback({ tone, message: text, highlightAction: "insurance-skip" });
+  };
+
+  const handleTakeInsurance = () => {
+    onInsurance(seat.index, hand.id, cappedAmount);
+    pushInsuranceFeedback("better");
+  };
+
+  const handleSkipInsurance = () => {
+    onDeclineInsurance(seat.index, hand.id);
+    pushInsuranceFeedback("correct");
+  };
+
   return (
     <div
       key={hand.id}
@@ -112,7 +141,7 @@ const renderInsurancePrompt = (
         <Button
           size="sm"
           className="h-7 px-3 text-[11px] font-semibold uppercase tracking-[0.3em]"
-          onClick={() => onInsurance(seat.index, hand.id, cappedAmount)}
+          onClick={handleTakeInsurance}
           disabled={disabled}
         >
           Take {formatCurrency(cappedAmount)}
@@ -121,7 +150,9 @@ const renderInsurancePrompt = (
           size="sm"
           variant="outline"
           className="h-7 px-3 text-[11px] font-semibold uppercase tracking-[0.3em]"
-          onClick={() => onDeclineInsurance(seat.index, hand.id)}
+          data-coach={liveHighlight ? "best" : undefined}
+          onClick={handleSkipInsurance}
+          title="Basic strategy: Skip insurance"
         >
           Skip
         </Button>
@@ -238,7 +269,9 @@ export const CardLayer: React.FC<CardLayerProps> = ({
   game,
   dimensions,
   onInsurance,
-  onDeclineInsurance
+  onDeclineInsurance,
+  coachMode,
+  onCoachFeedback
 }) => {
   const clusterRefs = React.useRef(new Map<number, HTMLDivElement | null>());
   const clusterRefCallbacks = React.useRef(new Map<number, (node: HTMLDivElement | null) => void>());
@@ -484,7 +517,9 @@ export const CardLayer: React.FC<CardLayerProps> = ({
         });
 
         const promptElements = hands
-          .map((hand) => renderInsurancePrompt(seat, hand, game, onInsurance, onDeclineInsurance))
+          .map((hand) =>
+            renderInsurancePrompt(seat, hand, game, onInsurance, onDeclineInsurance, coachMode, onCoachFeedback)
+          )
           .filter(Boolean) as React.ReactNode[];
 
         const promptStack =

--- a/src/index.css
+++ b/src/index.css
@@ -247,3 +247,34 @@ button:disabled {
     opacity: 1;
   }
 }
+
+[data-coach="best"] {
+  box-shadow: 0 0 0 2px rgba(200, 162, 74, 0.55), 0 0 18px rgba(200, 162, 74, 0.35);
+  position: relative;
+}
+
+[data-coach="best"]::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 12px;
+  pointer-events: none;
+  background: radial-gradient(ellipse at center, rgba(200, 162, 74, 0.15), transparent 70%);
+  animation: coachPulse 1.8s ease-in-out infinite;
+}
+
+@keyframes coachPulse {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-coach="best"]::after {
+    animation: none;
+  }
+}

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -9,6 +9,8 @@ export const App: React.FC = () => {
     game,
     error,
     clearError,
+    coachMode,
+    setCoachMode,
     sit,
     leave,
     addChip,
@@ -55,6 +57,7 @@ export const App: React.FC = () => {
         )}
         <Table
           game={game}
+          coachMode={coachMode}
           actions={{
             sit,
             leave,
@@ -73,6 +76,7 @@ export const App: React.FC = () => {
             playDealer,
             nextRound
           }}
+          onCoachModeChange={setCoachMode}
         />
       </div>
     </main>

--- a/src/utils/basicStrategy.ts
+++ b/src/utils/basicStrategy.ts
@@ -1,0 +1,353 @@
+import type { RuleConfig } from "../engine/types";
+
+export type Action = "hit" | "stand" | "double" | "split" | "surrender" | "insurance-skip";
+export type HandKind = "pair" | "soft" | "hard";
+
+export type PlayerContext = {
+  dealerUpcard: { rank: "A" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "J" | "Q" | "K"; value10?: boolean };
+  cards: Array<{ rank: string }>;
+  isInitialTwoCards: boolean;
+  afterSplit: boolean;
+  legal: { hit: boolean; stand: boolean; double: boolean; split: boolean; surrender: boolean };
+};
+
+export type Recommendation = {
+  kind: HandKind;
+  best: Action;
+  fallback?: Action;
+  reasoning: string;
+  tableRef: string;
+};
+
+type DealerUpcard = "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "A";
+type StrategyCode =
+  | "H"
+  | "S"
+  | "Dh"
+  | "Ds"
+  | "Rh"
+  | "Rs"
+  | "P"
+  | "Ph"
+  | "Ps"
+  | "Pd";
+
+type StrategyTable = Record<string, Partial<Record<DealerUpcard, StrategyCode>>>;
+
+const dealerOrder: DealerUpcard[] = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "A"];
+
+const HARD_TOTALS: StrategyTable = {
+  "5": fillRow("H"),
+  "6": fillRow("H"),
+  "7": fillRow("H"),
+  "8": withEntries("H", { "5": "Dh", "6": "Dh" }),
+  "9": withEntries("H", { "3": "Dh", "4": "Dh", "5": "Dh", "6": "Dh" }),
+  "10": withEntries("H", { "2": "Dh", "3": "Dh", "4": "Dh", "5": "Dh", "6": "Dh", "7": "Dh", "8": "Dh", "9": "Dh" }),
+  "11": withEntries("H", { "2": "Dh", "3": "Dh", "4": "Dh", "5": "Dh", "6": "Dh", "7": "Dh", "8": "Dh", "9": "Dh", "10": "Dh" }),
+  "12": withEntries("H", { "4": "S", "5": "S", "6": "S" }),
+  "13": withEntries("H", { "2": "S", "3": "S", "4": "S", "5": "S", "6": "S" }),
+  "14": withEntries("H", { "2": "S", "3": "S", "4": "S", "5": "S", "6": "S" }),
+  "15": withEntries("H", { "2": "S", "3": "S", "4": "S", "5": "S", "6": "S", "10": "Rh" }),
+  "16": withEntries("H", { "2": "S", "3": "S", "4": "S", "5": "S", "6": "S", "9": "Rh", "10": "Rh", "A": "Rh" }),
+  "17": fillRow("S"),
+  "18": fillRow("S"),
+  "19": fillRow("S"),
+  "20": fillRow("S")
+};
+
+const SOFT_TOTALS: StrategyTable = {
+  "13": withEntries("H", { "5": "Dh", "6": "Dh" }),
+  "14": withEntries("H", { "5": "Dh", "6": "Dh" }),
+  "15": withEntries("H", { "4": "Dh", "5": "Dh", "6": "Dh" }),
+  "16": withEntries("H", { "4": "Dh", "5": "Dh", "6": "Dh" }),
+  "17": withEntries("H", { "3": "Dh", "4": "Dh", "5": "Dh", "6": "Dh" }),
+  "18": withEntries("S", { "3": "Ds", "4": "Ds", "5": "Ds", "6": "Ds", "9": "H", "10": "H" }),
+  "19": withEntries("S", { "6": "Ds" }),
+  "20": fillRow("S"),
+  "21": fillRow("S")
+};
+
+const PAIR_ACTIONS: StrategyTable = {
+  "A": fillRow("P"),
+  "10": fillRow("S"),
+  "9": withEntries("S", { "2": "P", "3": "P", "4": "P", "5": "P", "6": "P", "8": "P", "9": "P" }),
+  "8": fillRow("P"),
+  "7": withEntries("H", { "2": "P", "3": "P", "4": "P", "5": "P", "6": "P", "7": "P" }),
+  "6": withEntries("H", { "2": "P", "3": "P", "4": "P", "5": "P", "6": "P" }),
+  "5": HARD_TOTALS["10"],
+  "4": withEntries("H", { "5": "Pd", "6": "Pd" }),
+  "3": withEntries("H", { "2": "P", "3": "P", "4": "P", "5": "P", "6": "P", "7": "P" }),
+  "2": withEntries("H", { "2": "P", "3": "P", "4": "P", "5": "P", "6": "P", "7": "P" })
+};
+
+function fillRow(code: StrategyCode): Partial<Record<DealerUpcard, StrategyCode>> {
+  return dealerOrder.reduce<Partial<Record<DealerUpcard, StrategyCode>>>((row, dealer) => {
+    row[dealer] = code;
+    return row;
+  }, {});
+}
+
+function withEntries(
+  base: StrategyCode,
+  entries: Partial<Record<DealerUpcard, StrategyCode>>
+): Partial<Record<DealerUpcard, StrategyCode>> {
+  const row = fillRow(base);
+  Object.assign(row, entries);
+  return row;
+}
+
+const TEN_RANKS = new Set(["10", "J", "Q", "K"]);
+
+const rankToDealerKey = (rank: string): DealerUpcard => {
+  if (rank === "A") {
+    return "A";
+  }
+  if (TEN_RANKS.has(rank)) {
+    return "10";
+  }
+  if (dealerOrder.includes(rank as DealerUpcard)) {
+    return rank as DealerUpcard;
+  }
+  return "10";
+};
+
+const actionFromCode = (code: StrategyCode): { best: Action; fallback?: Action } => {
+  switch (code) {
+    case "H":
+      return { best: "hit" };
+    case "S":
+      return { best: "stand" };
+    case "Dh":
+      return { best: "double", fallback: "hit" };
+    case "Ds":
+      return { best: "double", fallback: "stand" };
+    case "Rh":
+      return { best: "surrender", fallback: "hit" };
+    case "Rs":
+      return { best: "surrender", fallback: "stand" };
+    case "P":
+      return { best: "split" };
+    case "Ph":
+      return { best: "split", fallback: "hit" };
+    case "Ps":
+      return { best: "split", fallback: "stand" };
+    case "Pd":
+      return { best: "split", fallback: "double" };
+    default:
+      return { best: "hit" };
+  }
+};
+
+const actionLabel = (action: Action): string => {
+  switch (action) {
+    case "hit":
+      return "Hit";
+    case "stand":
+      return "Stand";
+    case "double":
+      return "Double";
+    case "split":
+      return "Split";
+    case "surrender":
+      return "Surrender";
+    case "insurance-skip":
+      return "Skip Insurance";
+    default:
+      return action;
+  }
+};
+
+const capitalize = (value: string): string => value.charAt(0).toUpperCase() + value.slice(1);
+
+const toTableRef = (rules: RuleConfig): string => {
+  const base = `6D-${rules.dealerStandsOnSoft17 ? "S17" : "H17"}`;
+  const surrender =
+    rules.surrender === "none"
+      ? "No-Surr"
+      : rules.surrender === "early"
+        ? "Early-Surr"
+        : "Late-Surr";
+  const das = rules.doubleAfterSplit ? "DAS" : "NoDAS";
+  return `${base}-${surrender}-${das}`;
+};
+
+const chooseAction = (
+  candidates: Action[],
+  legal: PlayerContext["legal"]
+): { chosen: Action | null; fallback?: Action } => {
+  for (let index = 0; index < candidates.length; index += 1) {
+    const action = candidates[index];
+    if (action === "hit" && legal.hit) {
+      return { chosen: action, fallback: index === 0 ? undefined : action };
+    }
+    if (action === "stand" && legal.stand) {
+      return { chosen: action, fallback: index === 0 ? undefined : action };
+    }
+    if (action === "double" && legal.double) {
+      return { chosen: action, fallback: index === 0 ? undefined : action };
+    }
+    if (action === "split" && legal.split) {
+      return { chosen: action, fallback: index === 0 ? undefined : action };
+    }
+    if (action === "surrender" && legal.surrender) {
+      return { chosen: action, fallback: index === 0 ? undefined : action };
+    }
+  }
+  return { chosen: null };
+};
+
+export const totalHard = (cards: Array<{ rank: string }>): number => {
+  return cards.reduce((sum, card) => {
+    if (card.rank === "A") {
+      return sum + 1;
+    }
+    if (TEN_RANKS.has(card.rank)) {
+      return sum + 10;
+    }
+    const numeric = Number.parseInt(card.rank, 10);
+    return Number.isNaN(numeric) ? sum + 10 : sum + numeric;
+  }, 0);
+};
+
+export const isSoft = (cards: Array<{ rank: string }>): boolean => {
+  const hard = totalHard(cards);
+  const aceCount = cards.filter((card) => card.rank === "A").length;
+  if (aceCount === 0) {
+    return false;
+  }
+  return hard + 10 <= 21;
+};
+
+export const canDoubleByRule = (rules: RuleConfig, total: number): boolean => {
+  switch (rules.doubleAllowed) {
+    case "anyTwo":
+      return true;
+    case "9to11":
+      return total >= 9 && total <= 11;
+    case "10to11":
+      return total >= 10 && total <= 11;
+    default:
+      return false;
+  }
+};
+
+const resolveStrategyCode = (
+  kind: HandKind,
+  playerValue: string,
+  dealer: DealerUpcard
+): StrategyCode => {
+  const table = kind === "pair" ? PAIR_ACTIONS : kind === "soft" ? SOFT_TOTALS : HARD_TOTALS;
+  const key = playerValue;
+  const row = table[key];
+  const fallbackRow = kind === "pair" && !row ? HARD_TOTALS[key] : undefined;
+  if (row && row[dealer]) {
+    return row[dealer] as StrategyCode;
+  }
+  if (fallbackRow && fallbackRow[dealer]) {
+    return fallbackRow[dealer] as StrategyCode;
+  }
+  return "H";
+};
+
+const describeHand = (kind: HandKind, cards: PlayerContext["cards"], total: number): string => {
+  if (kind === "pair") {
+    const rank = cards[0]?.rank ?? "?";
+    return `Pair ${rank === "A" ? "Aces" : `${rank}s`}`;
+  }
+  if (kind === "soft") {
+    return `Soft ${total}`;
+  }
+  return `Hard ${total}`;
+};
+
+export function getRecommendation(ctx: PlayerContext, rules: RuleConfig): Recommendation {
+  const legal = ctx.legal;
+  const dealer = rankToDealerKey(ctx.dealerUpcard.value10 ? "10" : ctx.dealerUpcard.rank);
+  const hardTotal = totalHard(ctx.cards);
+  const softHand = isSoft(ctx.cards);
+
+  const deriveKind = (): HandKind => {
+    if (
+      ctx.cards.length === 2 &&
+      ctx.isInitialTwoCards &&
+      !ctx.afterSplit &&
+      legal.split &&
+      ctx.cards[0]?.rank === ctx.cards[1]?.rank
+    ) {
+      return "pair";
+    }
+    if (softHand) {
+      return "soft";
+    }
+    return "hard";
+  };
+
+  let kind = deriveKind();
+  const softTotal = hardTotal + 10;
+  let tableKey =
+    kind === "pair"
+      ? pairKeyFromRank(ctx.cards[0]?.rank ?? "")
+      : String(kind === "soft" ? softTotal : hardTotal);
+  let code = resolveStrategyCode(kind, tableKey, dealer);
+  let { best, fallback } = actionFromCode(code);
+
+  if (best === "split" && !legal.split) {
+    kind = softHand ? "soft" : "hard";
+    tableKey = String(kind === "soft" ? softTotal : hardTotal);
+    code = resolveStrategyCode(kind, tableKey, dealer);
+    ({ best, fallback } = actionFromCode(code));
+  }
+
+  const totalForDouble = kind === "soft" ? softTotal : hardTotal;
+
+  if (!rules.dealerStandsOnSoft17 && kind === "hard" && hardTotal === 11 && dealer === "A") {
+    best = "double";
+    fallback = "hit";
+  }
+
+  if (!rules.dealerStandsOnSoft17 && kind === "soft" && Number.parseInt(tableKey, 10) === 18 && dealer === "A") {
+    best = "hit";
+    fallback = undefined;
+  }
+
+  const candidates: Action[] = [best];
+  if (fallback) {
+    candidates.push(fallback);
+  }
+  if (best === "double") {
+    candidates.push("hit", "stand");
+  }
+  if (best === "surrender") {
+    candidates.push(fallback ?? "hit", "stand");
+  }
+
+  if (best === "double" && !canDoubleByRule(rules, totalForDouble)) {
+    candidates.unshift(fallback ?? "hit");
+  }
+
+  const { chosen, fallback: resolvedFallback } = chooseAction(candidates, legal);
+  const finalAction = chosen ?? (legal.stand ? "stand" : "hit");
+  const fallbackAction = finalAction === best ? fallback : resolvedFallback ?? (finalAction === best ? undefined : finalAction);
+
+  const tableRef = toTableRef(rules);
+  const description = describeHand(kind, ctx.cards, kind === "soft" ? softTotal : hardTotal);
+  const reasoning = `${description} vs ${dealer} → ${actionLabel(finalAction)} (${tableRef})`;
+
+  return {
+    kind,
+    best,
+    fallback: finalAction === best ? fallbackAction : finalAction,
+    reasoning,
+    tableRef
+  };
+}
+
+const pairKeyFromRank = (rank: string): string => {
+  if (rank === "A") {
+    return "A";
+  }
+  if (TEN_RANKS.has(rank)) {
+    return "10";
+  }
+  return String(Number.parseInt(rank, 10) || rank || "10");
+};

--- a/tests/basicStrategy.test.ts
+++ b/tests/basicStrategy.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { defaultRuleConfig } from "../src/engine/rules.config";
+import type { RuleConfig } from "../src/engine/types";
+import type { PlayerContext, Recommendation, Action } from "../src/utils/basicStrategy";
+import { getRecommendation } from "../src/utils/basicStrategy";
+
+const cloneRules = (overrides: Partial<RuleConfig> = {}): RuleConfig => ({
+  ...defaultRuleConfig,
+  ...overrides
+});
+
+const buildContext = (
+  cards: string[],
+  dealer: "A" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "J" | "Q" | "K",
+  legalOverrides: Partial<PlayerContext["legal"]> = {},
+  extras: Partial<Pick<PlayerContext, "isInitialTwoCards" | "afterSplit">> = {}
+): PlayerContext => ({
+  dealerUpcard: { rank: dealer },
+  cards: cards.map((rank) => ({ rank })),
+  isInitialTwoCards: extras.isInitialTwoCards ?? cards.length === 2,
+  afterSplit: extras.afterSplit ?? false,
+  legal: {
+    hit: true,
+    stand: true,
+    double: true,
+    split: false,
+    surrender: true,
+    ...legalOverrides
+  }
+});
+
+const resolvedAction = (rec: Recommendation, legal: PlayerContext["legal"]): Action => {
+  const preferred = rec.best;
+  if (preferred === "surrender" && !legal.surrender) {
+    return rec.fallback ?? "hit";
+  }
+  if (preferred === "split" && !legal.split) {
+    return rec.fallback ?? "hit";
+  }
+  if (preferred === "double" && !legal.double) {
+    return rec.fallback ?? "hit";
+  }
+  if (preferred === "hit" && !legal.hit) {
+    return rec.fallback ?? "stand";
+  }
+  if (preferred === "stand" && !legal.stand) {
+    return rec.fallback ?? "hit";
+  }
+  if (preferred === "double" && rec.fallback && !legal.double) {
+    return rec.fallback;
+  }
+  return legal[preferred as keyof typeof legal] ? preferred : rec.fallback ?? preferred;
+};
+
+describe("basic strategy recommendations", () => {
+  it("suggests surrender on hard 16 vs 10 when allowed", () => {
+    const ctx = buildContext(["10", "6"], "10");
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("surrender");
+    expect(rec.fallback).toBe("hit");
+  });
+
+  it("suggests hitting hard 12 vs 3", () => {
+    const ctx = buildContext(["9", "3"], "3");
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("hit");
+  });
+
+  it("suggests hitting hard 11 vs Ace under S17 rules", () => {
+    const ctx = buildContext(["5", "6"], "A");
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("hit");
+  });
+
+  it("suggests doubling hard 9 vs 3", () => {
+    const ctx = buildContext(["4", "5"], "3");
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("double");
+    expect(rec.fallback).toBe("hit");
+  });
+
+  it("suggests hitting soft 18 vs 9", () => {
+    const ctx = buildContext(["A", "7"], "9");
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("hit");
+  });
+
+  it("suggests doubling soft 19 vs 6", () => {
+    const ctx = buildContext(["A", "8"], "6");
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("double");
+    expect(rec.fallback).toBe("stand");
+  });
+
+  it("splits eights against ten", () => {
+    const ctx = buildContext(["8", "8"], "10", { split: true });
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("split");
+  });
+
+  it("splits aces against ace", () => {
+    const ctx = buildContext(["A", "A"], "A", { split: true });
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("split");
+  });
+
+  it("stands on nines vs seven", () => {
+    const ctx = buildContext(["9", "9"], "7", { split: true });
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("stand");
+  });
+
+  it("never splits tens", () => {
+    const ctx = buildContext(["10", "10"], "6", { split: true });
+    const rec = getRecommendation(ctx, defaultRuleConfig);
+    expect(rec.best).toBe("stand");
+  });
+
+  it("doubles hard 11 vs Ace on H17 tables", () => {
+    const ctx = buildContext(["5", "6"], "A");
+    const rules = cloneRules({ dealerStandsOnSoft17: false });
+    const rec = getRecommendation(ctx, rules);
+    expect(rec.best).toBe("double");
+  });
+
+  it("falls back when surrender is unavailable", () => {
+    const ctx = buildContext(["10", "6"], "10", { surrender: false });
+    const rules = cloneRules({ surrender: "none" });
+    const rec = getRecommendation(ctx, rules);
+    expect(resolvedAction(rec, ctx.legal)).not.toBe("surrender");
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable basic strategy module that returns table-driven recommendations with rule-aware fallbacks
- persist a coach mode preference and surface a toggle in the table header with off/feedback/live states
- highlight recommended actions and show verdict messaging, including insurance guidance, when the coach is enabled
- ensure feedback verdict pills remain visible even when the action buttons are hidden

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e445a08ee883299f168e0a41e62f90