### PR TITLE
feat: add NoirJack skin

### DIFF
--- a/src/components/UIModeToggle.tsx
+++ b/src/components/UIModeToggle.tsx
@@ -16,15 +16,15 @@ export const UIModeToggle: React.FC<UIModeToggleProps> = ({ mode, onChange }) =>
   );
 
   return (
-    <div className="inline-flex rounded-full border border-emerald-700 bg-emerald-900/60 p-1 text-xs text-emerald-200 shadow"> 
+    <div className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-black/40 p-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/70 shadow-lg backdrop-blur">
       <button
         type="button"
         onClick={handleSelect("classic")}
         className={cn(
-          "rounded-full px-3 py-1 font-semibold uppercase tracking-[0.2em] transition",
+          "rounded-full px-3 py-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#E9C46A]",
           mode === "classic"
-            ? "bg-emerald-600 text-emerald-50 shadow-inner"
-            : "text-emerald-200 hover:text-emerald-50"
+            ? "bg-white/20 text-white shadow-inner"
+            : "text-white/70 hover:text-white"
         )}
         aria-pressed={mode === "classic"}
         aria-label="Switch to classic table UI"
@@ -33,17 +33,17 @@ export const UIModeToggle: React.FC<UIModeToggleProps> = ({ mode, onChange }) =>
       </button>
       <button
         type="button"
-        onClick={handleSelect("mobile")}
+        onClick={handleSelect("noirjack")}
         className={cn(
-          "rounded-full px-3 py-1 font-semibold uppercase tracking-[0.2em] transition",
-          mode === "mobile"
-            ? "bg-emerald-600 text-emerald-50 shadow-inner"
-            : "text-emerald-200 hover:text-emerald-50"
+          "rounded-full px-3 py-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#E9C46A]",
+          mode === "noirjack"
+            ? "bg-white/20 text-white shadow-inner"
+            : "text-white/70 hover:text-white"
         )}
-        aria-pressed={mode === "mobile"}
-        aria-label="Switch to mobile-first UI"
+        aria-pressed={mode === "noirjack"}
+        aria-label="Switch to NoirJack UI"
       >
-        Mobile
+        NoirJack
       </button>
     </div>
   );

--- a/src/components/mobile/PlayerHandView.tsx
+++ b/src/components/mobile/PlayerHandView.tsx
@@ -33,22 +33,23 @@ export const PlayerHandView: React.FC<PlayerHandViewProps> = ({ seat, activeHand
   const [focusedHandId, setFocusedHandId] = React.useState<string | null>(null);
 
   React.useEffect(() => {
+    const seatHands = seat?.hands ?? [];
     if (!focusedHandId) {
       if (activeHandId) {
         setFocusedHandId(activeHandId);
         return;
       }
-      if (hands.length > 0) {
-        setFocusedHandId(hands[0].id);
+      if (seatHands.length > 0) {
+        setFocusedHandId(seatHands[0].id);
       }
     }
-  }, [activeHandId, hands, focusedHandId]);
+  }, [activeHandId, focusedHandId, seat]);
 
   React.useEffect(() => {
     if (activeHandId && focusedHandId !== activeHandId) {
       setFocusedHandId(activeHandId);
     }
-  }, [activeHandId, focusedHandId]);
+  }, [activeHandId, focusedHandId, seat]);
 
   const focusedHand = hands.find((hand) => hand.id === focusedHandId) ?? hands[0];
 

--- a/src/components/noirjack/Card.tsx
+++ b/src/components/noirjack/Card.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import type { Card } from "../../engine/types";
+import { Club, Diamond, Heart, Spade } from "lucide-react";
+
+interface NoirJackCardProps {
+  card: Card;
+  faceDown?: boolean;
+  width: number;
+  height: number;
+  index?: number;
+}
+
+const SUIT_META: Record<string, { Icon: React.ComponentType<{ size?: number; strokeWidth?: number }>; color: string }> = {
+  "♠": { Icon: Spade, color: "#111827" },
+  "♣": { Icon: Club, color: "#111827" },
+  "♥": { Icon: Heart, color: "#b91c1c" },
+  "♦": { Icon: Diamond, color: "#b91c1c" }
+};
+
+const rankDisplay = (rank: string): string => {
+  if (rank === "10") {
+    return rank;
+  }
+  return rank.toUpperCase();
+};
+
+export const NoirJackCard: React.FC<NoirJackCardProps> = ({ card, faceDown = false, width, height, index = 0 }) => {
+  const meta = SUIT_META[card.suit] ?? SUIT_META["♠"];
+  const displayRank = rankDisplay(card.rank);
+  const shellStyle = React.useMemo(
+    () => ({ width, height, "--deal-index": index } as React.CSSProperties),
+    [width, height, index]
+  );
+
+  return (
+    <div className="nj-card-shell" style={shellStyle} aria-hidden={false}>
+      <div className={`nj-card ${faceDown ? "is-face-down" : "is-face-up"}`}>
+        <div className="nj-card-side nj-card-face" aria-hidden={faceDown}>
+          <div className="nj-card-rank" style={{ color: meta.color }}>
+            <span>{displayRank}</span>
+            <meta.Icon size={18} strokeWidth={1.6} />
+          </div>
+          <div className="nj-card-rank-bottom" style={{ color: meta.color }}>
+            <span>{displayRank}</span>
+            <meta.Icon size={18} strokeWidth={1.6} />
+          </div>
+          <div className="nj-card-suit" aria-hidden>
+            <meta.Icon size={44} strokeWidth={1.3} color={meta.color} />
+          </div>
+        </div>
+        <div className="nj-card-side nj-card-back" aria-hidden={!faceDown} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/noirjack/CardFan.tsx
+++ b/src/components/noirjack/CardFan.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import type { Card } from "../../engine/types";
+import { NoirJackCard } from "./Card";
+import { useCardMetrics } from "./hooks";
+
+interface CardFanProps {
+  cards: Card[];
+  faceDownIndexes?: number[];
+  containerWidth: number;
+}
+
+const toSet = (indexes?: number[]): Set<number> => {
+  if (!indexes || indexes.length === 0) {
+    return new Set();
+  }
+  return new Set(indexes);
+};
+
+export const NoirJackCardFan: React.FC<CardFanProps> = ({ cards, faceDownIndexes, containerWidth }) => {
+  const metrics = useCardMetrics(containerWidth);
+  const overlapBase = Math.max(12, Math.round(metrics.width * (cards.length > 5 ? 0.28 : 0.35)));
+  const totalWidth = metrics.width + (cards.length - 1) * (metrics.width - overlapBase);
+  const effectiveWidth = containerWidth > 0 ? Math.min(totalWidth, containerWidth) : totalWidth;
+  const shrinkRatio = totalWidth > effectiveWidth ? effectiveWidth / totalWidth : 1;
+  const width = Math.round(metrics.width * shrinkRatio);
+  const height = Math.round(metrics.height * shrinkRatio);
+  const overlap = Math.max(12, Math.round(overlapBase * shrinkRatio));
+  const stackWidth = width + (cards.length - 1) * (width - overlap);
+  const baseContainer = containerWidth > 0 ? containerWidth : stackWidth;
+  const startX = (baseContainer - stackWidth) / 2;
+  const faceDown = React.useMemo(() => toSet(faceDownIndexes), [faceDownIndexes]);
+
+  return (
+    <div className="relative" style={{ height, width: containerWidth || stackWidth }}>
+      {cards.map((card, index) => {
+        const left = startX + index * (width - overlap);
+        const rotation = (index - (cards.length - 1) / 2) * 2.4;
+        return (
+          <div
+            key={`${card.rank}-${card.suit}-${index}`}
+            className="absolute top-0"
+            style={{
+              width,
+              height,
+              left,
+              transform: `rotate(${rotation}deg)`,
+              transformOrigin: "center bottom",
+              zIndex: index + 1
+            }}
+          >
+            <NoirJackCard card={card} faceDown={faceDown.has(index)} width={width} height={height} index={index} />
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/noirjack/Controls.tsx
+++ b/src/components/noirjack/Controls.tsx
@@ -1,0 +1,330 @@
+import React from "react";
+import type { CoachMode } from "../../store/useGameStore";
+import type { ChipDenomination } from "../../theme/palette";
+import { formatCurrency } from "../../utils/currency";
+import type { Action } from "../../utils/basicStrategy";
+import { cn } from "../../utils/cn";
+import { usePrefersReducedMotion } from "./hooks";
+
+const CHIP_VALUES: ChipDenomination[] = [1, 5, 25, 100, 500];
+
+type ActionAvailability = {
+  hit: boolean;
+  stand: boolean;
+  double: boolean;
+  split: boolean;
+  surrender: boolean;
+  deal: boolean;
+  finishInsurance: boolean;
+  playDealer: boolean;
+  nextRound: boolean;
+};
+
+interface ChipTrayProps {
+  activeChip: ChipDenomination;
+  onSelect: (value: ChipDenomination) => void;
+  onAdd: (value: ChipDenomination) => void;
+  onRemove: (value: ChipDenomination) => void;
+  onRemoveTop: () => void;
+  disabled: boolean;
+  bankroll: number;
+  bet: number;
+}
+
+const ChipTray: React.FC<ChipTrayProps> = ({
+  activeChip,
+  onSelect,
+  onAdd,
+  onRemove,
+  onRemoveTop,
+  disabled,
+  bankroll,
+  bet
+}) => {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [bounceChip, setBounceChip] = React.useState<ChipDenomination | null>(null);
+
+  const triggerBounce = (value: ChipDenomination) => {
+    if (prefersReducedMotion) {
+      return;
+    }
+    setBounceChip(value);
+    window.setTimeout(() => {
+      setBounceChip((current) => (current === value ? null : current));
+    }, 220);
+  };
+
+  const handleSelect = (value: ChipDenomination) => {
+    onSelect(value);
+    if (!disabled) {
+      onAdd(value);
+      triggerBounce(value);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between text-[0.62rem] uppercase tracking-[0.32em] text-[var(--nj-text-muted)]">
+        <span>Chips</span>
+        <span>
+          Bet <span className="text-[var(--nj-text)]">{formatCurrency(bet)}</span>
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        {CHIP_VALUES.map((value) => {
+          const isSelected = activeChip === value;
+          const bounce = bounceChip === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              className={cn(
+                "nj-chip",
+                isSelected ? "ring-2 ring-[rgba(233,196,106,0.6)]" : undefined,
+                bounce ? "nj-chip-bounce" : undefined
+              )}
+              onClick={() => handleSelect(value)}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                if (!disabled) {
+                  onRemove(value);
+                }
+              }}
+              data-selected={isSelected}
+              aria-label={`Select ${value} chip`}
+            >
+              {value}
+            </button>
+          );
+        })}
+      </div>
+      <div className="grid grid-cols-3 gap-2 text-[0.62rem] uppercase tracking-[0.28em]">
+        <button
+          type="button"
+          className="nj-btn col-span-2"
+          onClick={() => onAdd(activeChip)}
+          disabled={disabled}
+        >
+          Add {activeChip}
+        </button>
+        <button type="button" className="nj-btn" onClick={() => onRemove(activeChip)} disabled={disabled}>
+          Remove
+        </button>
+        <button type="button" className="nj-btn col-span-3" onClick={onRemoveTop} disabled={disabled}>
+          Undo Last
+        </button>
+      </div>
+      <div className="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(10,15,20,0.35)] px-4 py-3 text-[0.62rem] uppercase tracking-[0.32em] text-[var(--nj-text-muted)]">
+        <div className="flex items-center justify-between">
+          <span>Bankroll</span>
+          <span className="text-[var(--nj-text)]">{formatCurrency(bankroll)}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface ActionButtonsProps {
+  availability: ActionAvailability;
+  onDeal: () => void;
+  onFinishInsurance: () => void;
+  onPlayDealer: () => void;
+  onNextRound: () => void;
+  onHit: () => void;
+  onStand: () => void;
+  onDouble: () => void;
+  onSplit: () => void;
+  onSurrender: () => void;
+  highlightedAction?: Action | null;
+}
+
+const highlightAttr = (highlighted: Action | null, action: Action): string | undefined => {
+  if (!highlighted) {
+    return undefined;
+  }
+  return highlighted === action ? "best" : undefined;
+};
+
+const ActionButtons: React.FC<ActionButtonsProps> = ({
+  availability,
+  onDeal,
+  onFinishInsurance,
+  onPlayDealer,
+  onNextRound,
+  onHit,
+  onStand,
+  onDouble,
+  onSplit,
+  onSurrender,
+  highlightedAction
+}) => {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-3">
+        <button
+          type="button"
+          className="nj-btn nj-btn-primary h-16 text-base uppercase tracking-[0.32em]"
+          onClick={onHit}
+          disabled={!availability.hit}
+          data-coach={highlightAttr(highlightedAction, "hit")}
+        >
+          Hit
+        </button>
+        <button
+          type="button"
+          className="nj-btn h-16 text-base uppercase tracking-[0.32em]"
+          onClick={onStand}
+          disabled={!availability.stand}
+          data-coach={highlightAttr(highlightedAction, "stand")}
+        >
+          Stand
+        </button>
+      </div>
+      <div className="grid grid-cols-3 gap-3 text-[0.62rem] uppercase tracking-[0.28em]">
+        <button
+          type="button"
+          className="nj-btn"
+          onClick={onDouble}
+          disabled={!availability.double}
+          data-coach={highlightAttr(highlightedAction, "double")}
+        >
+          Double
+        </button>
+        <button
+          type="button"
+          className="nj-btn"
+          onClick={onSplit}
+          disabled={!availability.split}
+          data-coach={highlightAttr(highlightedAction, "split")}
+        >
+          Split
+        </button>
+        <button
+          type="button"
+          className="nj-btn"
+          onClick={onSurrender}
+          disabled={!availability.surrender}
+          data-coach={highlightAttr(highlightedAction, "surrender")}
+        >
+          Surrender
+        </button>
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-[0.62rem] uppercase tracking-[0.28em] md:grid-cols-4">
+        <button type="button" className="nj-btn" onClick={onDeal} disabled={!availability.deal}>
+          Deal
+        </button>
+        <button type="button" className="nj-btn" onClick={onFinishInsurance} disabled={!availability.finishInsurance}>
+          Finish Insurance
+        </button>
+        <button type="button" className="nj-btn" onClick={onPlayDealer} disabled={!availability.playDealer}>
+          Play Dealer
+        </button>
+        <button type="button" className="nj-btn" onClick={onNextRound} disabled={!availability.nextRound}>
+          Next Round
+        </button>
+      </div>
+    </div>
+  );
+};
+
+interface ControlsZoneProps {
+  activeChip: ChipDenomination;
+  onSelectChip: (value: ChipDenomination) => void;
+  onAddChip: (value: ChipDenomination) => void;
+  onRemoveChip: (value: ChipDenomination) => void;
+  onRemoveTopChip: () => void;
+  chipDisabled: boolean;
+  availability: ActionAvailability;
+  onDeal: () => void;
+  onFinishInsurance: () => void;
+  onPlayDealer: () => void;
+  onNextRound: () => void;
+  onHit: () => void;
+  onStand: () => void;
+  onDouble: () => void;
+  onSplit: () => void;
+  onSurrender: () => void;
+  highlightedAction?: Action | null;
+  coachMode: CoachMode;
+  coachMessage?: { tone: "correct" | "better"; text: string } | null;
+  bankroll: number;
+  bet: number;
+}
+
+export const ControlsZone: React.FC<ControlsZoneProps> = ({
+  activeChip,
+  onSelectChip,
+  onAddChip,
+  onRemoveChip,
+  onRemoveTopChip,
+  chipDisabled,
+  availability,
+  onDeal,
+  onFinishInsurance,
+  onPlayDealer,
+  onNextRound,
+  onHit,
+  onStand,
+  onDouble,
+  onSplit,
+  onSurrender,
+  highlightedAction,
+  coachMode,
+  coachMessage,
+  bankroll,
+  bet
+}) => {
+  return (
+    <section className="nj-sticky-bottom">
+      <div className="flex flex-col gap-4 rounded-[24px] border border-[rgba(255,255,255,0.08)] bg-[rgba(4,12,10,0.75)] px-4 py-4 backdrop-blur-lg sm:flex-row sm:items-start sm:justify-between">
+        <div className="sm:w-[260px]">
+          <ChipTray
+            activeChip={activeChip}
+            onSelect={onSelectChip}
+            onAdd={onAddChip}
+            onRemove={onRemoveChip}
+            onRemoveTop={onRemoveTopChip}
+            disabled={chipDisabled}
+            bankroll={bankroll}
+            bet={bet}
+          />
+        </div>
+        <div className="flex-1">
+          <div className="flex flex-col gap-4 rounded-[20px] border border-[rgba(255,255,255,0.08)] bg-[rgba(10,15,20,0.35)] p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2 text-[0.62rem] uppercase tracking-[0.28em] text-[var(--nj-text-muted)]">
+              <span>Coach {coachMode === "off" ? "Off" : coachMode === "live" ? "Live" : "Feedback"}</span>
+              <span>Bankroll {formatCurrency(bankroll)}</span>
+            </div>
+            {coachMessage ? (
+              <div
+                className={cn(
+                  "rounded-2xl px-3 py-2 text-[0.62rem] uppercase tracking-[0.28em]",
+                  coachMessage.tone === "correct"
+                    ? "border border-[rgba(34,197,94,0.45)] bg-[rgba(34,197,94,0.15)] text-[var(--nj-text)]"
+                    : "border border-[rgba(233,196,106,0.45)] bg-[rgba(233,196,106,0.12)] text-[var(--nj-gold)]"
+                )}
+              >
+                {coachMessage.text}
+              </div>
+            ) : null}
+            <ActionButtons
+              availability={availability}
+              onDeal={onDeal}
+              onFinishInsurance={onFinishInsurance}
+              onPlayDealer={onPlayDealer}
+              onNextRound={onNextRound}
+              onHit={onHit}
+              onStand={onStand}
+              onDouble={onDouble}
+              onSplit={onSplit}
+              onSurrender={onSurrender}
+              highlightedAction={highlightedAction}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export type { ActionAvailability };

--- a/src/components/noirjack/DealerZone.tsx
+++ b/src/components/noirjack/DealerZone.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import type { Dealer, Phase } from "../../engine/types";
+import { bestTotal, getHandTotals, isBust } from "../../engine/totals";
+import { NoirJackCardFan } from "./CardFan";
+import { useResizeObserver } from "./hooks";
+
+interface DealerZoneProps {
+  dealer: Dealer;
+  phase: Phase;
+  insuranceMessage?: string | null;
+}
+
+const dealerLabel = (dealer: Dealer, phase: Phase): string => {
+  const totals = getHandTotals(dealer.hand);
+  if (phase === "playerActions" || phase === "dealerPlay" || phase === "settlement") {
+    if (isBust(dealer.hand)) {
+      return "BUST";
+    }
+    if (totals.soft && totals.soft !== totals.hard) {
+      return `${bestTotal(dealer.hand)} / ${totals.hard}`;
+    }
+    return `${bestTotal(dealer.hand)}`;
+  }
+  if (dealer.upcard) {
+    const value = dealer.upcard.rank === "10" ? "10" : dealer.upcard.rank;
+    return `Showing ${value}`;
+  }
+  return "Waiting";
+};
+
+const faceDownCards = (dealer: Dealer, phase: Phase): number[] => {
+  if (phase === "playerActions" || phase === "dealerPlay" || phase === "settlement") {
+    return [];
+  }
+  if (dealer.hand.cards.length > 1) {
+    return [dealer.hand.cards.length - 1];
+  }
+  return [];
+};
+
+export const DealerZone: React.FC<DealerZoneProps> = ({ dealer, phase, insuranceMessage }) => {
+  const [ref, width] = useResizeObserver<HTMLDivElement>();
+  const label = dealerLabel(dealer, phase);
+  const faceDown = React.useMemo(() => faceDownCards(dealer, phase), [dealer, phase]);
+
+  return (
+    <section ref={ref} className="nj-glass flex flex-col items-center gap-3 px-4 py-5 text-center">
+      <NoirJackCardFan cards={dealer.hand.cards} faceDownIndexes={faceDown} containerWidth={width} />
+      <div className="text-[0.68rem] uppercase tracking-[0.38em] text-[var(--nj-text-muted)]">
+        <span className="font-cinzel text-sm text-[var(--nj-text)]">Dealer</span>
+        <span className="ml-2 text-[var(--nj-text-muted)]">· {label}</span>
+      </div>
+      {insuranceMessage ? (
+        <div className="rounded-full border border-[rgba(233,196,106,0.25)] bg-[rgba(233,196,106,0.08)] px-3 py-1 text-[0.65rem] uppercase tracking-[0.32em] text-[var(--nj-gold)]">
+          {insuranceMessage}
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/src/components/noirjack/InsuranceSheet.tsx
+++ b/src/components/noirjack/InsuranceSheet.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { formatCurrency } from "../../utils/currency";
+
+interface InsuranceSheetProps {
+  open: boolean;
+  amount: number;
+  onTake: () => void;
+  onSkip: () => void;
+}
+
+export const InsuranceSheet: React.FC<InsuranceSheetProps> = ({ open, amount, onTake, onSkip }) => {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-end justify-center bg-black/40 backdrop-blur-sm">
+      <div
+        className="nj-glass w-full max-w-lg rounded-t-[28px] border border-[rgba(233,196,106,0.25)] bg-[rgba(6,20,16,0.9)] px-5 pb-6 pt-6 text-[var(--nj-text)] shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Insurance offer"
+        style={{ paddingBottom: `max(env(safe-area-inset-bottom), 24px)` }}
+      >
+        <p className="text-[0.62rem] uppercase tracking-[0.32em] text-[var(--nj-text-muted)]">Insurance Offer</p>
+        <h2 className="mt-3 text-lg font-semibold tracking-[0.06em]">Dealer shows Ace — take insurance for {formatCurrency(amount)}?</h2>
+        <div className="mt-5 grid grid-cols-2 gap-3">
+          <button type="button" className="nj-btn nj-btn-primary h-14 text-base uppercase tracking-[0.3em]" onClick={onTake}>
+            Take Insurance
+          </button>
+          <button type="button" className="nj-btn h-14 text-base uppercase tracking-[0.3em]" onClick={onSkip}>
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/noirjack/NoirJackTable.tsx
+++ b/src/components/noirjack/NoirJackTable.tsx
@@ -1,0 +1,478 @@
+import React from "react";
+import type { GameState, Hand } from "../../engine/types";
+import { PRIMARY_SEAT_INDEX, filterSeatsForMode } from "../../ui/config";
+import type { CoachMode } from "../../store/useGameStore";
+import type { ChipDenomination } from "../../theme/palette";
+import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
+import { getRecommendation, type Action, type PlayerContext } from "../../utils/basicStrategy";
+import { TopBar } from "./TopBar";
+import { DealerZone } from "./DealerZone";
+import { PlayerZone } from "./PlayerZone";
+import { ControlsZone, type ActionAvailability } from "./Controls";
+import { InsuranceSheet } from "./InsuranceSheet";
+import { ResultBanner, type ResultTone } from "./ResultBanner";
+import { usePrefersReducedMotion } from "./hooks";
+import { formatCurrency } from "../../utils/currency";
+
+interface NoirJackTableProps {
+  game: GameState;
+  coachMode: CoachMode;
+  actions: {
+    sit: (seatIndex: number) => void;
+    leave: (seatIndex: number) => void;
+    addChip: (seatIndex: number, denom: number) => void;
+    removeChipValue: (seatIndex: number, denom: number) => void;
+    removeTopChip: (seatIndex: number) => void;
+    deal: () => void;
+    playerHit: () => void;
+    playerStand: () => void;
+    playerDouble: () => void;
+    playerSplit: () => void;
+    playerSurrender: () => void;
+    takeInsurance: (seatIndex: number, handId: string, amount: number) => void;
+    declineInsurance: (seatIndex: number, handId: string) => void;
+    finishInsurance: () => void;
+    playDealer: () => void;
+    nextRound: () => void;
+  };
+  onCoachModeChange: (mode: CoachMode) => void;
+  error: string | null;
+  onDismissError: () => void;
+  modeToggle: React.ReactNode;
+}
+
+const hasReadySeat = (game: GameState): boolean => {
+  const seat = game.seats[PRIMARY_SEAT_INDEX];
+  if (!seat?.occupied) {
+    return false;
+  }
+  if (seat.baseBet < game.rules.minBet || seat.baseBet > game.rules.maxBet) {
+    return false;
+  }
+  return seat.baseBet > 0 && seat.baseBet <= game.bankroll;
+};
+
+const findActiveHand = (game: GameState): Hand | null => {
+  if (!game.activeHandId) {
+    return null;
+  }
+  for (const seat of filterSeatsForMode(game.seats)) {
+    const hand = seat.hands.find((candidate) => candidate.id === game.activeHandId);
+    if (hand) {
+      return hand;
+    }
+  }
+  return null;
+};
+
+const parseResultMessage = (messages: string[]): { tone: ResultTone; message: string } | null => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message.startsWith("Seat 1")) {
+      continue;
+    }
+    if (message.includes("wins")) {
+      const amountMatch = message.match(/€([0-9.,]+)/);
+      const amount = amountMatch ? Number.parseFloat(amountMatch[1].replace(",", "")) : null;
+      return {
+        tone: "win",
+        message: amount ? `Win +€${amount.toFixed(2)}` : "Win"
+      };
+    }
+    if (message.includes("push")) {
+      return { tone: "push", message: "Push" };
+    }
+    if (message.includes("loses")) {
+      const amountMatch = message.match(/€([0-9.,]+)/);
+      const amount = amountMatch ? Number.parseFloat(amountMatch[1].replace(",", "")) : null;
+      return {
+        tone: "lose",
+        message: amount ? `Lose -€${amount.toFixed(2)}` : "Lose"
+      };
+    }
+  }
+  return null;
+};
+
+const buildCoachMessage = (action: Action, correct: boolean): string => {
+  const label = action.charAt(0).toUpperCase() + action.slice(1);
+  return correct ? `Nice! ${label} was right.` : `Try ${label} next time.`;
+};
+
+const usePrevious = <T,>(value: T): T | undefined => {
+  const ref = React.useRef<T>();
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+};
+
+const penetrationPercentage = (game: GameState): string => {
+  const totalCards = game.shoe.cards.length + game.shoe.discard.length;
+  if (totalCards === 0) {
+    return "0%";
+  }
+  const penetration = game.shoe.discard.length / totalCards;
+  return `${Math.round(penetration * 100)}%`;
+};
+
+export const NoirJackTable: React.FC<NoirJackTableProps> = ({
+  game,
+  coachMode,
+  actions,
+  onCoachModeChange,
+  error,
+  onDismissError,
+  modeToggle
+}) => {
+  const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
+  const [coachMessage, setCoachMessage] = React.useState<{ tone: "correct" | "better"; text: string } | null>(null);
+  const [flashAction, setFlashAction] = React.useState<Action | null>(null);
+  const [result, setResult] = React.useState<{ tone: ResultTone; message: string } | null>(null);
+  const [srAnnouncement, setSrAnnouncement] = React.useState<string>("");
+  const messageTimer = React.useRef<number | null>(null);
+  const highlightTimer = React.useRef<number | null>(null);
+  const resultTimer = React.useRef<number | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  React.useEffect(() => {
+    if (messageTimer.current) {
+      window.clearTimeout(messageTimer.current);
+      messageTimer.current = null;
+    }
+    if (coachMessage) {
+      messageTimer.current = window.setTimeout(() => {
+        setCoachMessage(null);
+        messageTimer.current = null;
+      }, 2600);
+    }
+    return () => {
+      if (messageTimer.current) {
+        window.clearTimeout(messageTimer.current);
+      }
+    };
+  }, [coachMessage]);
+
+  React.useEffect(() => {
+    return () => {
+      if (highlightTimer.current) {
+        window.clearTimeout(highlightTimer.current);
+      }
+      if (resultTimer.current) {
+        window.clearTimeout(resultTimer.current);
+      }
+    };
+  }, []);
+
+  const seat = game.seats[PRIMARY_SEAT_INDEX] ?? null;
+  const activeHand = findActiveHand(game);
+
+  const actionContext = React.useMemo(() => {
+    if (!activeHand || !seat || game.phase !== "playerActions") {
+      return null;
+    }
+    return {
+      hand: activeHand,
+      hit: canHit(activeHand),
+      stand: !activeHand.isResolved,
+      double: canDouble(activeHand, game.rules) && game.bankroll >= activeHand.bet,
+      split: canSplit(activeHand, seat, game.rules) && game.bankroll >= activeHand.bet,
+      surrender: canSurrender(activeHand, game.rules)
+    };
+  }, [activeHand, game.bankroll, game.phase, game.rules, seat]);
+
+  const dealerUpcard = game.dealer.upcard;
+
+  const recommendation = React.useMemo(() => {
+    if (!actionContext || !dealerUpcard) {
+      return null;
+    }
+    const rank = dealerUpcard.rank as PlayerContext["dealerUpcard"]["rank"];
+    const context: PlayerContext = {
+      dealerUpcard: {
+        rank,
+        value10: dealerUpcard.rank === "10" || dealerUpcard.rank === "J" || dealerUpcard.rank === "Q" || dealerUpcard.rank === "K"
+      },
+      cards: actionContext.hand.cards.map((card) => ({ rank: card.rank })),
+      isInitialTwoCards: actionContext.hand.cards.length === 2 && !actionContext.hand.hasActed,
+      afterSplit: Boolean(actionContext.hand.isSplitHand),
+      legal: {
+        hit: actionContext.hit,
+        stand: actionContext.stand,
+        double: actionContext.double,
+        split: actionContext.split,
+        surrender: actionContext.surrender
+      }
+    };
+    return getRecommendation(context, game.rules);
+  }, [actionContext, dealerUpcard, game.rules]);
+
+  const recommendedAction = React.useMemo<Action | null>(() => {
+    if (!recommendation || !actionContext) {
+      return null;
+    }
+    const isLegal = (action: Action | undefined): boolean => {
+      if (!action) {
+        return false;
+      }
+      switch (action) {
+        case "hit":
+          return actionContext.hit;
+        case "stand":
+          return actionContext.stand;
+        case "double":
+          return actionContext.double;
+        case "split":
+          return actionContext.split;
+        case "surrender":
+          return actionContext.surrender;
+        default:
+          return false;
+      }
+    };
+    if (isLegal(recommendation.best)) {
+      return recommendation.best;
+    }
+    if (recommendation.fallback && isLegal(recommendation.fallback)) {
+      return recommendation.fallback;
+    }
+    return null;
+  }, [actionContext, recommendation]);
+
+  const highlightedAction = React.useMemo<Action | null>(() => {
+    if (flashAction) {
+      return flashAction;
+    }
+    if (coachMode === "live") {
+      return recommendedAction;
+    }
+    return null;
+  }, [coachMode, flashAction, recommendedAction]);
+
+  const vibrate = React.useCallback(() => {
+    if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
+      navigator.vibrate(prefersReducedMotion ? 0 : 12);
+    }
+  }, [prefersReducedMotion]);
+
+  const triggerFeedback = React.useCallback(
+    (action: Action, callback: () => void) => {
+      vibrate();
+      if (coachMode === "feedback" && recommendedAction) {
+        const correct = action === recommendedAction;
+        setCoachMessage({ tone: correct ? "correct" : "better", text: buildCoachMessage(recommendedAction, correct) });
+        if (!correct) {
+          setFlashAction(recommendedAction);
+          if (highlightTimer.current) {
+            window.clearTimeout(highlightTimer.current);
+          }
+          highlightTimer.current = window.setTimeout(() => {
+            setFlashAction(null);
+            highlightTimer.current = null;
+          }, 1000);
+        } else {
+          setFlashAction(null);
+        }
+      }
+      callback();
+    },
+    [coachMode, recommendedAction, vibrate]
+  );
+
+  const handleHit = React.useCallback(() => triggerFeedback("hit", actions.playerHit), [actions.playerHit, triggerFeedback]);
+  const handleStand = React.useCallback(() => triggerFeedback("stand", actions.playerStand), [actions.playerStand, triggerFeedback]);
+  const handleDouble = React.useCallback(() => triggerFeedback("double", actions.playerDouble), [actions.playerDouble, triggerFeedback]);
+  const handleSplit = React.useCallback(() => triggerFeedback("split", actions.playerSplit), [actions.playerSplit, triggerFeedback]);
+  const handleSurrender = React.useCallback(
+    () => triggerFeedback("surrender", actions.playerSurrender),
+    [actions.playerSurrender, triggerFeedback]
+  );
+
+  const availability = React.useMemo<ActionAvailability>(() => ({
+    hit: Boolean(actionContext?.hit),
+    stand: Boolean(actionContext?.stand),
+    double: Boolean(actionContext?.double),
+    split: Boolean(actionContext?.split),
+    surrender: Boolean(actionContext?.surrender),
+    deal: game.phase === "betting" && hasReadySeat(game),
+    finishInsurance: game.phase === "insurance",
+    playDealer: game.phase === "dealerPlay",
+    nextRound: game.phase === "settlement"
+  }), [actionContext, game]);
+
+  const handleAddChip = React.useCallback(
+    (value: ChipDenomination) => {
+      if (game.phase !== "betting" || !seat) {
+        return;
+      }
+      const nextBet = seat.baseBet + value;
+      if (nextBet > game.rules.maxBet || nextBet > game.bankroll) {
+        return;
+      }
+      actions.addChip(PRIMARY_SEAT_INDEX, value);
+    },
+    [actions, game.bankroll, game.phase, game.rules.maxBet, seat]
+  );
+
+  const handleRemoveChipValue = React.useCallback(
+    (value: ChipDenomination) => {
+      if (game.phase !== "betting" || !seat || seat.baseBet <= 0) {
+        return;
+      }
+      actions.removeChipValue(PRIMARY_SEAT_INDEX, value);
+    },
+    [actions, game.phase, seat]
+  );
+
+  const handleRemoveTopChip = React.useCallback(() => {
+    if (game.phase !== "betting" || !seat || seat.baseBet <= 0) {
+      return;
+    }
+    actions.removeTopChip(PRIMARY_SEAT_INDEX);
+  }, [actions, game.phase, seat]);
+
+  const [insuranceHandId, insuranceAmount] = React.useMemo(() => {
+    if (game.phase !== "insurance" || !seat) {
+      return [null, 0] as const;
+    }
+    const hand = seat.hands.find((candidate) => candidate.insuranceBet === undefined && !candidate.isResolved);
+    if (!hand) {
+      return [null, 0] as const;
+    }
+    return [hand.id, Math.min(hand.bet / 2, game.bankroll)];
+  }, [game.bankroll, game.phase, seat]);
+
+  const showInsuranceSheet = Boolean(insuranceHandId && game.awaitingInsuranceResolution);
+
+  const takeInsurance = React.useCallback(() => {
+    if (!insuranceHandId) {
+      return;
+    }
+    actions.takeInsurance(PRIMARY_SEAT_INDEX, insuranceHandId, insuranceAmount);
+  }, [actions, insuranceAmount, insuranceHandId]);
+
+  const skipInsurance = React.useCallback(() => {
+    if (!insuranceHandId) {
+      return;
+    }
+    actions.declineInsurance(PRIMARY_SEAT_INDEX, insuranceHandId);
+  }, [actions, insuranceHandId]);
+
+  const prevPhase = usePrevious(game.phase);
+  const prevBankroll = usePrevious(game.bankroll);
+  const [bankrollPulse, setBankrollPulse] = React.useState<"win" | "lose" | null>(null);
+
+  React.useEffect(() => {
+    if (game.phase === "settlement" && prevPhase !== "settlement") {
+      const parsed = parseResultMessage(game.messageLog);
+      if (parsed) {
+        setResult(parsed);
+        setSrAnnouncement(parsed.message);
+        if (resultTimer.current) {
+          window.clearTimeout(resultTimer.current);
+        }
+        resultTimer.current = window.setTimeout(() => {
+          setResult(null);
+          resultTimer.current = null;
+        }, prefersReducedMotion ? 0 : 1800);
+      }
+    }
+    if (game.phase !== "settlement" && prevPhase === "settlement") {
+      setResult(null);
+    }
+  }, [game.messageLog, game.phase, prevPhase, prefersReducedMotion]);
+
+  React.useEffect(() => {
+    if (!result) {
+      setSrAnnouncement("");
+    }
+  }, [result]);
+
+  React.useEffect(() => {
+    if (prevBankroll === undefined || prevBankroll === game.bankroll) {
+      return;
+    }
+    const pulse: "win" | "lose" = game.bankroll > prevBankroll ? "win" : "lose";
+    setBankrollPulse(pulse);
+    const timeout = window.setTimeout(() => setBankrollPulse(null), prefersReducedMotion ? 0 : pulse === "win" ? 900 : 600);
+    return () => window.clearTimeout(timeout);
+  }, [game.bankroll, prevBankroll, prefersReducedMotion]);
+
+  React.useEffect(() => {
+    if (game.phase !== "settlement") {
+      setCoachMessage((current) => (coachMode === "feedback" ? current : null));
+      setFlashAction(null);
+    }
+  }, [coachMode, game.phase]);
+
+  const visibleSeats = React.useMemo(() => filterSeatsForMode(game.seats), [game.seats]);
+  const totalPendingBets = visibleSeats.reduce((sum, seatCandidate) => sum + seatCandidate.baseBet, 0);
+
+  const insuranceMessage = game.phase === "insurance" ? "Insurance available" : null;
+
+  return (
+    <main className="noirjack-theme">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 pb-16">
+        <TopBar
+          bankroll={game.bankroll}
+          pendingBet={seat?.baseBet ?? 0}
+          round={game.roundCount}
+          phase={game.phase}
+          cardsRemaining={game.shoe.cards.length}
+          discardCount={game.shoe.discard.length}
+          penetration={penetrationPercentage(game)}
+          rules={game.rules}
+          coachMode={coachMode}
+          onCoachModeChange={onCoachModeChange}
+          modeToggle={modeToggle}
+          bankrollPulse={bankrollPulse}
+        />
+        {error ? (
+          <div className="nj-glass border border-[rgba(220,38,38,0.4)] bg-[rgba(45,12,12,0.6)] px-4 py-3 text-sm text-[var(--nj-text)]">
+            <div className="flex items-center justify-between">
+              <span>{error}</span>
+              <button type="button" className="nj-btn px-3 py-1 text-[0.68rem] uppercase tracking-[0.28em]" onClick={onDismissError}>
+                Dismiss
+              </button>
+            </div>
+          </div>
+        ) : null}
+        <DealerZone dealer={game.dealer} phase={game.phase} insuranceMessage={insuranceMessage} />
+        <PlayerZone seat={seat} activeHandId={game.activeHandId} />
+        <div className="text-[0.62rem] uppercase tracking-[0.32em] text-[var(--nj-text-muted)]">
+          Pending bets {formatCurrency(totalPendingBets)}
+        </div>
+        <ControlsZone
+          activeChip={activeChip}
+          onSelectChip={setActiveChip}
+          onAddChip={handleAddChip}
+          onRemoveChip={handleRemoveChipValue}
+          onRemoveTopChip={handleRemoveTopChip}
+          chipDisabled={game.phase !== "betting"}
+          availability={availability}
+          onDeal={actions.deal}
+          onFinishInsurance={actions.finishInsurance}
+          onPlayDealer={actions.playDealer}
+          onNextRound={actions.nextRound}
+          onHit={handleHit}
+          onStand={handleStand}
+          onDouble={handleDouble}
+          onSplit={handleSplit}
+          onSurrender={handleSurrender}
+          highlightedAction={highlightedAction}
+          coachMode={coachMode}
+          coachMessage={coachMessage}
+          bankroll={game.bankroll}
+          bet={seat?.baseBet ?? 0}
+        />
+      </div>
+      {showInsuranceSheet ? (
+        <InsuranceSheet open amount={insuranceAmount} onTake={takeInsurance} onSkip={skipInsurance} />
+      ) : null}
+      {result ? <ResultBanner tone={result.tone} message={result.message} /> : null}
+      <div className="sr-announcer" aria-live="polite">
+        {srAnnouncement}
+      </div>
+    </main>
+  );
+};

--- a/src/components/noirjack/PlayerZone.tsx
+++ b/src/components/noirjack/PlayerZone.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import type { Seat } from "../../engine/types";
+import { bestTotal, getHandTotals, isBust } from "../../engine/totals";
+import { formatCurrency } from "../../utils/currency";
+import { NoirJackCardFan } from "./CardFan";
+import { useResizeObserver } from "./hooks";
+import { cn } from "../../utils/cn";
+
+interface PlayerZoneProps {
+  seat: Seat | null;
+  activeHandId: string | null;
+}
+
+const statusLabel = (hand: Seat["hands"][number]): string => {
+  if (hand.isSurrendered) {
+    return "Surrender";
+  }
+  if (isBust(hand)) {
+    return "Bust";
+  }
+  if (hand.isBlackjack) {
+    return "Blackjack";
+  }
+  if (hand.isResolved) {
+    return "Stand";
+  }
+  return "Playing";
+};
+
+export const PlayerZone: React.FC<PlayerZoneProps> = ({ seat, activeHandId }) => {
+  const hands = seat?.hands ?? [];
+  const [ref, width] = useResizeObserver<HTMLDivElement>();
+  const [focusedHandId, setFocusedHandId] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const seatHands = seat?.hands ?? [];
+    if (!focusedHandId) {
+      if (activeHandId) {
+        setFocusedHandId(activeHandId);
+        return;
+      }
+      if (seatHands.length > 0) {
+        setFocusedHandId(seatHands[0].id);
+      }
+    }
+  }, [activeHandId, focusedHandId, seat]);
+
+  React.useEffect(() => {
+    if (activeHandId && focusedHandId !== activeHandId) {
+      setFocusedHandId(activeHandId);
+    }
+  }, [activeHandId, focusedHandId, seat]);
+
+  const focusedHand = hands.find((hand) => hand.id === focusedHandId) ?? hands[0];
+  const totals = focusedHand ? getHandTotals(focusedHand) : null;
+
+  const totalDisplay = totals
+    ? isBust(focusedHand)
+      ? "Bust"
+      : totals.soft && totals.soft !== totals.hard
+        ? `${bestTotal(focusedHand)} / ${totals.hard}`
+        : `${bestTotal(focusedHand)}`
+    : "--";
+
+  return (
+    <section ref={ref} className="nj-glass flex flex-col gap-5 px-4 py-5">
+      <div className="flex flex-col items-center gap-4">
+        {focusedHand ? (
+          <NoirJackCardFan cards={focusedHand.cards} containerWidth={width} />
+        ) : (
+          <div className="flex h-36 w-full items-center justify-center text-sm text-[var(--nj-text-muted)]">
+            Place a bet to start
+          </div>
+        )}
+        <div className="w-full rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(10,15,20,0.35)] px-4 py-3">
+          <dl className="grid grid-cols-2 gap-3 text-[0.68rem] uppercase tracking-[0.32em] text-[var(--nj-text-muted)] sm:grid-cols-4">
+            <div className="flex flex-col gap-1">
+              <dt>Total</dt>
+              <dd className="text-lg font-semibold text-[var(--nj-text)]">{totalDisplay}</dd>
+            </div>
+            <div className="flex flex-col gap-1">
+              <dt>Bet</dt>
+              <dd className="text-lg font-semibold text-[var(--nj-text)]">{formatCurrency(focusedHand?.bet ?? 0)}</dd>
+            </div>
+            {hands.length > 1 && focusedHand ? (
+              <div className="flex flex-col gap-1">
+                <dt>Hand</dt>
+                <dd className="text-lg font-semibold text-[var(--nj-text)]">
+                  {hands.findIndex((hand) => hand.id === focusedHand.id) + 1}/{hands.length}
+                </dd>
+              </div>
+            ) : null}
+            {focusedHand ? (
+              <div className="flex flex-col gap-1">
+                <dt>Status</dt>
+                <dd className="text-sm font-semibold text-[var(--nj-text-muted)]">{statusLabel(focusedHand)}</dd>
+              </div>
+            ) : null}
+          </dl>
+        </div>
+      </div>
+      {hands.length > 1 ? (
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {hands.map((hand, index) => {
+            const isActive = hand.id === focusedHand?.id;
+            const isEngineActive = hand.id === activeHandId;
+            return (
+              <button
+                key={hand.id}
+                type="button"
+                onClick={() => setFocusedHandId(hand.id)}
+                className={cn(
+                  "nj-btn px-4 py-2 text-[0.62rem] uppercase tracking-[0.32em]",
+                  isActive
+                    ? "bg-[rgba(233,196,106,0.12)] text-[var(--nj-text)] border-[rgba(233,196,106,0.35)]"
+                    : "text-[var(--nj-text-muted)]"
+                )}
+                aria-pressed={isActive}
+              >
+                {isEngineActive ? "● " : ""}H{index + 1}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/src/components/noirjack/ResultBanner.tsx
+++ b/src/components/noirjack/ResultBanner.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export type ResultTone = "win" | "lose" | "push";
+
+interface ResultBannerProps {
+  message: string;
+  tone: ResultTone;
+}
+
+export const ResultBanner: React.FC<ResultBannerProps> = ({ message, tone }) => {
+  return (
+    <div className="nj-result-banner" data-tone={tone} role="status" aria-live="polite">
+      {message}
+    </div>
+  );
+};

--- a/src/components/noirjack/TopBar.tsx
+++ b/src/components/noirjack/TopBar.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { Info, Settings } from "lucide-react";
+import type { RuleConfig } from "../../engine/types";
+import { formatCurrency } from "../../utils/currency";
+import { RuleBadges } from "../RuleBadges";
+import type { CoachMode } from "../../store/useGameStore";
+import { cn } from "../../utils/cn";
+
+const COACH_LABELS: Record<CoachMode, string> = {
+  off: "Off",
+  feedback: "Feedback",
+  live: "Live"
+};
+
+const COACH_DESCRIPTIONS: Record<CoachMode, string> = {
+  off: "Coach disabled",
+  feedback: "Show verdicts after each move",
+  live: "Highlight best move"
+};
+
+const CYCLE: CoachMode[] = ["off", "feedback", "live"];
+
+interface TopBarProps {
+  bankroll: number;
+  pendingBet: number;
+  round: number;
+  phase: string;
+  cardsRemaining: number;
+  discardCount: number;
+  penetration: string;
+  rules: RuleConfig;
+  coachMode: CoachMode;
+  onCoachModeChange: (mode: CoachMode) => void;
+  modeToggle: React.ReactNode;
+  bankrollPulse?: "win" | "lose" | null;
+}
+
+export const TopBar: React.FC<TopBarProps> = ({
+  bankroll,
+  pendingBet,
+  round,
+  phase,
+  cardsRemaining,
+  discardCount,
+  penetration,
+  rules,
+  coachMode,
+  onCoachModeChange,
+  modeToggle,
+  bankrollPulse
+}) => {
+  const handleCoachToggle = () => {
+    const currentIndex = CYCLE.indexOf(coachMode);
+    const nextIndex = (currentIndex + 1) % CYCLE.length;
+    onCoachModeChange(CYCLE[nextIndex]);
+  };
+
+  return (
+    <header className="nj-glass sticky top-0 z-20 flex flex-col gap-4 rounded-[28px] border border-[rgba(255,255,255,0.08)] bg-[rgba(4,12,10,0.72)] px-5 py-5 backdrop-blur-lg">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="font-cinzel text-xl tracking-[0.6em] text-[var(--nj-text)]">NoirJack</span>
+            <RuleBadges rules={rules} />
+          </div>
+          <div className="text-[0.7rem] uppercase tracking-[0.38em] text-[var(--nj-text-muted)]">
+            Immersive single-seat blackjack — mint decisions, glass focus.
+          </div>
+        </div>
+        <div className="flex flex-col items-stretch gap-3 text-[var(--nj-text)] lg:items-end">
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              className="nj-btn px-3 py-2 text-[0.62rem] uppercase tracking-[0.32em]"
+              onClick={handleCoachToggle}
+              aria-label={`Toggle coach mode (currently ${COACH_LABELS[coachMode]})`}
+              title={COACH_DESCRIPTIONS[coachMode]}
+            >
+              Coach · {COACH_LABELS[coachMode]}
+            </button>
+            <button
+              type="button"
+              className="nj-btn h-10 w-10 p-0"
+              aria-label="Table information"
+            >
+              <Info size={18} strokeWidth={1.5} />
+            </button>
+            <button type="button" className="nj-btn h-10 w-10 p-0" aria-label="Table settings">
+              <Settings size={18} strokeWidth={1.5} />
+            </button>
+          </div>
+          <div className="flex items-center justify-end gap-2">{modeToggle}</div>
+        </div>
+      </div>
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-[0.68rem] uppercase tracking-[0.32em] text-[var(--nj-text-muted)] sm:grid-cols-3 lg:grid-cols-6">
+        <div className="flex flex-col gap-1">
+          <dt>Bankroll</dt>
+          <dd className={cn("text-lg font-semibold text-[var(--nj-text)]", bankrollPulse === "win" ? "nj-bankroll-win" : undefined, bankrollPulse === "lose" ? "nj-bankroll-lose" : undefined)}>
+            {formatCurrency(bankroll)}
+          </dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt>Bet</dt>
+          <dd className="text-lg font-semibold text-[var(--nj-text)]">{formatCurrency(pendingBet)}</dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt>Round</dt>
+          <dd className="text-lg font-semibold text-[var(--nj-text)]">{round}</dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt>Phase</dt>
+          <dd className="text-lg font-semibold text-[var(--nj-text)]">{phase}</dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt>Cards / Discard</dt>
+          <dd className="text-lg font-semibold text-[var(--nj-text)]">{cardsRemaining} / {discardCount}</dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt>Penetration</dt>
+          <dd className="text-lg font-semibold text-[var(--nj-text)]">{penetration}</dd>
+        </div>
+        <div className="flex flex-col gap-1">
+          <dt>Table</dt>
+          <dd className="text-lg font-semibold text-[var(--nj-text)]">
+            {formatCurrency(rules.minBet)} – {formatCurrency(rules.maxBet)}
+          </dd>
+        </div>
+      </dl>
+    </header>
+  );
+};

--- a/src/components/noirjack/hooks.ts
+++ b/src/components/noirjack/hooks.ts
@@ -1,0 +1,69 @@
+import React from "react";
+
+const clamp = (min: number, value: number, max: number): number => Math.min(max, Math.max(min, value));
+
+export interface CardMetrics {
+  width: number;
+  height: number;
+}
+
+const computeMetrics = (containerWidth: number): CardMetrics => {
+  const basis = containerWidth > 0 ? containerWidth : typeof window !== "undefined" ? window.innerWidth : 360;
+  const width = Math.round(clamp(80, basis * 0.26, 138));
+  const height = Math.round(width * 1.42);
+  return { width, height };
+};
+
+export const useCardMetrics = (containerWidth: number): CardMetrics => {
+  const [metrics, setMetrics] = React.useState<CardMetrics>(() => computeMetrics(containerWidth));
+
+  React.useEffect(() => {
+    setMetrics(computeMetrics(containerWidth));
+  }, [containerWidth]);
+
+  return metrics;
+};
+
+export const useResizeObserver = <T extends HTMLElement>(): [React.RefObject<T>, number] => {
+  const ref = React.useRef<T>(null);
+  const [width, setWidth] = React.useState<number>(0);
+
+  React.useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry?.contentRect?.width) {
+        setWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(element);
+    setWidth(element.getBoundingClientRect().width);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, width];
+};
+
+export const usePrefersReducedMotion = (): boolean => {
+  const [prefers, setPrefers] = React.useState<boolean>(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return false;
+    }
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const listener = () => setPrefers(media.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, []);
+
+  return prefers;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,11 @@
+@import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Inter:wght@400;600&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-  font-family: theme('fontFamily.sans');
+  font-family: "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --card-w: clamp(72px, 8.5vw, 110px);
   --card-h: calc(var(--card-w) * 1.43);
   --card-stack-overlap: calc(var(--card-h) * 0.28);
@@ -18,6 +20,18 @@
   --result-fg: #0b1f19;
   --result-bg: rgba(11, 31, 25, 0.75);
   --result-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  /* NoirJack tokens */
+  --nj-felt: #064e3b;
+  --nj-glass: rgba(10, 15, 20, 0.7);
+  --nj-gold: #e9c46a;
+  --nj-mint: #2dd4bf;
+  --nj-text: #ffffff;
+  --nj-text-muted: #d1d5db;
+  --nj-win: #22c55e;
+  --nj-lose: #dc2626;
+  --nj-card-face: #f9fafb;
+  --nj-outline: rgba(255, 255, 255, 0.12);
+  --nj-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
 .dealer-area {
@@ -276,5 +290,447 @@ button:disabled {
 @media (prefers-reduced-motion: reduce) {
   [data-coach="best"]::after {
     animation: none;
+  }
+}
+
+.font-cinzel {
+  font-family: "Cinzel", "Times New Roman", serif;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+}
+
+.noirjack-theme {
+  min-height: 100vh;
+  color: var(--nj-text);
+  background: radial-gradient(150% 120% at 50% 0%, rgba(3, 24, 18, 0.85), rgba(6, 78, 59, 0.98) 38%, rgba(3, 30, 23, 0.95) 100%);
+  padding: clamp(16px, 2vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2vw, 28px);
+  font-size: clamp(18px, 1.1vw + 0.8rem, 22px);
+  letter-spacing: 0.02em;
+  position: relative;
+}
+
+.noirjack-theme::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(50% 50% at 50% 15%, rgba(233, 196, 106, 0.12), transparent),
+    radial-gradient(35% 35% at 20% 80%, rgba(45, 212, 191, 0.08), transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.noirjack-theme * {
+  font-family: inherit;
+}
+
+.noirjack-theme main,
+.noirjack-theme section,
+.noirjack-theme header,
+.noirjack-theme footer {
+  position: relative;
+  z-index: 1;
+}
+
+.nj-glass {
+  background: var(--nj-glass);
+  backdrop-filter: blur(10px) saturate(1.1);
+  border: 1px solid var(--nj-outline);
+  border-radius: 20px;
+  box-shadow: var(--nj-shadow);
+}
+
+.nj-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 12px;
+  border: 1px solid var(--nj-outline);
+  color: var(--nj-text);
+  background: rgba(255, 255, 255, 0.02);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+  min-height: 48px;
+}
+
+.nj-btn-primary {
+  background: linear-gradient(180deg, #0f7a63, #0b6150);
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  box-shadow: 0 10px 26px rgba(5, 16, 13, 0.38);
+}
+
+.nj-btn:hover:not([disabled]) {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.35);
+}
+
+.nj-btn-primary:hover:not([disabled]) {
+  box-shadow: 0 18px 36px rgba(4, 30, 23, 0.55);
+}
+
+.nj-btn:active:not([disabled]) {
+  transform: translateY(1px) scale(0.99);
+}
+
+.nj-btn[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.nj-btn:focus-visible {
+  outline: 2px solid rgba(233, 196, 106, 0.85);
+  outline-offset: 3px;
+}
+
+.noirjack-theme [data-coach="best"] {
+  box-shadow: 0 0 0 2px rgba(233, 196, 106, 0.55), 0 0 22px rgba(233, 196, 106, 0.35);
+  position: relative;
+}
+
+.noirjack-theme [data-coach="best"]::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(ellipse at center, rgba(233, 196, 106, 0.12), transparent 70%);
+  animation: njPulse 1.8s ease-in-out infinite;
+}
+
+.nj-chip {
+  position: relative;
+  width: 60px;
+  height: 60px;
+  border-radius: 999px;
+  border: 2px solid rgba(233, 196, 106, 0.5);
+  display: inline-grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: #08110e;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.32), rgba(255, 255, 255, 0) 50%),
+    radial-gradient(circle at 70% 70%, rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0) 55%);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 12px 18px rgba(255, 255, 255, 0.15), 0 12px 24px rgba(0, 0, 0, 0.4);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease, opacity 0.2s ease;
+  cursor: pointer;
+}
+
+.nj-chip::after {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  box-shadow: inset 0 6px 12px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+}
+
+.nj-chip[data-selected="true"] {
+  border-color: rgba(233, 196, 106, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(233, 196, 106, 0.45), 0 14px 26px rgba(233, 196, 106, 0.18);
+}
+
+.nj-chip:focus-visible {
+  outline: 2px solid rgba(233, 196, 106, 0.85);
+  outline-offset: 3px;
+}
+
+.nj-chip:hover {
+  transform: translateY(-2px) scale(1.02);
+}
+
+.nj-chip.nj-chip-bounce {
+  animation: njChipBounce 220ms ease-out;
+}
+
+.nj-chip.nj-chip-fade {
+  animation: njChipFade 280ms ease-in forwards;
+}
+
+.nj-card-shell {
+  position: relative;
+  display: block;
+  transform-origin: center bottom;
+  animation: njCardDeal 320ms ease-out backwards;
+  animation-delay: calc(var(--deal-index, 0) * 60ms);
+}
+
+.nj-card {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transition: transform 300ms ease;
+}
+
+.nj-card.is-face-down {
+  transform: rotateY(180deg);
+}
+
+.nj-card-side {
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  backface-visibility: hidden;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.nj-card-face {
+  background: var(--nj-card-face);
+  color: #0b1520;
+}
+
+.nj-card-face::after {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: 10px;
+  border: 1px solid rgba(8, 21, 16, 0.08);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.05));
+  pointer-events: none;
+}
+
+.nj-card-back {
+  background: linear-gradient(135deg, rgba(8, 12, 16, 0.92), rgba(14, 20, 26, 0.88)),
+    repeating-linear-gradient(45deg, rgba(233, 196, 106, 0.22), rgba(233, 196, 106, 0.22) 6px, rgba(10, 15, 20, 0.4) 6px, rgba(10, 15, 20, 0.4) 12px);
+  border: 1px solid rgba(233, 196, 106, 0.55);
+  transform: rotateY(180deg);
+  box-shadow: inset 0 0 0 1px rgba(233, 196, 106, 0.45);
+}
+
+.nj-card-back::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(233, 196, 106, 0.45);
+  background: radial-gradient(circle at center, rgba(233, 196, 106, 0.08), transparent 65%);
+}
+
+.nj-card-rank {
+  position: absolute;
+  top: 8px;
+  left: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 1.4rem;
+}
+
+.nj-card-rank-bottom {
+  position: absolute;
+  bottom: 8px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 1.4rem;
+  transform: rotate(180deg);
+}
+
+.nj-card-suit {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.4rem;
+  pointer-events: none;
+}
+
+.nj-card-suit svg {
+  filter: drop-shadow(0 8px 12px rgba(0, 0, 0, 0.25));
+}
+
+.nj-result-banner {
+  position: fixed;
+  top: clamp(16px, 5vh, 60px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 24px;
+  border-radius: 999px;
+  border: 1px solid rgba(233, 196, 106, 0.4);
+  background: rgba(7, 16, 13, 0.85);
+  color: var(--nj-text);
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  box-shadow: var(--nj-shadow);
+  opacity: 0;
+  animation: njResult 1.6s ease forwards;
+  z-index: 40;
+}
+
+.nj-result-banner[data-tone="win"] {
+  border-color: rgba(34, 197, 94, 0.55);
+  color: var(--nj-win);
+}
+
+.nj-result-banner[data-tone="lose"] {
+  border-color: rgba(220, 38, 38, 0.55);
+  color: var(--nj-lose);
+}
+
+.nj-result-banner[data-tone="push"] {
+  border-color: rgba(233, 196, 106, 0.45);
+  color: var(--nj-gold);
+}
+
+.nj-sticky-bottom {
+  position: sticky;
+  bottom: 0;
+  padding-bottom: max(env(safe-area-inset-bottom), 16px);
+}
+
+.nj-safe-bottom {
+  padding-bottom: max(env(safe-area-inset-bottom), 0px);
+}
+
+.nj-bankroll-win {
+  animation: njBankrollGlow 900ms ease-out;
+}
+
+.nj-bankroll-lose {
+  animation: njBankrollFlash 600ms ease-out;
+}
+
+.nj-hint-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 12px;
+  background: rgba(233, 196, 106, 0.18);
+  border: 1px solid rgba(233, 196, 106, 0.3);
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--nj-gold);
+}
+
+.sr-announcer {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes njCardDeal {
+  from {
+    opacity: 0;
+    transform: translate3d(0, -12px, 0) scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes njChipBounce {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+  35% {
+    transform: translateY(-6px) scale(1.05);
+  }
+  70% {
+    transform: translateY(2px) scale(0.98);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes njChipFade {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes njResult {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -12px);
+  }
+  20% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  80% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -8px);
+  }
+}
+
+@keyframes njPulse {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes njBankrollGlow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.45);
+  }
+  100% {
+    box-shadow: 0 0 0 14px rgba(34, 197, 94, 0);
+  }
+}
+
+@keyframes njBankrollFlash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(220, 38, 38, 0.6);
+  }
+  100% {
+    box-shadow: 0 0 0 14px rgba(220, 38, 38, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .noirjack-theme * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .nj-card,
+  .nj-card-shell,
+  .nj-result-banner,
+  .nj-chip {
+    animation: none !important;
+  }
+  .nj-card {
+    transition: none !important;
   }
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -3,7 +3,7 @@ import { Table } from "../components/Table";
 import { useGameStore } from "../store/useGameStore";
 import { Button } from "../components/ui/button";
 import { isSingleSeatMode, PRIMARY_SEAT_INDEX } from "../ui/config";
-import { MobileTable } from "../components/mobile/MobileTable";
+import { NoirJackTable } from "../components/noirjack/NoirJackTable";
 import { useDisplayMode } from "../ui/displayMode";
 import { UIModeToggle } from "../components/UIModeToggle";
 import type { DisplayMode } from "../ui/displayMode";
@@ -77,9 +77,9 @@ export const App: React.FC = () => {
     />
   );
 
-  if (displayMode === "mobile") {
+  if (displayMode === "noirjack") {
     return (
-      <MobileTable
+      <NoirJackTable
         game={game}
         coachMode={coachMode}
         actions={actions}

--- a/src/ui/displayMode.ts
+++ b/src/ui/displayMode.ts
@@ -1,12 +1,19 @@
 import React from "react";
 
-export type DisplayMode = "classic" | "mobile";
+export type DisplayMode = "classic" | "noirjack";
 
 const DISPLAY_QUERY_KEY = "ui";
 const DISPLAY_STORAGE_KEY = "ui.display";
 const DEFAULT_MODE: DisplayMode = "classic";
 
-const isValidMode = (value: string | null): value is DisplayMode => value === "classic" || value === "mobile";
+const isValidMode = (value: string | null): value is DisplayMode => value === "classic" || value === "noirjack";
+
+const mapLegacyMode = (value: string | null): DisplayMode | null => {
+  if (value === "mobile") {
+    return "noirjack";
+  }
+  return null;
+};
 
 const readStoredMode = (): DisplayMode | null => {
   if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
@@ -16,6 +23,11 @@ const readStoredMode = (): DisplayMode | null => {
     const stored = window.localStorage.getItem(DISPLAY_STORAGE_KEY);
     if (isValidMode(stored)) {
       return stored;
+    }
+    const legacy = mapLegacyMode(stored);
+    if (legacy) {
+      persistMode(legacy);
+      return legacy;
     }
   } catch {
     // ignore storage errors
@@ -61,6 +73,11 @@ const resolveInitialMode = (): DisplayMode => {
     if (isValidMode(queryMode)) {
       persistMode(queryMode);
       return queryMode;
+    }
+    const legacy = mapLegacyMode(queryMode);
+    if (legacy) {
+      persistMode(legacy);
+      return legacy;
     }
   } catch {
     // ignore query parse errors


### PR DESCRIPTION
## Summary
- add the NoirJack skin with dedicated top bar, dealer/player layouts, controls, overlays, and accessibility support
- implement themed cards, chips, glass surfaces, and motion tokens to deliver the new brand styling
- update the UI mode toggle and display mode utilities so Classic and NoirJack skins can be selected side by side

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5483c06bc8329903b337f4179afe8