### PR TITLE
fix: switch audio service to wav library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@eslint/js": "^8.55.0",
         "@playwright/test": "^1.55.1",
         "@testing-library/react": "^14.0.0",
+        "@types/howler": "^2.2.12",
         "@types/node": "^20.11.0",
         "@types/react": "^18.2.45",
         "@types/react-dom": "^18.2.18",
@@ -1652,6 +1653,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/howler": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@types/howler/-/howler-2.2.12.tgz",
+      "integrity": "sha512-hy769UICzOSdK0Kn1FBk4gN+lswcj1EKRkmiDtMkUGvFfYJzgaDXmVXkSShS2m89ERAatGIPnTUlp2HhfkVo5g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@eslint/js": "^8.55.0",
     "@playwright/test": "^1.55.1",
     "@testing-library/react": "^14.0.0",
+    "@types/howler": "^2.2.12",
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -1,11 +1,11 @@
 import { Howl } from "howler";
-import cardDeal from "../assets/audio/card-deal.mp3";
-import cardFlip from "../assets/audio/card-flip.mp3";
-import chipStack from "../assets/audio/chip-stack.mp3";
-import insuranceCash from "../assets/audio/insurance-cash.mp3";
-import loseSwell from "../assets/audio/lose-swell.mp3";
-import pushChime from "../assets/audio/push-chime.mp3";
-import winFanfare from "../assets/audio/win-fanfare.mp3";
+import chipStack from "../assets/audio/2 Card Playing FX2_1.wav";
+import cardDeal from "../assets/audio/Card Deal 2.wav";
+import cardFlip from "../assets/audio/Card Slide 1.wav";
+import insuranceCash from "../assets/audio/Card Slide 2.wav";
+import loseSwell from "../assets/audio/Card Slap 3.wav";
+import pushChime from "../assets/audio/Card Slap 2.wav";
+import winFanfare from "../assets/audio/Full deal 1.wav";
 
 type ResultSound = "win" | "lose" | "push" | "blackjack" | "insurance";
 

--- a/src/types/audio.d.ts
+++ b/src/types/audio.d.ts
@@ -1,8 +1,3 @@
-declare module "*.mp3" {
-  const src: string;
-  export default src;
-}
-
 declare module "*.wav" {
   const src: string;
   export default src;


### PR DESCRIPTION
## Summary
- replace the audio service's mp3 imports with the new wav files that best match each gameplay cue
- remove the obsolete mp3 module declaration now that only wav assets are consumed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f7672eac8329aa6bbd0971463ed3