### PR TITLE
feat: animate dealer hits sequentially

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -467,19 +467,35 @@ const dealerShouldHit = (state: GameState): boolean => {
   return false;
 };
 
-export const playDealer = (state: GameState): void => {
+export type DealerStepResult = "idle" | "hit" | "stand";
+
+export const playDealerStep = (state: GameState): DealerStepResult => {
   if (state.phase !== "dealerPlay") {
-    return;
+    return "idle";
   }
   state.dealer.hand.isResolved = false;
-  while (dealerShouldHit(state)) {
+  if (dealerShouldHit(state)) {
     const card = drawCard(state.shoe);
     state.dealer.hand.cards.push(card);
     appendLog(state, `Dealer draws ${card.rank}${card.suit}`);
+    return "hit";
   }
   const total = bestTotal(state.dealer.hand);
   appendLog(state, `Dealer stands with ${total}`);
   nextPhase(state, "settlement");
+  return "stand";
+};
+
+export const playDealer = (state: GameState): void => {
+  if (state.phase !== "dealerPlay") {
+    return;
+  }
+  while (true) {
+    const result = playDealerStep(state);
+    if (result !== "hit") {
+      break;
+    }
+  }
 };
 
 const blackjackPayoutMultiplier = (rules: RuleConfig): number => {

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -5,7 +5,7 @@ import {
   declineInsurance,
   finishInsurance,
   initGame,
-  playDealer,
+  playDealerStep,
   playerDouble,
   playerHit,
   playerSplit,
@@ -20,6 +20,7 @@ import {
 } from "../engine/engine";
 import type { GameState, Seat } from "../engine/types";
 import { isSingleSeatMode, PRIMARY_SEAT_INDEX } from "../ui/config";
+import { ANIM, DEAL_STAGGER, REDUCED } from "../utils/animConstants";
 
 const BANKROLL_KEY = "blackjack_bankroll";
 const SEATS_KEY = "blackjack_seats";
@@ -31,6 +32,28 @@ type SeatPersist = {
   occupied: boolean;
   baseBet: number;
   chips: number[];
+};
+
+const DEALER_BUFFER_MS = 120;
+const DEALER_STEP_DELAY_MS = (ANIM.deal.duration + DEAL_STAGGER) * 1000 + DEALER_BUFFER_MS;
+const DEALER_FLIP_DELAY_MS = ANIM.flip.duration * 1000 + DEALER_BUFFER_MS;
+
+const animationDelay = (ms: number): number => (REDUCED ? 0 : ms);
+
+let dealerStepTimer: ReturnType<typeof setTimeout> | null = null;
+let dealerSettleTimer: ReturnType<typeof setTimeout> | null = null;
+let dealerSequenceActive = false;
+
+const stopDealerTimers = (): void => {
+  if (dealerStepTimer !== null) {
+    clearTimeout(dealerStepTimer);
+    dealerStepTimer = null;
+  }
+  if (dealerSettleTimer !== null) {
+    clearTimeout(dealerSettleTimer);
+    dealerSettleTimer = null;
+  }
+  dealerSequenceActive = false;
 };
 
 const persistState = (state: GameState): void => {
@@ -144,232 +167,291 @@ const ensureChipArray = (seat: Seat): number[] => {
   return seat.chips;
 };
 
-export const useGameStore = create<GameStore>((set) => ({
-  game: hydrateGame(),
-  error: null,
-  coachMode: hydrateCoachMode(),
-  clearError: () => set({ error: null }),
-  sit: (seatIndex) => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => sit(draft, seatIndex));
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  leave: (seatIndex) => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => leave(draft, seatIndex));
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  setBet: (seatIndex, amount) => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => setBet(draft, seatIndex, amount));
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  addChip: (seatIndex, denom) => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => {
-        const seat = draft.seats[seatIndex];
-        const chips = ensureChipArray(seat);
-        chips.push(Math.floor(denom));
-        seat.baseBet = sumChips(chips);
+export const useGameStore = create<GameStore>((set, get) => {
+  const stepDelay = animationDelay(DEALER_STEP_DELAY_MS);
+
+  const runDealerSequence = (initialDelay = animationDelay(DEALER_FLIP_DELAY_MS)): void => {
+    if (dealerSequenceActive) {
+      return;
+    }
+    const current = get().game;
+    if (current.phase !== "dealerPlay") {
+      return;
+    }
+    dealerSequenceActive = true;
+
+    const scheduleNextStep = (delay: number): void => {
+      if (dealerStepTimer !== null) {
+        clearTimeout(dealerStepTimer);
+      }
+      dealerStepTimer = setTimeout(() => {
+        dealerStepTimer = null;
+        let stepResult: ReturnType<typeof playDealerStep> = "idle";
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => {
+            stepResult = playDealerStep(draft);
+          });
+          persistState(nextGame);
+          return { game: nextGame, error: null };
+        });
+        if (stepResult === "hit") {
+          scheduleNextStep(stepDelay);
+          return;
+        }
+        if (stepResult === "stand") {
+          if (dealerSettleTimer !== null) {
+            clearTimeout(dealerSettleTimer);
+          }
+          dealerSettleTimer = setTimeout(() => {
+            dealerSettleTimer = null;
+            set((store) => {
+              const nextGame = mutateGame(store.game, (draft) => {
+                settleAllHands(draft);
+              });
+              persistState(nextGame);
+              return { game: nextGame, error: null };
+            });
+            dealerSequenceActive = false;
+          }, stepDelay);
+          return;
+        }
+        dealerSequenceActive = false;
+      }, delay);
+    };
+
+    scheduleNextStep(initialDelay);
+  };
+
+  return {
+    game: hydrateGame(),
+    error: null,
+    coachMode: hydrateCoachMode(),
+    clearError: () => set({ error: null }),
+    sit: (seatIndex) => {
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => sit(draft, seatIndex));
+        persistState(nextGame);
+        return { game: nextGame, error: null };
       });
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  removeChipValue: (seatIndex, denom) => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => {
-        const seat = draft.seats[seatIndex];
-        const chips = ensureChipArray(seat);
-        const targetIndex = chips.lastIndexOf(Math.floor(denom));
-        if (targetIndex >= 0) {
-          chips.splice(targetIndex, 1);
+    },
+    leave: (seatIndex) => {
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => leave(draft, seatIndex));
+        persistState(nextGame);
+        return { game: nextGame, error: null };
+      });
+    },
+    setBet: (seatIndex, amount) => {
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => setBet(draft, seatIndex, amount));
+        persistState(nextGame);
+        return { game: nextGame, error: null };
+      });
+    },
+    addChip: (seatIndex, denom) => {
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => {
+          const seat = draft.seats[seatIndex];
+          const chips = ensureChipArray(seat);
+          chips.push(Math.floor(denom));
           seat.baseBet = sumChips(chips);
+        });
+        persistState(nextGame);
+        return { game: nextGame, error: null };
+      });
+    },
+    removeChipValue: (seatIndex, denom) => {
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => {
+          const seat = draft.seats[seatIndex];
+          const chips = ensureChipArray(seat);
+          const targetIndex = chips.lastIndexOf(Math.floor(denom));
+          if (targetIndex >= 0) {
+            chips.splice(targetIndex, 1);
+            seat.baseBet = sumChips(chips);
+          }
+        });
+        persistState(nextGame);
+        return { game: nextGame, error: null };
+      });
+    },
+    removeTopChip: (seatIndex) => {
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => {
+          const seat = draft.seats[seatIndex];
+          const chips = ensureChipArray(seat);
+          if (chips.length > 0) {
+            chips.pop();
+            seat.baseBet = sumChips(chips);
+          }
+        });
+        persistState(nextGame);
+        return { game: nextGame, error: null };
+      });
+    },
+    deal: () => {
+      stopDealerTimers();
+      try {
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => deal(draft));
+          persistState(nextGame);
+          return { game: nextGame, error: null };
+        });
+      } catch (error) {
+        set({ error: (error as Error).message });
+      }
+    },
+    playerHit: () => {
+      try {
+        let shouldStartDealer = false;
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => {
+            playerHit(draft);
+            shouldStartDealer = draft.phase === "dealerPlay";
+          });
+          persistState(nextGame);
+          return { game: nextGame, error: null };
+        });
+        if (shouldStartDealer) {
+          runDealerSequence();
         }
-      });
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  removeTopChip: (seatIndex) => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => {
-        const seat = draft.seats[seatIndex];
-        const chips = ensureChipArray(seat);
-        if (chips.length > 0) {
-          chips.pop();
-          seat.baseBet = sumChips(chips);
+      } catch (error) {
+        set({ error: (error as Error).message });
+      }
+    },
+    playerStand: () => {
+      try {
+        let shouldStartDealer = false;
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => {
+            playerStand(draft);
+            shouldStartDealer = draft.phase === "dealerPlay";
+          });
+          persistState(nextGame);
+          return { game: nextGame, error: null };
+        });
+        if (shouldStartDealer) {
+          runDealerSequence();
         }
-      });
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  deal: () => {
-    try {
-      set((store) => {
-        const nextGame = mutateGame(store.game, (draft) => deal(draft));
-        persistState(nextGame);
-        return { game: nextGame, error: null };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message });
-    }
-  },
-  playerHit: () => {
-    try {
-      set((store) => {
-        const nextGame = mutateGame(store.game, (draft) => {
-          playerHit(draft);
-          if (draft.phase === "dealerPlay") {
-            playDealer(draft);
-            settleAllHands(draft);
-          }
+      } catch (error) {
+        set({ error: (error as Error).message });
+      }
+    },
+    playerDouble: () => {
+      try {
+        let shouldStartDealer = false;
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => {
+            playerDouble(draft);
+            shouldStartDealer = draft.phase === "dealerPlay";
+          });
+          persistState(nextGame);
+          return { game: nextGame, error: null };
         });
-        persistState(nextGame);
-        return { game: nextGame, error: null };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message });
-    }
-  },
-  playerStand: () => {
-    try {
-      set((store) => {
-        const nextGame = mutateGame(store.game, (draft) => {
-          playerStand(draft);
-          if (draft.phase === "dealerPlay") {
-            playDealer(draft);
-            settleAllHands(draft);
-          }
-        });
-        persistState(nextGame);
-        return { game: nextGame, error: null };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message });
-    }
-  },
-  playerDouble: () => {
-    try {
-      set((store) => {
-        const nextGame = mutateGame(store.game, (draft) => {
-          playerDouble(draft);
-          if (draft.phase === "dealerPlay") {
-            playDealer(draft);
-            settleAllHands(draft);
-          }
-        });
-        persistState(nextGame);
-        return { game: nextGame, error: null };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message });
-    }
-  },
-  playerSplit: () => {
-    try {
-      set((store) => {
-        const nextGame = mutateGame(store.game, (draft) => playerSplit(draft));
-        persistState(nextGame);
-        return { game: nextGame, error: null };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message });
-    }
-  },
-  playerSurrender: () => {
-    try {
-      set((store) => {
-        const nextGame = mutateGame(store.game, (draft) => {
-          playerSurrender(draft);
-          if (draft.phase === "dealerPlay") {
-            playDealer(draft);
-            settleAllHands(draft);
-          }
-        });
-        persistState(nextGame);
-        return { game: nextGame, error: null };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message });
-    }
-  },
-  takeInsurance: (seatIndex, handId, amount) => {
-    try {
-      set((store) => {
-        const nextGame = mutateGame(store.game, (draft) => {
-          takeInsurance(draft, seatIndex, handId, amount);
-        });
-        persistState(nextGame);
-        return { game: nextGame, error: null };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message });
-    }
-  },
-  declineInsurance: (seatIndex, handId) => {
-    try {
-      set((store) => {
-        const nextGame = mutateGame(store.game, (draft) => {
-          declineInsurance(draft, seatIndex, handId);
-        });
-        persistState(nextGame);
-        return { game: nextGame, error: null };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message });
-    }
-  },
-  finishInsurance: () => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => {
-        finishInsurance(draft);
-        if (draft.phase === "dealerPlay") {
-          playDealer(draft);
-          settleAllHands(draft);
-        } else if (draft.phase === "settlement") {
-          settleAllHands(draft);
+        if (shouldStartDealer) {
+          runDealerSequence();
         }
+      } catch (error) {
+        set({ error: (error as Error).message });
+      }
+    },
+    playerSplit: () => {
+      try {
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => playerSplit(draft));
+          persistState(nextGame);
+          return { game: nextGame, error: null };
+        });
+      } catch (error) {
+        set({ error: (error as Error).message });
+      }
+    },
+    playerSurrender: () => {
+      try {
+        let shouldStartDealer = false;
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => {
+            playerSurrender(draft);
+            shouldStartDealer = draft.phase === "dealerPlay";
+          });
+          persistState(nextGame);
+          return { game: nextGame, error: null };
+        });
+        if (shouldStartDealer) {
+          runDealerSequence();
+        }
+      } catch (error) {
+        set({ error: (error as Error).message });
+      }
+    },
+    takeInsurance: (seatIndex, handId, amount) => {
+      try {
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => {
+            takeInsurance(draft, seatIndex, handId, amount);
+          });
+          persistState(nextGame);
+          return { game: nextGame, error: null };
+        });
+      } catch (error) {
+        set({ error: (error as Error).message });
+      }
+    },
+    declineInsurance: (seatIndex, handId) => {
+      try {
+        set((store) => {
+          const nextGame = mutateGame(store.game, (draft) => {
+            declineInsurance(draft, seatIndex, handId);
+          });
+          persistState(nextGame);
+          return { game: nextGame, error: null };
+        });
+      } catch (error) {
+        set({ error: (error as Error).message });
+      }
+    },
+    finishInsurance: () => {
+      let shouldStartDealer = false;
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => {
+          finishInsurance(draft);
+          if (draft.phase === "dealerPlay") {
+            shouldStartDealer = true;
+          } else if (draft.phase === "settlement") {
+            settleAllHands(draft);
+          }
+        });
+        persistState(nextGame);
+        return { game: nextGame, error: null };
       });
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  playDealer: () => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => {
-        playDealer(draft);
-        settleAllHands(draft);
+      if (shouldStartDealer) {
+        runDealerSequence();
+      }
+    },
+    playDealer: () => {
+      runDealerSequence();
+    },
+    settle: () => {
+      stopDealerTimers();
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => settleAllHands(draft));
+        persistState(nextGame);
+        return { game: nextGame, error: null };
       });
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  settle: () => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => settleAllHands(draft));
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  nextRound: () => {
-    set((store) => {
-      const nextGame = mutateGame(store.game, (draft) => prepareNextRound(draft));
-      persistState(nextGame);
-      return { game: nextGame, error: null };
-    });
-  },
-  setCoachMode: (mode) => {
-    if (typeof localStorage !== "undefined") {
-      localStorage.setItem(COACH_MODE_KEY, mode);
+    },
+    nextRound: () => {
+      stopDealerTimers();
+      set((store) => {
+        const nextGame = mutateGame(store.game, (draft) => prepareNextRound(draft));
+        persistState(nextGame);
+        return { game: nextGame, error: null };
+      });
+    },
+    setCoachMode: (mode) => {
+      if (typeof localStorage !== "undefined") {
+        localStorage.setItem(COACH_MODE_KEY, mode);
+      }
+      set({ coachMode: mode });
     }
-    set({ coachMode: mode });
-  }
-}));
+  };
+});


### PR DESCRIPTION
## Summary
- add a step-wise dealer play helper so single hits can be animated
- trigger dealer draws from the store with timed delays and finish with settlement
- reuse animation constants to space out reveals and cancel timers on round changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e51610bb0483298d0fd0f63f898c27