### PR TITLE
feat: add mobile-first blackjack interface

### DIFF
--- a/src/components/UIModeToggle.tsx
+++ b/src/components/UIModeToggle.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import type { DisplayMode } from "../ui/displayMode";
+import { cn } from "../utils/cn";
+
+interface UIModeToggleProps {
+  mode: DisplayMode;
+  onChange: (mode: DisplayMode) => void;
+}
+
+export const UIModeToggle: React.FC<UIModeToggleProps> = ({ mode, onChange }) => {
+  const handleSelect = React.useCallback(
+    (next: DisplayMode) => () => {
+      onChange(next);
+    },
+    [onChange]
+  );
+
+  return (
+    <div className="inline-flex rounded-full border border-emerald-700 bg-emerald-900/60 p-1 text-xs text-emerald-200 shadow"> 
+      <button
+        type="button"
+        onClick={handleSelect("classic")}
+        className={cn(
+          "rounded-full px-3 py-1 font-semibold uppercase tracking-[0.2em] transition",
+          mode === "classic"
+            ? "bg-emerald-600 text-emerald-50 shadow-inner"
+            : "text-emerald-200 hover:text-emerald-50"
+        )}
+        aria-pressed={mode === "classic"}
+        aria-label="Switch to classic table UI"
+      >
+        Classic
+      </button>
+      <button
+        type="button"
+        onClick={handleSelect("mobile")}
+        className={cn(
+          "rounded-full px-3 py-1 font-semibold uppercase tracking-[0.2em] transition",
+          mode === "mobile"
+            ? "bg-emerald-600 text-emerald-50 shadow-inner"
+            : "text-emerald-200 hover:text-emerald-50"
+        )}
+        aria-pressed={mode === "mobile"}
+        aria-label="Switch to mobile-first UI"
+      >
+        Mobile
+      </button>
+    </div>
+  );
+};

--- a/src/components/mobile/ActionBar.tsx
+++ b/src/components/mobile/ActionBar.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { Button } from "../ui/button";
+import { cn } from "../../utils/cn";
+import type { CoachMode } from "../../store/useGameStore";
+import type { Action } from "../../utils/basicStrategy";
+
+interface ActionAvailability {
+  hit: boolean;
+  stand: boolean;
+  double: boolean;
+  split: boolean;
+  surrender: boolean;
+  deal: boolean;
+  finishInsurance: boolean;
+  playDealer: boolean;
+  nextRound: boolean;
+}
+
+interface ActionBarProps {
+  availability: ActionAvailability;
+  onDeal: () => void;
+  onFinishInsurance: () => void;
+  onPlayDealer: () => void;
+  onNextRound: () => void;
+  onHit: () => void;
+  onStand: () => void;
+  onDouble: () => void;
+  onSplit: () => void;
+  onSurrender: () => void;
+  highlightedAction?: Action | null;
+  coachMode: CoachMode;
+}
+
+export const ActionBar: React.FC<ActionBarProps> = ({
+  availability,
+  onDeal,
+  onFinishInsurance,
+  onPlayDealer,
+  onNextRound,
+  onHit,
+  onStand,
+  onDouble,
+  onSplit,
+  onSurrender,
+  highlightedAction,
+  coachMode
+}) => {
+  const actionHighlight = (action: Action): string | undefined => {
+    if (!highlightedAction) {
+      return undefined;
+    }
+    return highlightedAction === action ? "best" : undefined;
+  };
+
+  return (
+    <div className="grid gap-3" style={{ paddingBottom: "max(env(safe-area-inset-bottom), 0px)" }}>
+      <div className="grid grid-cols-2 gap-3">
+        <Button size="lg" onClick={onHit} disabled={!availability.hit} data-coach={actionHighlight("hit")}
+          className={cn(
+            "h-14 text-lg font-semibold uppercase tracking-[0.3em]",
+            highlightedAction === "hit" && coachMode === "live" ? "shadow-[0_0_0_3px_rgba(200,162,74,0.7)]" : undefined
+          )}
+        >
+          Hit
+        </Button>
+        <Button
+          size="lg"
+          variant="outline"
+          onClick={onStand}
+          disabled={!availability.stand}
+          data-coach={actionHighlight("stand")}
+          className={cn(
+            "h-14 text-lg font-semibold uppercase tracking-[0.3em]",
+            highlightedAction === "stand" && coachMode === "live" ? "shadow-[0_0_0_3px_rgba(200,162,74,0.7)]" : undefined
+          )}
+        >
+          Stand
+        </Button>
+      </div>
+      <div className="grid grid-cols-3 gap-3 text-[12px] uppercase tracking-[0.24em]">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onDouble}
+          disabled={!availability.double}
+          data-coach={actionHighlight("double")}
+        >
+          Double
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onSplit}
+          disabled={!availability.split}
+          data-coach={actionHighlight("split")}
+        >
+          Split
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onSurrender}
+          disabled={!availability.surrender}
+          data-coach={actionHighlight("surrender")}
+        >
+          Surrender
+        </Button>
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-[12px] uppercase tracking-[0.24em] md:grid-cols-4">
+        <Button onClick={onDeal} disabled={!availability.deal}>
+          Deal
+        </Button>
+        <Button variant="outline" onClick={onFinishInsurance} disabled={!availability.finishInsurance}>
+          Finish Insurance
+        </Button>
+        <Button variant="outline" onClick={onPlayDealer} disabled={!availability.playDealer}>
+          Play Dealer
+        </Button>
+        <Button variant="outline" onClick={onNextRound} disabled={!availability.nextRound}>
+          Next Round
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/mobile/AppShellMobile.tsx
+++ b/src/components/mobile/AppShellMobile.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+interface AppShellMobileProps {
+  topBar: React.ReactNode;
+  dealer: React.ReactNode;
+  player: React.ReactNode;
+  bottomBar: React.ReactNode;
+  insuranceSheet?: React.ReactNode;
+  resultBanner?: React.ReactNode;
+  errorBanner?: React.ReactNode;
+}
+
+export const AppShellMobile: React.FC<AppShellMobileProps> = ({
+  topBar,
+  dealer,
+  player,
+  bottomBar,
+  insuranceSheet,
+  resultBanner,
+  errorBanner
+}) => {
+  return (
+    <div className="relative min-h-screen bg-gradient-to-b from-emerald-950 via-emerald-900 to-emerald-950 text-emerald-50">
+      <div className="sticky top-0 z-40 border-b border-emerald-800/60 bg-emerald-950/80 backdrop-blur">
+        {topBar}
+        {errorBanner && <div className="border-t border-emerald-800/60">{errorBanner}</div>}
+      </div>
+      {resultBanner && <div className="z-30 px-4 pt-3">{resultBanner}</div>}
+      <div className="flex flex-col gap-4 px-4 pb-28 pt-6 sm:mx-auto sm:max-w-4xl">
+        {dealer}
+        {player}
+      </div>
+      <div className="sticky bottom-0 z-40 border-t border-emerald-800/60 bg-emerald-950/85 backdrop-blur">
+        {bottomBar}
+      </div>
+      {insuranceSheet}
+    </div>
+  );
+};

--- a/src/components/mobile/CardFan.tsx
+++ b/src/components/mobile/CardFan.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import type { Card } from "../../engine/types";
+import { PlayingCard } from "../table/PlayingCard";
+import { useCardMetrics } from "./hooks";
+
+const BASE_CARD_WIDTH = 92;
+const BASE_CARD_HEIGHT = 132;
+
+interface CardFanProps {
+  cards: Card[];
+  faceDownIndexes?: number[];
+  containerWidth: number;
+}
+
+const toSet = (indexes?: number[]): Set<number> => {
+  if (!indexes || indexes.length === 0) {
+    return new Set();
+  }
+  return new Set(indexes);
+};
+
+export const CardFan: React.FC<CardFanProps> = ({ cards, faceDownIndexes, containerWidth }) => {
+  const metrics = useCardMetrics(containerWidth);
+  const overlapBase = Math.max(12, Math.round(metrics.width * (cards.length > 5 ? 0.28 : 0.35)));
+  const totalWidth = metrics.width + (cards.length - 1) * (metrics.width - overlapBase);
+  const effectiveWidth = containerWidth > 0 ? Math.min(totalWidth, containerWidth) : totalWidth;
+  const shrinkRatio = totalWidth > effectiveWidth ? effectiveWidth / totalWidth : 1;
+  const width = Math.round(metrics.width * shrinkRatio);
+  const scale = width / BASE_CARD_WIDTH;
+  const height = Math.round(BASE_CARD_HEIGHT * scale);
+  const overlap = Math.max(12, Math.round(overlapBase * shrinkRatio));
+  const faceDown = React.useMemo(() => toSet(faceDownIndexes), [faceDownIndexes]);
+
+  return (
+    <div className="flex items-end justify-center" style={{ height }}>
+      {cards.map((card, index) => {
+        const isFirst = index === 0;
+        return (
+          <div
+            key={`${card.rank}-${card.suit}-${index}`}
+            className="relative"
+            style={{
+              width,
+              height,
+              marginLeft: isFirst ? 0 : -overlap,
+              zIndex: index + 1
+            }}
+          >
+            <div
+              className="absolute inset-0"
+              style={{ transform: `scale(${width / BASE_CARD_WIDTH})`, transformOrigin: "top left" }}
+            >
+              <PlayingCard rank={card.rank} suit={card.suit} faceDown={faceDown.has(index)} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/mobile/ChipTray.tsx
+++ b/src/components/mobile/ChipTray.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import type { ChipDenomination } from "../../theme/palette";
+import { Chip } from "../hud/Chip";
+import { Button } from "../ui/button";
+import { cn } from "../../utils/cn";
+
+const CHIP_VALUES: ChipDenomination[] = [1, 5, 25, 100, 500];
+
+interface ChipTrayProps {
+  activeChip: ChipDenomination;
+  onSelect: (value: ChipDenomination) => void;
+  onAdd: (value: ChipDenomination) => void;
+  onRemove: (value: ChipDenomination) => void;
+  onRemoveTop: () => void;
+  disabled?: boolean;
+}
+
+export const ChipTray: React.FC<ChipTrayProps> = ({
+  activeChip,
+  onSelect,
+  onAdd,
+  onRemove,
+  onRemoveTop,
+  disabled = false
+}) => {
+  const handleClick = (value: ChipDenomination) => {
+    onSelect(value);
+    if (!disabled) {
+      onAdd(value);
+    }
+  };
+
+  const handleContextMenu = (event: React.MouseEvent<HTMLButtonElement>, value: ChipDenomination) => {
+    event.preventDefault();
+    if (!disabled) {
+      onRemove(value);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.5em] text-emerald-200">Chips</span>
+      <div className="flex items-center gap-2">
+        {CHIP_VALUES.map((value) => (
+          <Chip
+            key={value}
+            value={value}
+            size={52}
+            selected={activeChip === value}
+            onClick={() => handleClick(value)}
+            onContextMenu={(event) => handleContextMenu(event, value)}
+            aria-label={`Select ${value} chip`}
+            className={cn(
+              "transition",
+              activeChip === value ? "ring-2 ring-emerald-400/80" : "hover:ring-2 hover:ring-emerald-400/40"
+            )}
+          />
+        ))}
+      </div>
+      <div className="grid grid-cols-3 gap-2 text-[12px]">
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => onAdd(activeChip)}
+          disabled={disabled}
+          className="col-span-2"
+        >
+          Add {activeChip}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => onRemove(activeChip)}
+          disabled={disabled}
+        >
+          Remove
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={onRemoveTop}
+          disabled={disabled}
+          className="col-span-3"
+        >
+          Undo last
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/mobile/DealerHandView.tsx
+++ b/src/components/mobile/DealerHandView.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import type { Dealer, Phase } from "../../engine/types";
+import { bestTotal, getHandTotals, isBust } from "../../engine/totals";
+import { CardFan } from "./CardFan";
+import { useResizeObserver } from "./hooks";
+
+interface DealerHandViewProps {
+  dealer: Dealer;
+  phase: Phase;
+}
+
+const formatDealerLabel = (dealer: Dealer, phase: Phase): string => {
+  const totals = getHandTotals(dealer.hand);
+  if (phase === "playerActions" || phase === "dealerPlay" || phase === "settlement") {
+    if (isBust(dealer.hand)) {
+      return "BUST";
+    }
+    if (totals.soft && totals.soft !== totals.hard) {
+      return `${bestTotal(dealer.hand)} / ${totals.hard}`;
+    }
+    return `${bestTotal(dealer.hand)}`;
+  }
+  if (dealer.upcard) {
+    const value = dealer.upcard.rank === "A" ? "A" : dealer.upcard.rank;
+    return `Showing ${value}`;
+  }
+  return "Waiting";
+};
+
+export const DealerHandView: React.FC<DealerHandViewProps> = ({ dealer, phase }) => {
+  const [ref, width] = useResizeObserver<HTMLDivElement>();
+  const label = formatDealerLabel(dealer, phase);
+
+  const cards = React.useMemo(() => dealer.hand.cards ?? [], [dealer.hand.cards]);
+  const faceDownIndexes = React.useMemo(() => {
+    if (phase === "playerActions" || phase === "dealerPlay" || phase === "settlement") {
+      return [];
+    }
+    if (dealer.hand.cards.length > 1) {
+      return [dealer.hand.cards.length - 1];
+    }
+    return [];
+  }, [dealer.hand.cards, phase]);
+
+  return (
+    <div ref={ref} className="flex flex-col items-center gap-2 rounded-3xl border border-emerald-800/60 bg-emerald-950/50 p-4">
+      <CardFan cards={cards} faceDownIndexes={faceDownIndexes} containerWidth={width} />
+      <div className="text-center text-[11px] uppercase tracking-[0.4em] text-emerald-200">Dealer · {label}</div>
+    </div>
+  );
+};

--- a/src/components/mobile/InsuranceSheet.tsx
+++ b/src/components/mobile/InsuranceSheet.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Button } from "../ui/button";
+import { formatCurrency } from "../../utils/currency";
+
+interface InsuranceSheetProps {
+  open: boolean;
+  amount: number;
+  onTake: () => void;
+  onSkip: () => void;
+}
+
+export const InsuranceSheet: React.FC<InsuranceSheetProps> = ({ open, amount, onTake, onSkip }) => {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-4">
+      <div
+        className="w-full max-w-md rounded-t-3xl border border-emerald-700/60 bg-[#0d2d22]/95 p-5 text-emerald-100 shadow-[0_-12px_36px_rgba(0,0,0,0.45)] backdrop-blur"
+        style={{ paddingBottom: "max(env(safe-area-inset-bottom), 20px)" }}
+      >
+        <p className="text-xs font-semibold uppercase tracking-[0.4em] text-emerald-300">Insurance Offer</p>
+        <h2 className="mt-3 text-lg font-semibold text-emerald-50">
+          Dealer shows Ace — insurance for {formatCurrency(amount)}?
+        </h2>
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <Button size="lg" onClick={onTake}>
+            Take Insurance
+          </Button>
+          <Button size="lg" variant="outline" onClick={onSkip}>
+            Skip
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/mobile/MobileTable.tsx
+++ b/src/components/mobile/MobileTable.tsx
@@ -1,0 +1,463 @@
+import React from "react";
+import type { GameState, Hand } from "../../engine/types";
+import { PRIMARY_SEAT_INDEX, filterSeatsForMode } from "../../ui/config";
+import type { CoachMode } from "../../store/useGameStore";
+import type { ChipDenomination } from "../../theme/palette";
+import { formatCurrency } from "../../utils/currency";
+import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
+import { getRecommendation, type Action, type PlayerContext } from "../../utils/basicStrategy";
+import { AppShellMobile } from "./AppShellMobile";
+import { TopBarCompact } from "./TopBarCompact";
+import { DealerHandView } from "./DealerHandView";
+import { PlayerHandView } from "./PlayerHandView";
+import { ChipTray } from "./ChipTray";
+import { ActionBar } from "./ActionBar";
+import { InsuranceSheet } from "./InsuranceSheet";
+import { ResultBanner, type ResultTone } from "./ResultBanner";
+import { Button } from "../ui/button";
+import { cn } from "../../utils/cn";
+
+interface MobileTableProps {
+  game: GameState;
+  coachMode: CoachMode;
+  actions: {
+    sit: (seatIndex: number) => void;
+    leave: (seatIndex: number) => void;
+    addChip: (seatIndex: number, denom: number) => void;
+    removeChipValue: (seatIndex: number, denom: number) => void;
+    removeTopChip: (seatIndex: number) => void;
+    deal: () => void;
+    playerHit: () => void;
+    playerStand: () => void;
+    playerDouble: () => void;
+    playerSplit: () => void;
+    playerSurrender: () => void;
+    takeInsurance: (seatIndex: number, handId: string, amount: number) => void;
+    declineInsurance: (seatIndex: number, handId: string) => void;
+    finishInsurance: () => void;
+    playDealer: () => void;
+    nextRound: () => void;
+  };
+  onCoachModeChange: (mode: CoachMode) => void;
+  error: string | null;
+  onDismissError: () => void;
+  modeToggle: React.ReactNode;
+}
+
+const hasReadySeat = (game: GameState): boolean => {
+  const seat = game.seats[PRIMARY_SEAT_INDEX];
+  if (!seat?.occupied) {
+    return false;
+  }
+  if (seat.baseBet < game.rules.minBet || seat.baseBet > game.rules.maxBet) {
+    return false;
+  }
+  return seat.baseBet > 0 && seat.baseBet <= game.bankroll;
+};
+
+const findActiveHand = (game: GameState): Hand | null => {
+  if (!game.activeHandId) {
+    return null;
+  }
+  for (const seat of filterSeatsForMode(game.seats)) {
+    const hand = seat.hands.find((candidate) => candidate.id === game.activeHandId);
+    if (hand) {
+      return hand;
+    }
+  }
+  return null;
+};
+
+const parseResultMessage = (messages: string[]): { tone: ResultTone; message: string } | null => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message.startsWith("Seat 1")) {
+      continue;
+    }
+    if (message.includes("wins")) {
+      const amountMatch = message.match(/€([0-9.,]+)/);
+      const amount = amountMatch ? Number.parseFloat(amountMatch[1].replace(",", "")) : null;
+      return {
+        tone: "win",
+        message: amount ? `Win +€${amount.toFixed(2)}` : "Win"
+      };
+    }
+    if (message.includes("push")) {
+      return { tone: "push", message: "Push" };
+    }
+    if (message.includes("loses")) {
+      const amountMatch = message.match(/€([0-9.,]+)/);
+      const amount = amountMatch ? Number.parseFloat(amountMatch[1].replace(",", "")) : null;
+      return {
+        tone: "lose",
+        message: amount ? `Lose -€${amount.toFixed(2)}` : "Lose"
+      };
+    }
+  }
+  return null;
+};
+
+const buildCoachMessage = (action: Action, correct: boolean): string => {
+  const label = action.charAt(0).toUpperCase() + action.slice(1);
+  return correct ? `Nice! ${label} was the right move.` : `Try ${label} next time.`;
+};
+
+const usePrevious = <T,>(value: T): T | undefined => {
+  const ref = React.useRef<T>();
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+};
+
+export const MobileTable: React.FC<MobileTableProps> = ({
+  game,
+  coachMode,
+  actions,
+  onCoachModeChange,
+  error,
+  onDismissError,
+  modeToggle
+}) => {
+  const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
+  const [coachMessage, setCoachMessage] = React.useState<{ tone: "correct" | "better"; text: string } | null>(null);
+  const [flashAction, setFlashAction] = React.useState<Action | null>(null);
+  const messageTimer = React.useRef<number | null>(null);
+  const highlightTimer = React.useRef<number | null>(null);
+  const [result, setResult] = React.useState<{ tone: ResultTone; message: string } | null>(null);
+  const resultTimer = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    if (messageTimer.current) {
+      window.clearTimeout(messageTimer.current);
+      messageTimer.current = null;
+    }
+    if (coachMessage) {
+      messageTimer.current = window.setTimeout(() => {
+        setCoachMessage(null);
+        messageTimer.current = null;
+      }, 2500);
+    }
+    return () => {
+      if (messageTimer.current) {
+        window.clearTimeout(messageTimer.current);
+      }
+    };
+  }, [coachMessage]);
+
+  React.useEffect(() => {
+    return () => {
+      if (resultTimer.current) {
+        window.clearTimeout(resultTimer.current);
+      }
+      if (highlightTimer.current) {
+        window.clearTimeout(highlightTimer.current);
+      }
+      if (messageTimer.current) {
+        window.clearTimeout(messageTimer.current);
+      }
+    };
+  }, []);
+
+  const seat = game.seats[PRIMARY_SEAT_INDEX] ?? null;
+  const activeHand = findActiveHand(game);
+
+  const actionContext = React.useMemo(() => {
+    if (!activeHand || !seat || game.phase !== "playerActions") {
+      return null;
+    }
+    return {
+      hand: activeHand,
+      hit: canHit(activeHand),
+      stand: !activeHand.isResolved,
+      double: canDouble(activeHand, game.rules) && game.bankroll >= activeHand.bet,
+      split: canSplit(activeHand, seat, game.rules) && game.bankroll >= activeHand.bet,
+      surrender: canSurrender(activeHand, game.rules)
+    };
+  }, [activeHand, game.bankroll, game.phase, game.rules, seat]);
+
+  const dealerUpcard = game.dealer.upcard;
+
+  const recommendation = React.useMemo(() => {
+    if (!actionContext || !dealerUpcard) {
+      return null;
+    }
+    const rank = dealerUpcard.rank as PlayerContext["dealerUpcard"]["rank"];
+    const context: PlayerContext = {
+      dealerUpcard: {
+        rank,
+        value10: dealerUpcard.rank === "10" || dealerUpcard.rank === "J" || dealerUpcard.rank === "Q" || dealerUpcard.rank === "K"
+      },
+      cards: actionContext.hand.cards.map((card) => ({ rank: card.rank })),
+      isInitialTwoCards: actionContext.hand.cards.length === 2 && !actionContext.hand.hasActed,
+      afterSplit: Boolean(actionContext.hand.isSplitHand),
+      legal: {
+        hit: actionContext.hit,
+        stand: actionContext.stand,
+        double: actionContext.double,
+        split: actionContext.split,
+        surrender: actionContext.surrender
+      }
+    };
+    return getRecommendation(context, game.rules);
+  }, [actionContext, dealerUpcard, game.rules]);
+
+  const recommendedAction = React.useMemo<Action | null>(() => {
+    if (!recommendation || !actionContext) {
+      return null;
+    }
+    const isLegal = (action: Action | undefined): boolean => {
+      if (!action) {
+        return false;
+      }
+      switch (action) {
+        case "hit":
+          return actionContext.hit;
+        case "stand":
+          return actionContext.stand;
+        case "double":
+          return actionContext.double;
+        case "split":
+          return actionContext.split;
+        case "surrender":
+          return actionContext.surrender;
+        default:
+          return false;
+      }
+    };
+    if (isLegal(recommendation.best)) {
+      return recommendation.best;
+    }
+    if (recommendation.fallback && isLegal(recommendation.fallback)) {
+      return recommendation.fallback;
+    }
+    return null;
+  }, [actionContext, recommendation]);
+
+  const highlightedAction = React.useMemo<Action | null>(() => {
+    if (flashAction) {
+      return flashAction;
+    }
+    if (coachMode === "live") {
+      return recommendedAction;
+    }
+    return null;
+  }, [coachMode, flashAction, recommendedAction]);
+
+  const triggerFeedback = React.useCallback(
+    (action: Action, callback: () => void) => {
+      if (coachMode === "feedback" && recommendedAction) {
+        const correct = action === recommendedAction;
+        setCoachMessage({ tone: correct ? "correct" : "better", text: buildCoachMessage(recommendedAction, correct) });
+        if (!correct) {
+          setFlashAction(recommendedAction);
+          if (highlightTimer.current) {
+            window.clearTimeout(highlightTimer.current);
+          }
+          highlightTimer.current = window.setTimeout(() => {
+            setFlashAction(null);
+            highlightTimer.current = null;
+          }, 1000);
+        } else {
+          setFlashAction(null);
+        }
+      }
+      callback();
+    },
+    [coachMode, recommendedAction]
+  );
+
+  const handleHit = React.useCallback(() => triggerFeedback("hit", actions.playerHit), [actions.playerHit, triggerFeedback]);
+  const handleStand = React.useCallback(
+    () => triggerFeedback("stand", actions.playerStand),
+    [actions.playerStand, triggerFeedback]
+  );
+  const handleDouble = React.useCallback(
+    () => triggerFeedback("double", actions.playerDouble),
+    [actions.playerDouble, triggerFeedback]
+  );
+  const handleSplit = React.useCallback(
+    () => triggerFeedback("split", actions.playerSplit),
+    [actions.playerSplit, triggerFeedback]
+  );
+  const handleSurrender = React.useCallback(
+    () => triggerFeedback("surrender", actions.playerSurrender),
+    [actions.playerSurrender, triggerFeedback]
+  );
+
+  const availability = React.useMemo(() => ({
+    hit: Boolean(actionContext?.hit),
+    stand: Boolean(actionContext?.stand),
+    double: Boolean(actionContext?.double),
+    split: Boolean(actionContext?.split),
+    surrender: Boolean(actionContext?.surrender),
+    deal: game.phase === "betting" && hasReadySeat(game),
+    finishInsurance: game.phase === "insurance",
+    playDealer: game.phase === "dealerPlay",
+    nextRound: game.phase === "settlement"
+  }), [actionContext, game]);
+
+  const handleAddChip = React.useCallback(
+    (value: ChipDenomination) => {
+      if (game.phase !== "betting" || !seat) {
+        return;
+      }
+      const nextBet = seat.baseBet + value;
+      if (nextBet > game.rules.maxBet || nextBet > game.bankroll) {
+        return;
+      }
+      actions.addChip(PRIMARY_SEAT_INDEX, value);
+    },
+    [actions, game.bankroll, game.phase, game.rules.maxBet, seat]
+  );
+
+  const handleRemoveChipValue = React.useCallback(
+    (value: ChipDenomination) => {
+      if (game.phase !== "betting" || !seat || seat.baseBet <= 0) {
+        return;
+      }
+      actions.removeChipValue(PRIMARY_SEAT_INDEX, value);
+    },
+    [actions, game.phase, seat]
+  );
+
+  const handleRemoveTopChip = React.useCallback(() => {
+    if (game.phase !== "betting" || !seat || seat.baseBet <= 0) {
+      return;
+    }
+    actions.removeTopChip(PRIMARY_SEAT_INDEX);
+  }, [actions, game.phase, seat]);
+
+  const [insuranceHandId, insuranceAmount] = React.useMemo(() => {
+    if (game.phase !== "insurance" || !seat) {
+      return [null, 0] as const;
+    }
+    const hand = seat.hands.find((candidate) => candidate.insuranceBet === undefined && !candidate.isResolved);
+    if (!hand) {
+      return [null, 0] as const;
+    }
+    return [hand.id, Math.min(hand.bet / 2, game.bankroll)];
+  }, [game.bankroll, game.phase, seat]);
+
+  const showInsuranceSheet = Boolean(insuranceHandId && game.awaitingInsuranceResolution);
+
+  const takeInsurance = React.useCallback(() => {
+    if (!insuranceHandId) {
+      return;
+    }
+    actions.takeInsurance(PRIMARY_SEAT_INDEX, insuranceHandId, insuranceAmount);
+  }, [actions, insuranceAmount, insuranceHandId]);
+
+  const skipInsurance = React.useCallback(() => {
+    if (!insuranceHandId) {
+      return;
+    }
+    actions.declineInsurance(PRIMARY_SEAT_INDEX, insuranceHandId);
+  }, [actions, insuranceHandId]);
+
+  const prevPhase = usePrevious(game.phase);
+
+  React.useEffect(() => {
+    if (game.phase === "settlement" && prevPhase !== "settlement") {
+      const parsed = parseResultMessage(game.messageLog);
+      if (parsed) {
+        setResult(parsed);
+        if (resultTimer.current) {
+          window.clearTimeout(resultTimer.current);
+        }
+        resultTimer.current = window.setTimeout(() => {
+          setResult(null);
+          resultTimer.current = null;
+        }, 3500);
+      }
+    }
+    if (game.phase !== "settlement" && prevPhase === "settlement") {
+      setResult(null);
+    }
+  }, [game.messageLog, game.phase, prevPhase]);
+
+  const errorBanner = error ? (
+    <div className="flex items-center justify-between bg-rose-900/60 px-4 py-2 text-sm text-rose-100">
+      <span>{error}</span>
+      <Button variant="ghost" size="sm" onClick={onDismissError}>
+        Dismiss
+      </Button>
+    </div>
+  ) : null;
+
+  return (
+    <AppShellMobile
+      topBar={
+        <TopBarCompact
+          rules={game.rules}
+          bankroll={game.bankroll}
+          round={game.roundCount}
+          phase={game.phase}
+          cardsRemaining={game.shoe.cards.length}
+          discardCount={game.shoe.discard.length}
+          coachMode={coachMode}
+          onCoachModeChange={onCoachModeChange}
+          modeToggle={modeToggle}
+        />
+      }
+      dealer={<DealerHandView dealer={game.dealer} phase={game.phase} />}
+      player={<PlayerHandView seat={seat} activeHandId={game.activeHandId} />}
+      bottomBar={
+        <div
+          className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-start sm:justify-between"
+          style={{ paddingBottom: "max(env(safe-area-inset-bottom), 16px)" }}
+        >
+          <div className="sm:w-[260px]">
+            <ChipTray
+              activeChip={activeChip}
+              onSelect={setActiveChip}
+              onAdd={handleAddChip}
+              onRemove={handleRemoveChipValue}
+              onRemoveTop={handleRemoveTopChip}
+              disabled={game.phase !== "betting"}
+            />
+          </div>
+          <div className="flex-1 rounded-3xl border border-emerald-800/60 bg-emerald-950/70 px-4 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.4)]">
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.32em] text-emerald-200">
+                <span>Bankroll {formatCurrency(game.bankroll)}</span>
+                <span>Bet {formatCurrency(seat?.baseBet ?? 0)}</span>
+              </div>
+              {coachMessage && (
+                <div
+                  className={cn(
+                    "rounded-2xl border px-3 py-2 text-xs font-semibold uppercase tracking-[0.28em]",
+                    coachMessage.tone === "correct"
+                      ? "border-emerald-400/70 bg-emerald-500/20 text-emerald-100"
+                      : "border-amber-400/70 bg-amber-500/20 text-amber-100"
+                  )}
+                >
+                  {coachMessage.text}
+                </div>
+              )}
+              <ActionBar
+                availability={availability}
+                onDeal={actions.deal}
+                onFinishInsurance={actions.finishInsurance}
+                onPlayDealer={actions.playDealer}
+                onNextRound={actions.nextRound}
+                onHit={handleHit}
+                onStand={handleStand}
+                onDouble={handleDouble}
+                onSplit={handleSplit}
+                onSurrender={handleSurrender}
+                highlightedAction={highlightedAction}
+                coachMode={coachMode}
+              />
+            </div>
+          </div>
+        </div>
+      }
+      insuranceSheet={
+        <InsuranceSheet open={showInsuranceSheet} amount={insuranceAmount} onTake={takeInsurance} onSkip={skipInsurance} />
+      }
+      resultBanner={result ? <ResultBanner tone={result.tone} message={result.message} /> : null}
+      errorBanner={errorBanner}
+    />
+  );
+};

--- a/src/components/mobile/PlayerHandView.tsx
+++ b/src/components/mobile/PlayerHandView.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import type { Seat } from "../../engine/types";
+import { CardFan } from "./CardFan";
+import { useResizeObserver } from "./hooks";
+import { bestTotal, getHandTotals, isBust } from "../../engine/totals";
+import { formatCurrency } from "../../utils/currency";
+import { cn } from "../../utils/cn";
+
+interface PlayerHandViewProps {
+  seat: Seat | null;
+  activeHandId: string | null;
+}
+
+const statusLabel = (hand: Seat["hands"][number]): string => {
+  if (hand.isSurrendered) {
+    return "Surrender";
+  }
+  if (isBust(hand)) {
+    return "Bust";
+  }
+  if (hand.isBlackjack) {
+    return "Blackjack";
+  }
+  if (hand.isResolved) {
+    return "Stand";
+  }
+  return "Playing";
+};
+
+export const PlayerHandView: React.FC<PlayerHandViewProps> = ({ seat, activeHandId }) => {
+  const hands = seat?.hands ?? [];
+  const [ref, width] = useResizeObserver<HTMLDivElement>();
+  const [focusedHandId, setFocusedHandId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!focusedHandId) {
+      if (activeHandId) {
+        setFocusedHandId(activeHandId);
+        return;
+      }
+      if (hands.length > 0) {
+        setFocusedHandId(hands[0].id);
+      }
+    }
+  }, [activeHandId, hands, focusedHandId]);
+
+  React.useEffect(() => {
+    if (activeHandId && focusedHandId !== activeHandId) {
+      setFocusedHandId(activeHandId);
+    }
+  }, [activeHandId, focusedHandId]);
+
+  const focusedHand = hands.find((hand) => hand.id === focusedHandId) ?? hands[0];
+
+  const totals = focusedHand ? getHandTotals(focusedHand) : null;
+  const totalDisplay = totals
+    ? isBust(focusedHand)
+      ? "Bust"
+      : totals.soft && totals.soft !== totals.hard
+        ? `${bestTotal(focusedHand)} / ${totals.hard}`
+        : `${bestTotal(focusedHand)}`
+    : "--";
+
+  const handleFocus = (handId: string) => {
+    setFocusedHandId(handId);
+  };
+
+  return (
+    <div
+      ref={ref}
+      className="flex flex-col gap-4 rounded-3xl border border-emerald-700/60 bg-[#0c2f24]/75 p-4 shadow-[0_20px_45px_rgba(0,0,0,0.35)]"
+    >
+      <div className="flex flex-col items-center gap-3">
+        {focusedHand ? (
+          <CardFan cards={focusedHand.cards} containerWidth={width} />
+        ) : (
+          <div className="flex h-36 w-full items-center justify-center text-sm text-emerald-200/70">
+            Place a bet to start
+          </div>
+        )}
+        <div className="flex w-full flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-700/40 bg-emerald-950/60 px-4 py-3 text-[11px] uppercase tracking-[0.32em] text-emerald-200">
+          <div className="flex flex-col text-left">
+            <span className="text-emerald-400/70">Total</span>
+            <span className="text-lg font-semibold text-emerald-50">{totalDisplay}</span>
+          </div>
+          <div className="flex flex-col text-left">
+            <span className="text-emerald-400/70">Bet</span>
+            <span className="text-lg font-semibold text-emerald-50">{formatCurrency(focusedHand?.bet ?? 0)}</span>
+          </div>
+          {hands.length > 1 && focusedHand && (
+            <div className="flex flex-col text-left">
+              <span className="text-emerald-400/70">Hand</span>
+              <span className="text-lg font-semibold text-emerald-50">
+                {hands.findIndex((hand) => hand.id === focusedHand.id) + 1}/{hands.length}
+              </span>
+            </div>
+          )}
+          {focusedHand && (
+            <div className="flex flex-col text-left">
+              <span className="text-emerald-400/70">Status</span>
+              <span className="text-sm font-semibold text-emerald-200">{statusLabel(focusedHand)}</span>
+            </div>
+          )}
+        </div>
+      </div>
+      {hands.length > 1 && (
+        <div className="flex items-center justify-center gap-2">
+          {hands.map((hand) => {
+            const isActive = hand.id === focusedHand?.id;
+            const isEngineActive = hand.id === activeHandId;
+            return (
+              <button
+                key={hand.id}
+                type="button"
+                onClick={() => handleFocus(hand.id)}
+                className={cn(
+                  "rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.32em] transition",
+                  isActive
+                    ? "border-emerald-400 bg-emerald-600/30 text-emerald-50"
+                    : "border-emerald-700/60 bg-emerald-950/40 text-emerald-200 hover:text-emerald-50"
+                )}
+                aria-pressed={isActive}
+              >
+                {isEngineActive ? "● " : ""}
+                H{hands.findIndex((candidate) => candidate.id === hand.id) + 1}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/mobile/ResultBanner.tsx
+++ b/src/components/mobile/ResultBanner.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { cn } from "../../utils/cn";
+
+export type ResultTone = "win" | "lose" | "push";
+
+interface ResultBannerProps {
+  message: string;
+  tone: ResultTone;
+}
+
+const toneClasses: Record<ResultTone, string> = {
+  win: "bg-emerald-600/80 border-emerald-300 text-emerald-50",
+  lose: "bg-rose-700/80 border-rose-300/80 text-rose-50",
+  push: "bg-amber-600/80 border-amber-300/80 text-amber-50"
+};
+
+export const ResultBanner: React.FC<ResultBannerProps> = ({ message, tone }) => {
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full max-w-sm rounded-full border px-4 py-2 text-center text-sm font-semibold uppercase tracking-[0.32em] shadow",
+        toneClasses[tone]
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      {message}
+    </div>
+  );
+};

--- a/src/components/mobile/TopBarCompact.tsx
+++ b/src/components/mobile/TopBarCompact.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import type { RuleConfig } from "../../engine/types";
+import { RuleBadges } from "../RuleBadges";
+import { formatCurrency } from "../../utils/currency";
+import type { CoachMode } from "../../store/useGameStore";
+import { CoachToggle } from "../CoachToggle";
+
+interface TopBarCompactProps {
+  rules: RuleConfig;
+  bankroll: number;
+  round: number;
+  phase: string;
+  cardsRemaining: number;
+  discardCount: number;
+  coachMode: CoachMode;
+  onCoachModeChange: (mode: CoachMode) => void;
+  modeToggle: React.ReactNode;
+}
+
+export const TopBarCompact: React.FC<TopBarCompactProps> = ({
+  rules,
+  bankroll,
+  round,
+  phase,
+  cardsRemaining,
+  discardCount,
+  coachMode,
+  onCoachModeChange,
+  modeToggle
+}) => {
+  return (
+    <div className="flex flex-col gap-3 px-4 py-3 text-emerald-100 sm:px-6">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h1 className="text-sm font-semibold uppercase tracking-[0.45em] text-emerald-50">Blackjack</h1>
+          <RuleBadges rules={rules} />
+        </div>
+        <div>{modeToggle}</div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-4 text-[11px] uppercase tracking-[0.28em] text-emerald-200">
+        <div className="flex flex-col">
+          <span className="text-emerald-400/70">Bankroll</span>
+          <span className="text-base font-semibold text-emerald-50">{formatCurrency(bankroll)}</span>
+        </div>
+        <div className="flex gap-4">
+          <div>
+            <span className="block text-emerald-400/70">Round</span>
+            <span className="text-sm font-semibold text-emerald-50">{round}</span>
+          </div>
+          <div>
+            <span className="block text-emerald-400/70">Phase</span>
+            <span className="text-sm font-semibold text-emerald-50">{phase}</span>
+          </div>
+        </div>
+        <div className="flex gap-4">
+          <div>
+            <span className="block text-emerald-400/70">Cards</span>
+            <span className="text-sm font-semibold text-emerald-50">{cardsRemaining}</span>
+          </div>
+          <div>
+            <span className="block text-emerald-400/70">Discard</span>
+            <span className="text-sm font-semibold text-emerald-50">{discardCount}</span>
+          </div>
+        </div>
+        <CoachToggle mode={coachMode} onChange={onCoachModeChange} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/mobile/hooks.ts
+++ b/src/components/mobile/hooks.ts
@@ -1,0 +1,48 @@
+import React from "react";
+
+const clamp = (min: number, value: number, max: number): number => Math.min(max, Math.max(min, value));
+
+export interface CardMetrics {
+  width: number;
+  height: number;
+}
+
+const computeMetrics = (containerWidth: number): CardMetrics => {
+  const vw = containerWidth > 0 ? containerWidth : typeof window !== "undefined" ? window.innerWidth : 360;
+  const width = Math.round(clamp(72, vw * 0.24, 128));
+  const height = Math.round(width * 1.4);
+  return { width, height };
+};
+
+export const useCardMetrics = (containerWidth: number): CardMetrics => {
+  const [metrics, setMetrics] = React.useState<CardMetrics>(() => computeMetrics(containerWidth));
+
+  React.useEffect(() => {
+    setMetrics(computeMetrics(containerWidth));
+  }, [containerWidth]);
+
+  return metrics;
+};
+
+export const useResizeObserver = <T extends HTMLElement>(): [React.RefObject<T>, number] => {
+  const ref = React.useRef<T>(null);
+  const [width, setWidth] = React.useState<number>(0);
+
+  React.useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry?.contentRect?.width) {
+        setWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(element);
+    setWidth(element.getBoundingClientRect().width);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, width];
+};

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -3,6 +3,10 @@ import { Table } from "../components/Table";
 import { useGameStore } from "../store/useGameStore";
 import { Button } from "../components/ui/button";
 import { isSingleSeatMode, PRIMARY_SEAT_INDEX } from "../ui/config";
+import { MobileTable } from "../components/mobile/MobileTable";
+import { useDisplayMode } from "../ui/displayMode";
+import { UIModeToggle } from "../components/UIModeToggle";
+import type { DisplayMode } from "../ui/displayMode";
 
 export const App: React.FC = () => {
   const {
@@ -28,6 +32,7 @@ export const App: React.FC = () => {
     playDealer,
     nextRound
   } = useGameStore();
+  const [displayMode, setDisplayMode] = useDisplayMode();
 
   React.useEffect(() => {
     if (!isSingleSeatMode) {
@@ -44,9 +49,52 @@ export const App: React.FC = () => {
     }
   }, [game.seats, leave, sit]);
 
+  const actions = {
+    sit,
+    leave,
+    addChip,
+    removeChipValue,
+    removeTopChip,
+    deal,
+    playerHit,
+    playerStand,
+    playerDouble,
+    playerSplit,
+    playerSurrender,
+    takeInsurance,
+    declineInsurance,
+    finishInsurance,
+    playDealer,
+    nextRound
+  };
+
+  const modeToggle = (
+    <UIModeToggle
+      mode={displayMode}
+      onChange={(mode: DisplayMode) => {
+        setDisplayMode(mode);
+      }}
+    />
+  );
+
+  if (displayMode === "mobile") {
+    return (
+      <MobileTable
+        game={game}
+        coachMode={coachMode}
+        actions={actions}
+        onCoachModeChange={setCoachMode}
+        error={error}
+        onDismissError={clearError}
+        modeToggle={modeToggle}
+      />
+    );
+  }
+
   return (
     <main className="min-h-screen bg-gradient-to-b from-emerald-950 via-emerald-900 to-emerald-950 p-6 text-emerald-50">
       <div className="mx-auto flex min-h-[calc(100vh-3rem)] w-full max-w-[1400px] flex-col gap-4">
+        <div className="flex items-center justify-end">{modeToggle}</div>
         {error && (
           <div className="flex items-center justify-between rounded-md border border-rose-600 bg-rose-900/60 px-4 py-2 text-sm">
             <span>{error}</span>
@@ -55,29 +103,7 @@ export const App: React.FC = () => {
             </Button>
           </div>
         )}
-        <Table
-          game={game}
-          coachMode={coachMode}
-          actions={{
-            sit,
-            leave,
-            addChip,
-            removeChipValue,
-            removeTopChip,
-            deal,
-            playerHit,
-            playerStand,
-            playerDouble,
-            playerSplit,
-            playerSurrender,
-            takeInsurance,
-            declineInsurance,
-            finishInsurance,
-            playDealer,
-            nextRound
-          }}
-          onCoachModeChange={setCoachMode}
-        />
+        <Table game={game} coachMode={coachMode} actions={actions} onCoachModeChange={setCoachMode} />
       </div>
     </main>
   );

--- a/src/ui/displayMode.ts
+++ b/src/ui/displayMode.ts
@@ -1,0 +1,93 @@
+import React from "react";
+
+export type DisplayMode = "classic" | "mobile";
+
+const DISPLAY_QUERY_KEY = "ui";
+const DISPLAY_STORAGE_KEY = "ui.display";
+const DEFAULT_MODE: DisplayMode = "classic";
+
+const isValidMode = (value: string | null): value is DisplayMode => value === "classic" || value === "mobile";
+
+const readStoredMode = (): DisplayMode | null => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(DISPLAY_STORAGE_KEY);
+    if (isValidMode(stored)) {
+      return stored;
+    }
+  } catch {
+    // ignore storage errors
+  }
+  return null;
+};
+
+const persistMode = (mode: DisplayMode): void => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(DISPLAY_STORAGE_KEY, mode);
+  } catch {
+    // ignore storage errors
+  }
+};
+
+const setQueryParam = (mode: DisplayMode): void => {
+  if (typeof window === "undefined" || typeof window.history === "undefined") {
+    return;
+  }
+  try {
+    const url = new URL(window.location.href);
+    if (mode === DEFAULT_MODE) {
+      url.searchParams.delete(DISPLAY_QUERY_KEY);
+    } else {
+      url.searchParams.set(DISPLAY_QUERY_KEY, mode);
+    }
+    window.history.replaceState({}, "", url.toString());
+  } catch {
+    // ignore URL issues
+  }
+};
+
+const resolveInitialMode = (): DisplayMode => {
+  if (typeof window === "undefined") {
+    return DEFAULT_MODE;
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const queryMode = params.get(DISPLAY_QUERY_KEY);
+    if (isValidMode(queryMode)) {
+      persistMode(queryMode);
+      return queryMode;
+    }
+  } catch {
+    // ignore query parse errors
+  }
+  const stored = readStoredMode();
+  if (stored) {
+    return stored;
+  }
+  persistMode(DEFAULT_MODE);
+  return DEFAULT_MODE;
+};
+
+export const getInitialDisplayMode = (): DisplayMode => resolveInitialMode();
+
+export const useDisplayMode = (): [DisplayMode, (mode: DisplayMode) => void] => {
+  const [mode, setMode] = React.useState<DisplayMode>(() => resolveInitialMode());
+
+  const updateMode = React.useCallback((next: DisplayMode) => {
+    setMode(next);
+    persistMode(next);
+    setQueryParam(next);
+  }, []);
+
+  React.useEffect(() => {
+    persistMode(mode);
+    setQueryParam(mode);
+  }, [mode]);
+
+  return [mode, updateMode];
+};


### PR DESCRIPTION
## Summary
- add display mode toggle to switch between classic and new mobile-first blackjack layouts
- implement mobile table shell with responsive dealer/player views, chip tray, action bar, insurance sheet, and result banner
- share responsive card fan and sizing utilities tailored for handheld play

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53c0e74f88329b54e527214f59674