### PR TITLE
feat: add mobile-first mobile blackjack interface

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -278,3 +278,24 @@ button:disabled {
     animation: none;
   }
 }
+
+@keyframes mobileSheetUp {
+  from {
+    opacity: 0;
+    transform: translateY(12%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-slide-up {
+  animation: mobileSheetUp 0.28s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-slide-up {
+    animation: none;
+  }
+}

--- a/src/mobile/ActionBar.tsx
+++ b/src/mobile/ActionBar.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import type { GameState, Hand } from "../engine/types";
+import { getLegalActions } from "../engine/rules";
+import { Button } from "../components/ui/button";
+import type { CoachMode } from "../store/useGameStore";
+import { cn } from "../utils/cn";
+import { PRIMARY_SEAT_INDEX } from "../ui/config";
+
+interface ActionBarProps {
+  game: GameState;
+  activeHand: Hand | null;
+  focusMatchesActive: boolean;
+  coachMode: CoachMode;
+  onDeal: () => void;
+  onHit: () => void;
+  onStand: () => void;
+  onDouble: () => void;
+  onSplit: () => void;
+  onSurrender: () => void;
+  onFinishInsurance: () => void;
+  onPlayDealer: () => void;
+  onNextRound: () => void;
+}
+
+const hasReadyBet = (game: GameState): boolean => {
+  const seat = game.seats[PRIMARY_SEAT_INDEX] ?? game.seats[0];
+  if (!seat) {
+    return false;
+  }
+  if (!seat.occupied) {
+    return false;
+  }
+  if (seat.baseBet < game.rules.minBet) {
+    return false;
+  }
+  if (seat.baseBet > game.rules.maxBet) {
+    return false;
+  }
+  return seat.baseBet > 0 && seat.baseBet <= game.bankroll;
+};
+
+const actionLabel = (phase: GameState["phase"]): string | null => {
+  switch (phase) {
+    case "betting":
+      return "Deal";
+    case "insurance":
+      return "Finish Insurance";
+    case "dealerPlay":
+      return "Play Dealer";
+    case "settlement":
+      return "Next Round";
+    default:
+      return null;
+  }
+};
+
+export const ActionBar: React.FC<ActionBarProps> = ({
+  game,
+  activeHand,
+  focusMatchesActive,
+  coachMode,
+  onDeal,
+  onHit,
+  onStand,
+  onDouble,
+  onSplit,
+  onSurrender,
+  onFinishInsurance,
+  onPlayDealer,
+  onNextRound
+}) => {
+  const legal = React.useMemo(() => {
+    if (!activeHand || game.phase !== "playerActions") {
+      return { hit: false, stand: false, double: false, split: false, surrender: false };
+    }
+    const base = getLegalActions(game, activeHand);
+    const bankrollOk = game.bankroll >= activeHand.bet;
+    return {
+      hit: base.canHit,
+      stand: base.canStand,
+      double: base.canDouble && bankrollOk,
+      split: base.canSplit && bankrollOk,
+      surrender: base.canSurrender
+    };
+  }, [activeHand, game]);
+
+  const primaryDisabled = !focusMatchesActive || game.phase !== "playerActions";
+
+  const utilityAction = actionLabel(game.phase);
+  const handleUtility = () => {
+    switch (game.phase) {
+      case "betting":
+        onDeal();
+        break;
+      case "insurance":
+        onFinishInsurance();
+        break;
+      case "dealerPlay":
+        onPlayDealer();
+        break;
+      case "settlement":
+        onNextRound();
+        break;
+      default:
+        break;
+    }
+  };
+
+  const utilityDisabled = (() => {
+    switch (game.phase) {
+      case "betting":
+        return !hasReadyBet(game);
+      case "insurance":
+        return false;
+      case "dealerPlay":
+        return false;
+      case "settlement":
+        return false;
+      default:
+        return true;
+    }
+  })();
+
+  const actionButtons = [
+    { label: "Hit", onClick: onHit, enabled: legal.hit && !primaryDisabled },
+    { label: "Stand", onClick: onStand, enabled: legal.stand && !primaryDisabled }
+  ];
+
+  const secondaryButtons = [
+    { label: "Double", onClick: onDouble, enabled: legal.double && !primaryDisabled },
+    { label: "Split", onClick: onSplit, enabled: legal.split && !primaryDisabled },
+    { label: "Surrender", onClick: onSurrender, enabled: legal.surrender && !primaryDisabled }
+  ];
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <div className="grid grid-cols-2 gap-2">
+        {actionButtons.map((button) => (
+          <Button
+            key={button.label}
+            size="lg"
+            className={cn(
+              "h-12 text-base font-semibold uppercase tracking-[0.3em]",
+              !button.enabled && "opacity-60"
+            )}
+            onClick={button.onClick}
+            disabled={!button.enabled}
+          >
+            {button.label}
+          </Button>
+        ))}
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        {secondaryButtons.map((button) => (
+          <Button
+            key={button.label}
+            variant="outline"
+            className={cn(
+              "h-11 text-[12px] font-semibold uppercase tracking-[0.28em]",
+              !button.enabled && "opacity-60"
+            )}
+            onClick={button.onClick}
+            disabled={!button.enabled}
+          >
+            {button.label}
+          </Button>
+        ))}
+      </div>
+      {utilityAction && (
+        <Button
+          variant="ghost"
+          className="h-11 border border-[#c8a24a]/50 bg-[#154232]/70 text-[12px] font-semibold uppercase tracking-[0.3em] text-emerald-100"
+          disabled={utilityDisabled}
+          onClick={handleUtility}
+        >
+          {utilityAction}
+        </Button>
+      )}
+      {coachMode !== "off" && (
+        <p className="text-center text-[10px] uppercase tracking-[0.32em] text-emerald-300">
+          Coach hints active
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/mobile/AppShellMobile.tsx
+++ b/src/mobile/AppShellMobile.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+interface AppShellMobileProps {
+  topBar: React.ReactNode;
+  children: React.ReactNode;
+  bottomBar: React.ReactNode;
+  overlays?: React.ReactNode;
+}
+
+export const AppShellMobile: React.FC<AppShellMobileProps> = ({ topBar, children, bottomBar, overlays }) => (
+  <div className="relative flex min-h-screen flex-col bg-gradient-to-b from-[#04110d] via-[#062118] to-[#04110d] text-emerald-50">
+    {topBar}
+    <div className="flex flex-1 flex-col gap-6 px-4 pb-32 pt-6 sm:mx-auto sm:w-full sm:max-w-3xl sm:px-6">
+      {children}
+    </div>
+    <div
+      className="sticky bottom-0 z-30 w-full border-t border-emerald-900/70 bg-[#061a13]/90 px-4 py-4 backdrop-blur"
+      style={{ paddingBottom: `calc(env(safe-area-inset-bottom) + 16px)` }}
+    >
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        {bottomBar}
+      </div>
+    </div>
+    {overlays}
+  </div>
+);

--- a/src/mobile/ChipTray.tsx
+++ b/src/mobile/ChipTray.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import type { ChipDenomination } from "../theme/palette";
+import { Chip } from "../components/hud/Chip";
+import { cn } from "../utils/cn";
+import { formatCurrency } from "../utils/currency";
+
+const CHIP_VALUES: ChipDenomination[] = [1, 5, 25, 100, 500];
+const LONG_PRESS_MS = 450;
+
+interface MobileChipTrayProps {
+  selected: ChipDenomination;
+  canModify: boolean;
+  onSelect: (value: ChipDenomination) => void;
+  onAdd: (value: ChipDenomination) => void;
+  onRemove: (value: ChipDenomination) => void;
+  onRemoveTop: () => void;
+  totalBet: number;
+}
+
+export const MobileChipTray: React.FC<MobileChipTrayProps> = ({
+  selected,
+  canModify,
+  onSelect,
+  onAdd,
+  onRemove,
+  onRemoveTop,
+  totalBet
+}) => {
+  const timerRef = React.useRef<number | null>(null);
+  const longPressValue = React.useRef<ChipDenomination | null>(null);
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    longPressValue.current = null;
+  };
+
+  React.useEffect(() => clearTimer, []);
+
+  const handlePointerDown = (value: ChipDenomination) => (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === "mouse" && event.button === 2) {
+      event.preventDefault();
+      if (canModify) {
+        onRemove(value);
+      }
+      return;
+    }
+    longPressValue.current = value;
+    timerRef.current = window.setTimeout(() => {
+      if (canModify) {
+        onRemove(value);
+      }
+      longPressValue.current = null;
+    }, LONG_PRESS_MS);
+  };
+
+  const handlePointerUp = (value: ChipDenomination) => () => {
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+      if (longPressValue.current !== null) {
+        onSelect(value);
+        if (canModify) {
+          onAdd(value);
+        }
+      }
+    }
+    longPressValue.current = null;
+  };
+
+  const handlePointerLeave = () => {
+    clearTimer();
+  };
+
+  const handleRemoveTop = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    if (canModify) {
+      onRemoveTop();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.45em] text-emerald-200">Bet</div>
+      <div className="rounded-2xl border border-[#c8a24a]/45 bg-[#0c2f24]/85 px-3 py-3 shadow-[0_16px_34px_rgba(0,0,0,0.45)]">
+        <div className="flex items-center gap-2">
+          {CHIP_VALUES.map((value) => {
+            const isActive = value === selected;
+            return (
+              <Chip
+                key={value}
+                value={value}
+                selected={isActive}
+                size={isActive ? 58 : 52}
+                className={cn(!canModify && "opacity-60")}
+                onPointerDown={handlePointerDown(value)}
+                onPointerUp={handlePointerUp(value)}
+                onPointerLeave={handlePointerLeave}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  if (canModify) {
+                    onRemove(value);
+                  }
+                }}
+                aria-pressed={isActive}
+              />
+            );
+          })}
+        </div>
+        <div className="mt-3 flex items-center justify-between text-[11px] uppercase tracking-[0.35em] text-emerald-300">
+          <span>Total {formatCurrency(totalBet)}</span>
+          <button
+            type="button"
+            onClick={handleRemoveTop}
+            className="rounded-full border border-emerald-400/40 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-200 hover:bg-emerald-800/60"
+            disabled={!canModify}
+          >
+            Remove chip
+          </button>
+        </div>
+        <p className="mt-2 text-[10px] text-emerald-400">
+          Tap to add · hold or right-click to remove
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/mobile/DealerHandView.tsx
+++ b/src/mobile/DealerHandView.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import type { GameState } from "../engine/types";
+import { getHandTotals, isBust } from "../engine/totals";
+import { ScaledCard } from "./ScaledCard";
+import type { CardMetrics } from "./useCardMetrics";
+import { formatHandTotals } from "./formatters";
+
+interface DealerHandViewProps {
+  game: GameState;
+  metrics: CardMetrics;
+}
+
+const dealerLabel = (game: GameState, revealHole: boolean): string => {
+  const { dealer } = game;
+  if (!dealer.hand.cards.length) {
+    return "Waiting";
+  }
+  if (!revealHole) {
+    const up = dealer.upcard;
+    if (up) {
+      return `Showing ${up.rank}${up.suit}`;
+    }
+    return "Showing";
+  }
+  if (dealer.hand.isBlackjack) {
+    return "Blackjack";
+  }
+  if (isBust(dealer.hand)) {
+    return "Bust";
+  }
+  const totals = getHandTotals(dealer.hand);
+  return formatHandTotals(totals);
+};
+
+export const DealerHandView: React.FC<DealerHandViewProps> = ({ game, metrics }) => {
+  const revealHole =
+    game.phase === "dealerPlay" || game.phase === "settlement" || game.dealer.hand.isBlackjack;
+
+  const cards = game.dealer.hand.cards;
+  const cardCount = cards.length || (game.dealer.upcard ? 1 : 0);
+  const fanWidth = metrics.fanWidth(cardCount);
+  const positions = metrics.positions(cardCount);
+
+  return (
+    <section aria-label="Dealer" className="flex flex-col items-center gap-3">
+      <div className="relative" style={{ width: fanWidth, minHeight: metrics.cardHeight }}>
+        {cards.map((card, index) => {
+          const faceDown = index === 1 && !revealHole;
+          const position = positions[index] ?? { left: 0 };
+          return (
+            <div
+              key={`${card.rank}${card.suit}${index}`}
+              className="absolute top-0"
+              style={{ left: position.left, transition: "left 120ms ease-out" }}
+            >
+              <ScaledCard card={card} faceDown={faceDown} width={metrics.cardWidth} height={metrics.cardHeight} />
+            </div>
+          );
+        })}
+        {cards.length === 0 && game.dealer.upcard && (
+          <ScaledCard card={game.dealer.upcard} width={metrics.cardWidth} height={metrics.cardHeight} />
+        )}
+      </div>
+      <div className="flex flex-col items-center text-xs uppercase tracking-[0.35em] text-emerald-200">
+        <span className="text-sm font-semibold text-emerald-100">Dealer</span>
+        <span className="text-[11px] text-emerald-300">{dealerLabel(game, revealHole)}</span>
+      </div>
+    </section>
+  );
+};

--- a/src/mobile/InsuranceSheet.tsx
+++ b/src/mobile/InsuranceSheet.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Button } from "../components/ui/button";
+import { formatCurrency } from "../utils/currency";
+import { cn } from "../utils/cn";
+import { REDUCED } from "../utils/animConstants";
+
+interface InsuranceSheetProps {
+  open: boolean;
+  amount: number;
+  onTake: () => void;
+  onSkip: () => void;
+}
+
+export const InsuranceSheet: React.FC<InsuranceSheetProps> = ({ open, amount, onTake, onSkip }) => {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Insurance offer"
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 flex justify-center px-4",
+        REDUCED ? "" : "animate-slide-up"
+      )}
+    >
+      <div
+        className="w-full max-w-md rounded-t-3xl border border-[#c8a24a]/50 bg-[#08221a]/95 px-5 py-6 text-center shadow-[0_-18px_42px_rgba(0,0,0,0.6)]"
+        style={{ paddingBottom: `calc(env(safe-area-inset-bottom) + 24px)` }}
+      >
+        <p className="text-sm font-semibold uppercase tracking-[0.32em] text-emerald-200">
+          Dealer shows Ace — Insurance?
+        </p>
+        <p className="mt-2 text-base text-emerald-100">Half bet: {formatCurrency(amount)}</p>
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <Button size="lg" onClick={onTake}>
+            Take Insurance
+          </Button>
+          <Button size="lg" variant="outline" onClick={onSkip}>
+            Skip
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/mobile/MobileTable.tsx
+++ b/src/mobile/MobileTable.tsx
@@ -1,0 +1,222 @@
+import React from "react";
+import type { GameState } from "../engine/types";
+import type { CoachMode } from "../store/useGameStore";
+import type { ChipDenomination } from "../theme/palette";
+import { AppShellMobile } from "./AppShellMobile";
+import { TopBarCompact } from "./TopBarCompact";
+import { DealerHandView } from "./DealerHandView";
+import { PlayerHandView } from "./PlayerHandView";
+import { MobileChipTray } from "./ChipTray";
+import { ActionBar } from "./ActionBar";
+import { InsuranceSheet } from "./InsuranceSheet";
+import { ResultBanner } from "./ResultBanner";
+import { useCardMetrics } from "./useCardMetrics";
+import { summarizeSeatOutcome, resolveOutcomeKind, MIN_AMOUNT, type OutcomeKind } from "./outcome";
+import { PRIMARY_SEAT_INDEX } from "../ui/config";
+
+interface MobileTableProps {
+  game: GameState;
+  coachMode: CoachMode;
+  actions: {
+    sit: (seatIndex: number) => void;
+    leave: (seatIndex: number) => void;
+    addChip: (seatIndex: number, denom: number) => void;
+    removeChipValue: (seatIndex: number, denom: number) => void;
+    removeTopChip: (seatIndex: number) => void;
+    deal: () => void;
+    playerHit: () => void;
+    playerStand: () => void;
+    playerDouble: () => void;
+    playerSplit: () => void;
+    playerSurrender: () => void;
+    takeInsurance: (seatIndex: number, handId: string, amount: number) => void;
+    declineInsurance: (seatIndex: number, handId: string) => void;
+    finishInsurance: () => void;
+    playDealer: () => void;
+    nextRound: () => void;
+  };
+  onCoachModeChange: (mode: CoachMode) => void;
+}
+
+const DEFAULT_CHIP: ChipDenomination = 25;
+
+export const MobileTable: React.FC<MobileTableProps> = ({ game, coachMode, actions, onCoachModeChange }) => {
+  const seat = game.seats[PRIMARY_SEAT_INDEX] ?? null;
+  const metrics = useCardMetrics();
+  const [selectedChip, setSelectedChip] = React.useState<ChipDenomination>(DEFAULT_CHIP);
+  const activeHand = seat?.hands.find((hand) => hand.id === game.activeHandId) ?? null;
+  const [focusedHandId, setFocusedHandId] = React.useState<string | null>(activeHand?.id ?? null);
+  const lastActiveRef = React.useRef<string | null>(activeHand?.id ?? null);
+
+  React.useEffect(() => {
+    const activeId = activeHand?.id ?? null;
+    if (activeId && activeId !== lastActiveRef.current) {
+      setFocusedHandId(activeId);
+    }
+    lastActiveRef.current = activeId;
+  }, [activeHand?.id]);
+
+  React.useEffect(() => {
+    if (!seat) {
+      setFocusedHandId(null);
+      return;
+    }
+    if (focusedHandId && seat.hands.some((hand) => hand.id === focusedHandId)) {
+      return;
+    }
+    if (activeHand) {
+      setFocusedHandId(activeHand.id);
+    } else if (seat.hands[0]) {
+      setFocusedHandId(seat.hands[0].id);
+    } else {
+      setFocusedHandId(null);
+    }
+  }, [seat, focusedHandId, activeHand]);
+
+  const handleSelectChip = (value: ChipDenomination) => {
+    setSelectedChip(value);
+  };
+
+  const handleAddChip = (value: ChipDenomination) => {
+    actions.addChip(PRIMARY_SEAT_INDEX, value);
+  };
+
+  const handleRemoveChip = (value: ChipDenomination) => {
+    actions.removeChipValue(PRIMARY_SEAT_INDEX, value);
+  };
+
+  const handleRemoveTop = () => {
+    actions.removeTopChip(PRIMARY_SEAT_INDEX);
+  };
+
+  const focusMatchesActive = !activeHand || focusedHandId === activeHand.id;
+  const totalBet = seat?.baseBet ?? 0;
+
+  const insuranceHand = React.useMemo(() => {
+    if (game.phase !== "insurance" || !seat) {
+      return null;
+    }
+    return seat.hands.find((hand) => hand.insuranceBet === undefined) ?? null;
+  }, [game.phase, seat]);
+
+  const insuranceAmount = insuranceHand ? Math.min(Math.floor(insuranceHand.bet / 2), Math.floor(game.bankroll)) : 0;
+  const showInsuranceSheet = Boolean(
+    insuranceHand && insuranceAmount > 0 && game.phase === "insurance" && game.awaitingInsuranceResolution
+  );
+
+  const previousRoundRef = React.useRef(game.roundCount);
+  const [banner, setBanner] = React.useState<{ kind: OutcomeKind; amount?: number; state: "enter" | "exit" } | null>(null);
+  const exitTimerRef = React.useRef<number | null>(null);
+  const removeTimerRef = React.useRef<number | null>(null);
+
+  const clearBannerTimers = React.useCallback(() => {
+    if (exitTimerRef.current) {
+      window.clearTimeout(exitTimerRef.current);
+      exitTimerRef.current = null;
+    }
+    if (removeTimerRef.current) {
+      window.clearTimeout(removeTimerRef.current);
+      removeTimerRef.current = null;
+    }
+  }, []);
+
+  const showBanner = React.useCallback(
+    (kind: OutcomeKind, amount?: number) => {
+      clearBannerTimers();
+      setBanner({ kind, amount, state: "enter" });
+      exitTimerRef.current = window.setTimeout(() => {
+        setBanner((current) => (current ? { ...current, state: "exit" } : null));
+        removeTimerRef.current = window.setTimeout(() => {
+          setBanner(null);
+        }, 300);
+      }, 2600);
+    },
+    [clearBannerTimers]
+  );
+
+  React.useEffect(() => clearBannerTimers, [clearBannerTimers]);
+
+  React.useEffect(() => {
+    const previousRound = previousRoundRef.current;
+    if (game.phase === "settlement" && game.roundCount > previousRound) {
+      const outcome = summarizeSeatOutcome(game, seat);
+      if (outcome) {
+        const kind = resolveOutcomeKind(outcome);
+        const amount = Math.abs(outcome.net);
+        showBanner(kind, amount > MIN_AMOUNT ? amount : undefined);
+      }
+    }
+    previousRoundRef.current = game.roundCount;
+  }, [game, seat, showBanner]);
+
+  const handleTakeInsurance = () => {
+    if (!insuranceHand || insuranceAmount <= 0) {
+      return;
+    }
+    actions.takeInsurance(PRIMARY_SEAT_INDEX, insuranceHand.id, insuranceAmount);
+  };
+
+  const handleSkipInsurance = () => {
+    if (!insuranceHand) {
+      return;
+    }
+    actions.declineInsurance(PRIMARY_SEAT_INDEX, insuranceHand.id);
+  };
+
+  const bottomBar = (
+    <>
+      <MobileChipTray
+        selected={selectedChip}
+        canModify={game.phase === "betting"}
+        onSelect={handleSelectChip}
+        onAdd={handleAddChip}
+        onRemove={handleRemoveChip}
+        onRemoveTop={handleRemoveTop}
+        totalBet={totalBet}
+      />
+      <ActionBar
+        game={game}
+        activeHand={activeHand}
+        focusMatchesActive={focusMatchesActive}
+        coachMode={coachMode}
+        onDeal={actions.deal}
+        onHit={actions.playerHit}
+        onStand={actions.playerStand}
+        onDouble={actions.playerDouble}
+        onSplit={actions.playerSplit}
+        onSurrender={actions.playerSurrender}
+        onFinishInsurance={actions.finishInsurance}
+        onPlayDealer={actions.playDealer}
+        onNextRound={actions.nextRound}
+      />
+    </>
+  );
+
+  return (
+    <AppShellMobile
+      topBar={<TopBarCompact game={game} coachMode={coachMode} onCoachModeChange={onCoachModeChange} />}
+      bottomBar={bottomBar}
+      overlays={
+        <>
+          <InsuranceSheet
+            open={showInsuranceSheet}
+            amount={insuranceAmount}
+            onTake={handleTakeInsurance}
+            onSkip={handleSkipInsurance}
+          />
+          {banner ? <ResultBanner kind={banner.kind} amount={banner.amount} state={banner.state} /> : null}
+        </>
+      }
+    >
+      <DealerHandView game={game} metrics={metrics} />
+      <PlayerHandView
+        game={game}
+        seat={seat}
+        focusedHandId={focusedHandId}
+        activeHandId={activeHand?.id ?? null}
+        metrics={metrics}
+        onFocusHand={setFocusedHandId}
+      />
+    </AppShellMobile>
+  );
+};

--- a/src/mobile/PlayerHandView.tsx
+++ b/src/mobile/PlayerHandView.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import type { GameState, Hand, Seat } from "../engine/types";
+import { getHandTotals, isBust } from "../engine/totals";
+import { ScaledCard } from "./ScaledCard";
+import type { CardMetrics } from "./useCardMetrics";
+import { formatBet, formatHandTotals } from "./formatters";
+import { cn } from "../utils/cn";
+
+interface PlayerHandViewProps {
+  game: GameState;
+  seat: Seat | null;
+  focusedHandId: string | null;
+  activeHandId: string | null;
+  metrics: CardMetrics;
+  onFocusHand: (handId: string) => void;
+}
+
+const buildStatusBadges = (hand: Hand): string[] => {
+  const badges: string[] = [];
+  if (hand.isBlackjack) {
+    badges.push("Blackjack");
+  }
+  if (hand.isDoubled) {
+    badges.push("Doubled");
+  }
+  if (hand.isSurrendered) {
+    badges.push("Surrendered");
+  }
+  if (isBust(hand)) {
+    badges.push("Bust");
+  }
+  return badges;
+};
+
+const handLabel = (index: number, total: number): string => {
+  if (total <= 1) {
+    return "";
+  }
+  return `Hand ${index + 1}/${total}`;
+};
+
+export const PlayerHandView: React.FC<PlayerHandViewProps> = ({
+  game,
+  seat,
+  focusedHandId,
+  activeHandId,
+  metrics,
+  onFocusHand
+}) => {
+  const hands = seat?.hands ?? [];
+  const focusedHand = hands.find((hand) => hand.id === focusedHandId) ?? hands[0] ?? null;
+  const activeHand = hands.find((hand) => hand.id === activeHandId) ?? null;
+  const fanWidth = metrics.fanWidth(focusedHand?.cards.length ?? 0);
+  const positions = metrics.positions(focusedHand?.cards.length ?? 0);
+
+  const infoLabel = focusedHand
+    ? formatHandTotals(getHandTotals(focusedHand))
+    : formatBet(seat?.baseBet ?? 0);
+
+  const badgeItems = focusedHand ? buildStatusBadges(focusedHand) : [];
+
+  return (
+    <section aria-label="Player" className="flex flex-col items-center gap-4">
+      <div className="relative" style={{ width: fanWidth, minHeight: metrics.cardHeight }}>
+        {focusedHand?.cards.map((card, index) => {
+          const position = positions[index] ?? { left: 0 };
+          return (
+            <div
+              key={`${card.rank}${card.suit}${index}`}
+              className="absolute top-0"
+              style={{ left: position.left, transition: "left 120ms ease-out" }}
+            >
+              <ScaledCard card={card} width={metrics.cardWidth} height={metrics.cardHeight} />
+            </div>
+          );
+        })}
+        {!focusedHand && (
+          <div className="flex h-full w-full items-center justify-center text-sm text-emerald-200">
+            {game.phase === "betting" ? "Place your bet" : "Waiting for deal"}
+          </div>
+        )}
+      </div>
+      <div className="flex w-full max-w-sm flex-col items-center gap-2">
+        <div className="grid w-full grid-cols-3 items-center gap-2 rounded-2xl border border-[#c8a24a]/50 bg-[#0e3226]/80 px-4 py-3 text-center text-[11px] uppercase tracking-[0.32em] text-emerald-200 shadow-[0_16px_34px_rgba(0,0,0,0.45)]">
+          <div className="flex flex-col gap-1">
+            <span className="text-emerald-300">Total</span>
+            <span className="text-base font-semibold tracking-[0.12em] text-emerald-50">{infoLabel}</span>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-emerald-300">Bet</span>
+            <span className="text-base font-semibold tracking-[0.12em] text-emerald-50">
+              {formatBet(focusedHand?.bet ?? seat?.baseBet ?? 0)}
+            </span>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-emerald-300">Hands</span>
+            <span className="text-base font-semibold tracking-[0.12em] text-emerald-50">
+              {handLabel(focusedHand ? hands.indexOf(focusedHand) : 0, hands.length) ||
+                (hands.length > 0 ? `${hands.length}` : "0")}
+            </span>
+          </div>
+        </div>
+        {badgeItems.length > 0 && (
+          <div className="flex flex-wrap justify-center gap-2">
+            {badgeItems.map((badge) => (
+              <span
+                key={badge}
+                className="rounded-full border border-emerald-400/50 bg-emerald-900/60 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.32em] text-emerald-200"
+              >
+                {badge}
+              </span>
+            ))}
+          </div>
+        )}
+        {hands.length > 1 && (
+          <div className="flex items-center gap-2">
+            {hands.map((hand) => {
+              const index = hands.indexOf(hand);
+              const isFocused = hand.id === (focusedHand?.id ?? focusedHandId);
+              const isActive = hand.id === activeHand?.id;
+              return (
+                <button
+                  key={hand.id}
+                  type="button"
+                  onClick={() => onFocusHand(hand.id)}
+                  className={cn(
+                    "min-w-[56px] rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] transition",
+                    isFocused
+                      ? "border-[#c8a24a] bg-[#1a4a36] text-emerald-50"
+                      : "border-[#c8a24a]/30 bg-[#0c2e23] text-emerald-200 hover:bg-[#144432]",
+                    isActive && "shadow-[0_0_0_1px_rgba(200,162,74,0.6)]"
+                  )}
+                  aria-pressed={isFocused}
+                >
+                  H{index + 1}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        {focusedHand && activeHand && focusedHand.id !== activeHand.id && (
+          <p className="text-center text-[11px] uppercase tracking-[0.32em] text-emerald-300">
+            Viewing different hand — actions apply to active hand H
+            {hands.indexOf(activeHand) + 1}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+};

--- a/src/mobile/ResultBanner.tsx
+++ b/src/mobile/ResultBanner.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { audioService } from "../services/AudioService";
+import { formatCurrency } from "../utils/currency";
+import { cn } from "../utils/cn";
+import type { OutcomeKind } from "./outcome";
+
+interface ResultBannerProps {
+  kind: OutcomeKind;
+  amount?: number;
+  state: "enter" | "exit";
+}
+
+const labelForKind = (kind: OutcomeKind): string => {
+  switch (kind) {
+    case "blackjack":
+      return "Blackjack";
+    case "insurance":
+      return "Insurance Win";
+    case "push":
+      return "Push";
+    case "win":
+      return "Win";
+    case "lose":
+    default:
+      return "Lose";
+  }
+};
+
+export const ResultBanner: React.FC<ResultBannerProps> = ({ kind, amount, state }) => {
+  React.useEffect(() => {
+    if (state === "enter") {
+      audioService.playResult(kind === "lose" ? "lose" : kind);
+    }
+  }, [kind, state]);
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none fixed inset-x-0 top-20 z-30 flex justify-center px-4",
+        state === "enter" && "opacity-100",
+        state === "exit" && "opacity-0"
+      )}
+      aria-live="polite"
+      role="status"
+    >
+      <div className="rounded-full border border-[#c8a24a]/60 bg-[#0f3226]/95 px-5 py-2 text-center text-sm font-semibold uppercase tracking-[0.32em] text-emerald-50 shadow-[0_12px_32px_rgba(0,0,0,0.5)]">
+        <span>{labelForKind(kind)}</span>
+        {amount && amount > 0.004 ? <span className="ml-3 text-emerald-200">{formatCurrency(amount)}</span> : null}
+      </div>
+    </div>
+  );
+};

--- a/src/mobile/ScaledCard.tsx
+++ b/src/mobile/ScaledCard.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import type { Card } from "../engine/types";
+import { PlayingCard } from "../components/table/PlayingCard";
+import { scaleForCardWidth } from "./useCardMetrics";
+
+interface ScaledCardProps {
+  card: Card;
+  faceDown?: boolean;
+  width: number;
+  height: number;
+}
+
+export const ScaledCard: React.FC<ScaledCardProps> = ({ card, faceDown = false, width, height }) => {
+  const scale = scaleForCardWidth(width);
+  return (
+    <div style={{ width, height }} className="pointer-events-none">
+      <div style={{ transform: `scale(${scale})`, transformOrigin: "top left" }}>
+        <PlayingCard rank={card.rank} suit={card.suit} faceDown={faceDown} />
+      </div>
+    </div>
+  );
+};

--- a/src/mobile/TopBarCompact.tsx
+++ b/src/mobile/TopBarCompact.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import type { GameState } from "../engine/types";
+import { formatCurrency } from "../utils/currency";
+import { CoachToggle } from "../components/CoachToggle";
+import type { CoachMode } from "../store/useGameStore";
+
+interface TopBarCompactProps {
+  game: GameState;
+  coachMode: CoachMode;
+  onCoachModeChange: (mode: CoachMode) => void;
+  rightSlot?: React.ReactNode;
+}
+
+const buildRuleBadges = (game: GameState): string[] => {
+  const items: string[] = [];
+  items.push(game.rules.dealerStandsOnSoft17 ? "S17" : "H17");
+  items.push(game.rules.blackjackPayout === "3:2" ? "3:2" : "6:5");
+  items.push(game.rules.doubleAfterSplit ? "DAS" : "No DAS");
+  items.push(game.rules.allowInsurance ? "Insurance" : "No Insurance");
+  return items;
+};
+
+export const TopBarCompact: React.FC<TopBarCompactProps> = ({
+  game,
+  coachMode,
+  onCoachModeChange,
+  rightSlot
+}) => {
+  const ruleBadges = buildRuleBadges(game);
+  const cardsRemaining = game.shoe.cards.length;
+
+  return (
+    <header className="sticky top-0 z-20 flex w-full flex-col gap-3 border-b border-emerald-800/60 bg-[#061d16]/80 px-4 py-3 backdrop-blur">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-col">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.4em] text-emerald-300">
+            Casino Blackjack
+          </span>
+          <h1 className="text-xl font-semibold uppercase tracking-[0.4em] text-emerald-50">Blackjack</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <CoachToggle mode={coachMode} onChange={onCoachModeChange} />
+          {rightSlot}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.35em] text-emerald-200">
+        {ruleBadges.map((badge) => (
+          <span
+            key={badge}
+            className="rounded-full border border-[#c8a24a]/40 bg-[#0d2f24]/80 px-2 py-1"
+          >
+            {badge}
+          </span>
+        ))}
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-[11px] uppercase tracking-[0.28em] text-emerald-200 sm:grid-cols-4">
+        <div>
+          <p className="text-emerald-400/80">Bankroll</p>
+          <p className="text-base font-semibold text-emerald-50">{formatCurrency(game.bankroll)}</p>
+        </div>
+        <div>
+          <p className="text-emerald-400/80">Round</p>
+          <p className="text-base font-semibold text-emerald-50">{game.roundCount}</p>
+        </div>
+        <div>
+          <p className="text-emerald-400/80">Phase</p>
+          <p className="text-base font-semibold text-emerald-50">{game.phase}</p>
+        </div>
+        <div>
+          <p className="text-emerald-400/80">Cards</p>
+          <p className="text-base font-semibold text-emerald-50">{cardsRemaining}</p>
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/src/mobile/formatters.ts
+++ b/src/mobile/formatters.ts
@@ -1,0 +1,11 @@
+import { formatCurrency } from "../utils/currency";
+import type { HandTotals } from "../engine/totals";
+
+export const formatHandTotals = (totals: HandTotals): string => {
+  if (totals.soft && totals.soft !== totals.hard) {
+    return `${totals.soft} (soft)`;
+  }
+  return `${totals.hard}`;
+};
+
+export const formatBet = (amount: number): string => formatCurrency(amount);

--- a/src/mobile/outcome.ts
+++ b/src/mobile/outcome.ts
@@ -1,0 +1,102 @@
+import { bestTotal, isBust } from "../engine/totals";
+import type { GameState, Seat } from "../engine/types";
+
+export const MIN_AMOUNT = 0.005;
+
+export type OutcomeKind = "win" | "lose" | "push" | "blackjack" | "insurance";
+
+export interface OutcomeSummary {
+  net: number;
+  baseNet: number;
+  insuranceNet: number;
+  hasBlackjackWin: boolean;
+}
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+export const summarizeSeatOutcome = (game: GameState, seat: Seat | null): OutcomeSummary | null => {
+  if (!seat) {
+    return null;
+  }
+  const dealerHand = game.dealer.hand;
+  const dealerBlackjack = dealerHand.isBlackjack;
+  const dealerBust = isBust(dealerHand);
+  const dealerTotal = bestTotal(dealerHand);
+
+  let totalBet = 0;
+  let totalInsurance = 0;
+  let basePayout = 0;
+  let insurancePayout = 0;
+  let hasBlackjackWin = false;
+
+  const blackjackMultiplier = game.rules.blackjackPayout === "6:5" ? 1.2 : 1.5;
+
+  for (const hand of seat.hands) {
+    const bet = hand.bet ?? 0;
+    const insuranceBet = hand.insuranceBet ?? 0;
+
+    totalBet += bet;
+    totalInsurance += insuranceBet;
+
+    if (dealerBlackjack) {
+      if (insuranceBet > 0) {
+        insurancePayout += insuranceBet * 3;
+      }
+      if (hand.isBlackjack) {
+        basePayout += bet;
+      }
+      continue;
+    }
+
+    if (hand.isSurrendered) {
+      basePayout += bet / 2;
+      continue;
+    }
+
+    if (isBust(hand)) {
+      continue;
+    }
+
+    if (hand.isBlackjack) {
+      basePayout += bet * (1 + blackjackMultiplier);
+      hasBlackjackWin = true;
+      continue;
+    }
+
+    if (dealerBust) {
+      basePayout += bet * 2;
+      continue;
+    }
+
+    const playerTotal = bestTotal(hand);
+    if (playerTotal > dealerTotal) {
+      basePayout += bet * 2;
+    } else if (playerTotal === dealerTotal) {
+      basePayout += bet;
+    }
+  }
+
+  if (totalBet <= 0 && totalInsurance <= 0) {
+    return null;
+  }
+
+  const baseNet = roundToCents(basePayout - totalBet);
+  const insuranceNet = roundToCents(insurancePayout - totalInsurance);
+  const net = roundToCents(baseNet + insuranceNet);
+
+  return { net, baseNet, insuranceNet, hasBlackjackWin };
+};
+
+export const resolveOutcomeKind = (outcome: OutcomeSummary): OutcomeKind => {
+  const { net, baseNet, insuranceNet, hasBlackjackWin } = outcome;
+  if (net > MIN_AMOUNT) {
+    if (insuranceNet > MIN_AMOUNT && baseNet <= MIN_AMOUNT) {
+      return "insurance";
+    }
+    return hasBlackjackWin ? "blackjack" : "win";
+  }
+  if (net < -MIN_AMOUNT) {
+    return "lose";
+  }
+  return "push";
+};

--- a/src/mobile/useCardMetrics.ts
+++ b/src/mobile/useCardMetrics.ts
@@ -1,0 +1,67 @@
+import React from "react";
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
+
+export interface CardMetrics {
+  cardWidth: number;
+  cardHeight: number;
+  overlap: (count: number) => number;
+  fanWidth: (count: number) => number;
+  positions: (count: number) => { left: number }[];
+}
+
+const BASE_WIDTH = 92;
+
+export const useCardMetrics = (): CardMetrics => {
+  const [viewportWidth, setViewportWidth] = React.useState<number>(() =>
+    typeof window === "undefined" ? 375 : window.innerWidth
+  );
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const handleResize = () => {
+      setViewportWidth(window.innerWidth);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const cardWidth = clamp(0.24 * viewportWidth, 72, 128);
+  const cardHeight = Math.round(cardWidth * 1.4);
+
+  const overlap = React.useCallback(
+    (count: number) => {
+      const factor = count > 5 ? 0.28 : 0.35;
+      return Math.max(12, Math.round(cardWidth * factor));
+    },
+    [cardWidth]
+  );
+
+  const fanWidth = React.useCallback(
+    (count: number) => {
+      if (count <= 0) {
+        return cardWidth;
+      }
+      const spacing = cardWidth - overlap(count);
+      return cardWidth + Math.max(0, count - 1) * spacing;
+    },
+    [cardWidth, overlap]
+  );
+
+  const positions = React.useCallback(
+    (count: number) => {
+      if (count <= 0) {
+        return [];
+      }
+      const spacing = cardWidth - overlap(count);
+      return Array.from({ length: count }, (_, index) => ({ left: index * spacing }));
+    },
+    [cardWidth, overlap]
+  );
+
+  return { cardWidth, cardHeight, overlap, fanWidth, positions };
+};
+
+export const scaleForCardWidth = (targetWidth: number): number => targetWidth / BASE_WIDTH;

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -3,6 +3,9 @@ import { Table } from "../components/Table";
 import { useGameStore } from "../store/useGameStore";
 import { Button } from "../components/ui/button";
 import { isSingleSeatMode, PRIMARY_SEAT_INDEX } from "../ui/config";
+import { useInterfaceMode } from "../ui/interfaceMode";
+import { InterfaceModeToggle } from "../ui/InterfaceModeToggle";
+import { MobileTable } from "../mobile/MobileTable";
 
 export const App: React.FC = () => {
   const {
@@ -28,6 +31,7 @@ export const App: React.FC = () => {
     playDealer,
     nextRound
   } = useGameStore();
+  const [interfaceMode, setInterfaceMode] = useInterfaceMode();
 
   React.useEffect(() => {
     if (!isSingleSeatMode) {
@@ -44,9 +48,49 @@ export const App: React.FC = () => {
     }
   }, [game.seats, leave, sit]);
 
+  const actionBundle = {
+    sit,
+    leave,
+    addChip,
+    removeChipValue,
+    removeTopChip,
+    deal,
+    playerHit,
+    playerStand,
+    playerDouble,
+    playerSplit,
+    playerSurrender,
+    takeInsurance,
+    declineInsurance,
+    finishInsurance,
+    playDealer,
+    nextRound
+  };
+
+  const classicView = (
+    <Table
+      game={game}
+      coachMode={coachMode}
+      actions={actionBundle}
+      onCoachModeChange={setCoachMode}
+    />
+  );
+
+  const mobileView = (
+    <MobileTable
+      game={game}
+      coachMode={coachMode}
+      actions={actionBundle}
+      onCoachModeChange={setCoachMode}
+    />
+  );
+
   return (
-    <main className="min-h-screen bg-gradient-to-b from-emerald-950 via-emerald-900 to-emerald-950 p-6 text-emerald-50">
-      <div className="mx-auto flex min-h-[calc(100vh-3rem)] w-full max-w-[1400px] flex-col gap-4">
+    <main className="min-h-screen bg-gradient-to-b from-emerald-950 via-emerald-900 to-emerald-950 p-4 text-emerald-50 sm:p-6">
+      <div className="mx-auto flex min-h-[calc(100vh-2rem)] w-full max-w-[1400px] flex-col gap-4">
+        <div className="flex justify-end">
+          <InterfaceModeToggle mode={interfaceMode} onChange={setInterfaceMode} />
+        </div>
         {error && (
           <div className="flex items-center justify-between rounded-md border border-rose-600 bg-rose-900/60 px-4 py-2 text-sm">
             <span>{error}</span>
@@ -55,29 +99,7 @@ export const App: React.FC = () => {
             </Button>
           </div>
         )}
-        <Table
-          game={game}
-          coachMode={coachMode}
-          actions={{
-            sit,
-            leave,
-            addChip,
-            removeChipValue,
-            removeTopChip,
-            deal,
-            playerHit,
-            playerStand,
-            playerDouble,
-            playerSplit,
-            playerSurrender,
-            takeInsurance,
-            declineInsurance,
-            finishInsurance,
-            playDealer,
-            nextRound
-          }}
-          onCoachModeChange={setCoachMode}
-        />
+        {interfaceMode === "mobile" ? mobileView : classicView}
       </div>
     </main>
   );

--- a/src/ui/InterfaceModeToggle.tsx
+++ b/src/ui/InterfaceModeToggle.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Button } from "../components/ui/button";
+import type { InterfaceMode } from "./interfaceMode";
+import { cn } from "../utils/cn";
+
+interface InterfaceModeToggleProps {
+  mode: InterfaceMode;
+  onChange: (mode: InterfaceMode) => void;
+}
+
+const options: { value: InterfaceMode; label: string }[] = [
+  { value: "classic", label: "Classic UI" },
+  { value: "mobile", label: "Mobile UI" }
+];
+
+export const InterfaceModeToggle: React.FC<InterfaceModeToggleProps> = ({ mode, onChange }) => (
+  <div className="inline-flex items-center gap-1 rounded-full border border-[#c8a24a]/50 bg-[#0f3126]/80 p-1 text-xs shadow-[0_12px_28px_rgba(0,0,0,0.45)] backdrop-blur">
+    {options.map((option) => {
+      const isActive = option.value === mode;
+      return (
+        <Button
+          key={option.value}
+          size="sm"
+          variant="ghost"
+          className={cn(
+            "h-7 rounded-full px-3 text-[11px] font-semibold uppercase tracking-[0.3em] transition",
+            isActive
+              ? "bg-emerald-500 text-emerald-950 hover:bg-emerald-400"
+              : "text-emerald-200 hover:bg-emerald-800/60"
+          )}
+          aria-pressed={isActive}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </Button>
+      );
+    })}
+  </div>
+);

--- a/src/ui/interfaceMode.ts
+++ b/src/ui/interfaceMode.ts
@@ -1,0 +1,81 @@
+import React from "react";
+
+export type InterfaceMode = "classic" | "mobile";
+
+const DEFAULT_MODE: InterfaceMode = "classic";
+const STORAGE_KEY = "blackjack.interfaceMode";
+const QUERY_KEY = "ui";
+
+const isInterfaceMode = (value: string | null): value is InterfaceMode =>
+  value === "classic" || value === "mobile";
+
+const readFromStorage = (): InterfaceMode | null => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return isInterfaceMode(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+const persistMode = (mode: InterfaceMode): void => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // ignore write errors
+  }
+};
+
+const resolveInitialMode = (): InterfaceMode => {
+  if (typeof window === "undefined") {
+    return DEFAULT_MODE;
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const queryValue = params.get(QUERY_KEY);
+    if (isInterfaceMode(queryValue)) {
+      persistMode(queryValue);
+      return queryValue;
+    }
+  } catch {
+    // ignore query parsing issues
+  }
+  const stored = readFromStorage();
+  if (stored) {
+    return stored;
+  }
+  persistMode(DEFAULT_MODE);
+  return DEFAULT_MODE;
+};
+
+const updateQueryParam = (mode: InterfaceMode): void => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    params.set(QUERY_KEY, mode);
+    const search = params.toString();
+    const nextUrl = `${window.location.pathname}${search ? `?${search}` : ""}${window.location.hash}`;
+    window.history.replaceState(null, "", nextUrl);
+  } catch {
+    // ignore history errors
+  }
+};
+
+export const useInterfaceMode = (): [InterfaceMode, React.Dispatch<React.SetStateAction<InterfaceMode>>] => {
+  const [mode, setMode] = React.useState<InterfaceMode>(() => resolveInitialMode());
+
+  React.useEffect(() => {
+    persistMode(mode);
+    updateQueryParam(mode);
+  }, [mode]);
+
+  return [mode, setMode];
+};


### PR DESCRIPTION
## Summary
- add a mobile-first Blackjack shell with sticky top bar, dealer/player panels, and responsive chip/action controls
- wire a UI mode toggle and persistence layer to switch between classic and mobile layouts
- surface insurance and result banner flows tailored for the single-seat mobile experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53c0e74f88329b54e527214f59674