### PR TITLE
feat: add noirjack ui skin

### DIFF
--- a/src/components/UIModeToggle.tsx
+++ b/src/components/UIModeToggle.tsx
@@ -16,7 +16,7 @@ export const UIModeToggle: React.FC<UIModeToggleProps> = ({ mode, onChange }) =>
   );
 
   return (
-    <div className="inline-flex rounded-full border border-emerald-700 bg-emerald-900/60 p-1 text-xs text-emerald-200 shadow"> 
+    <div className="inline-flex rounded-full border border-emerald-700 bg-emerald-900/60 p-1 text-xs text-emerald-200 shadow">
       <button
         type="button"
         onClick={handleSelect("classic")}
@@ -33,17 +33,17 @@ export const UIModeToggle: React.FC<UIModeToggleProps> = ({ mode, onChange }) =>
       </button>
       <button
         type="button"
-        onClick={handleSelect("mobile")}
+        onClick={handleSelect("noirjack")}
         className={cn(
           "rounded-full px-3 py-1 font-semibold uppercase tracking-[0.2em] transition",
-          mode === "mobile"
+          mode === "noirjack"
             ? "bg-emerald-600 text-emerald-50 shadow-inner"
             : "text-emerald-200 hover:text-emerald-50"
         )}
-        aria-pressed={mode === "mobile"}
-        aria-label="Switch to mobile-first UI"
+        aria-pressed={mode === "noirjack"}
+        aria-label="Switch to NoirJack UI"
       >
-        Mobile
+        NoirJack
       </button>
     </div>
   );

--- a/src/components/mobile/hooks.ts
+++ b/src/components/mobile/hooks.ts
@@ -7,19 +7,52 @@ export interface CardMetrics {
   height: number;
 }
 
-const computeMetrics = (containerWidth: number): CardMetrics => {
-  const vw = containerWidth > 0 ? containerWidth : typeof window !== "undefined" ? window.innerWidth : 360;
-  const width = Math.round(clamp(72, vw * 0.24, 128));
-  const height = Math.round(width * 1.4);
+const CARD_ASPECT_RATIO = 1.4;
+const MIN_CARD_WIDTH = 64;
+const MAX_CARD_WIDTH = 132;
+const MIN_CARD_HEIGHT = MIN_CARD_WIDTH * CARD_ASPECT_RATIO;
+const MAX_CARD_HEIGHT = MAX_CARD_WIDTH * CARD_ASPECT_RATIO;
+const MAX_SECTION_RATIO = 0.28;
+
+const getViewport = (): { width: number; height: number } => {
+  if (typeof window === "undefined") {
+    return { width: 360, height: 720 };
+  }
+  return { width: window.innerWidth, height: window.innerHeight };
+};
+
+export const computeCardMetrics = (
+  containerWidth: number,
+  viewport: { width: number; height: number } = getViewport()
+): CardMetrics => {
+  const basisWidth = containerWidth > 0 ? containerWidth : viewport.width;
+  const widthFromWidth = clamp(MIN_CARD_WIDTH, basisWidth * 0.24, MAX_CARD_WIDTH);
+  const maxCardHeight = clamp(MIN_CARD_HEIGHT, viewport.height * MAX_SECTION_RATIO, MAX_CARD_HEIGHT);
+  const widthFromHeight = clamp(MIN_CARD_WIDTH, maxCardHeight / CARD_ASPECT_RATIO, MAX_CARD_WIDTH);
+  const width = Math.round(Math.min(widthFromWidth, widthFromHeight));
+  const height = Math.round(width * CARD_ASPECT_RATIO);
   return { width, height };
 };
 
 export const useCardMetrics = (containerWidth: number): CardMetrics => {
-  const [metrics, setMetrics] = React.useState<CardMetrics>(() => computeMetrics(containerWidth));
+  const widthRef = React.useRef(containerWidth);
+  const [metrics, setMetrics] = React.useState<CardMetrics>(() => computeCardMetrics(containerWidth));
 
   React.useEffect(() => {
-    setMetrics(computeMetrics(containerWidth));
+    widthRef.current = containerWidth;
+    setMetrics(computeCardMetrics(containerWidth));
   }, [containerWidth]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const handleResize = () => {
+      setMetrics(computeCardMetrics(widthRef.current));
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   return metrics;
 };

--- a/src/components/noirjack/NoirCard.tsx
+++ b/src/components/noirjack/NoirCard.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Icon } from "@iconify/react";
+import type { Card } from "../../engine/types";
+import { cn } from "../../utils/cn";
+
+interface NoirCardProps {
+  card: Card;
+  faceDown?: boolean;
+  animateKey?: string;
+}
+
+const SUIT_META: Record<Card["suit"], { icon: string; tone: "red" | "black" }> = {
+  "♠": { icon: "game-icons:spades", tone: "black" },
+  "♣": { icon: "game-icons:clubs", tone: "black" },
+  "♥": { icon: "game-icons:hearts", tone: "red" },
+  "♦": { icon: "game-icons:diamonds", tone: "red" }
+};
+
+const rankDisplay = (rank: Card["rank"]): string => {
+  if (rank === "10") {
+    return "10";
+  }
+  return rank.toUpperCase();
+};
+
+export const NoirCard: React.FC<NoirCardProps> = ({ card, faceDown = false, animateKey }) => {
+  const [shouldAnimate, setShouldAnimate] = React.useState(false);
+  React.useEffect(() => {
+    if (!animateKey || typeof window === "undefined") {
+      return;
+    }
+    setShouldAnimate(true);
+    const timer = window.setTimeout(() => setShouldAnimate(false), 400);
+    return () => window.clearTimeout(timer);
+  }, [animateKey]);
+
+  const suitMeta = SUIT_META[card.suit];
+  const displayRank = rankDisplay(card.rank);
+
+  return (
+    <div className={cn("nj-card-wrapper", shouldAnimate && "nj-card-wrapper--deal")}
+      data-facedown={faceDown ? "true" : undefined}
+    >
+      <div className={cn("nj-card", faceDown && "nj-card--down")}
+        role="img"
+        aria-label={faceDown ? "Face down card" : `${displayRank} of ${card.suit}`}
+      >
+        <div className="nj-card__face" data-tone={suitMeta.tone}>
+          <div className="nj-card__corner nj-card__corner--top">
+            <span>{displayRank}</span>
+            <Icon icon={suitMeta.icon} width={18} height={18} />
+          </div>
+          <div className="nj-card__corner nj-card__corner--bottom">
+            <span>{displayRank}</span>
+            <Icon icon={suitMeta.icon} width={18} height={18} />
+          </div>
+          <div className="nj-card__pip">
+            <Icon icon={suitMeta.icon} width={38} height={38} />
+          </div>
+        </div>
+        <div className="nj-card__back">
+          <div className="nj-card__back-border" />
+          <div className="nj-card__back-pattern" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/noirjack/NoirCardFan.tsx
+++ b/src/components/noirjack/NoirCardFan.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import type { Card } from "../../engine/types";
+import { NoirCard } from "./NoirCard";
+import { useCardMetrics, useResizeObserver } from "../mobile/hooks";
+import { cn } from "../../utils/cn";
+
+interface NoirCardFanProps {
+  cards: Card[];
+  faceDownIndexes?: number[];
+  className?: string;
+}
+
+const toSet = (indexes?: number[]): Set<number> => {
+  if (!indexes || indexes.length === 0) {
+    return new Set();
+  }
+  return new Set(indexes);
+};
+
+export const NoirCardFan: React.FC<NoirCardFanProps> = ({ cards, faceDownIndexes, className }) => {
+  const [ref, width] = useResizeObserver<HTMLDivElement>();
+  const metrics = useCardMetrics(width);
+  const faceDown = React.useMemo(() => toSet(faceDownIndexes), [faceDownIndexes]);
+  const seenRef = React.useRef<Set<string>>(new Set());
+
+  const overlapBase = Math.max(16, Math.round(metrics.width * (cards.length > 5 ? 0.26 : 0.34)));
+  const totalWidth = metrics.width + (cards.length - 1) * (metrics.width - overlapBase);
+  const effectiveWidth = width > 0 ? Math.min(totalWidth, width) : totalWidth;
+  const shrinkRatio = totalWidth > 0 ? Math.min(1, effectiveWidth / totalWidth) : 1;
+  const cardWidth = Math.round(metrics.width * shrinkRatio);
+  const cardHeight = Math.round(metrics.height * shrinkRatio);
+  const overlap = Math.max(12, Math.round(overlapBase * shrinkRatio));
+
+  const animationKeys = React.useMemo(() => {
+    const map = new Map<number, string>();
+    const nextSeen = new Set<string>();
+    cards.forEach((card, index) => {
+      const key = `${index}-${card.rank}-${card.suit}`;
+      nextSeen.add(key);
+      if (!seenRef.current.has(key)) {
+        map.set(index, `${key}-${Date.now()}`);
+      }
+    });
+    seenRef.current = nextSeen;
+    return map;
+  }, [cards]);
+
+  return (
+    <div ref={ref} className={cn("nj-card-fan", className)} style={{ height: cardHeight }}>
+      {cards.map((card, index) => {
+        const isFirst = index === 0;
+        const animateKey = animationKeys.get(index);
+        return (
+          <div
+            key={`${card.rank}-${card.suit}-${index}`}
+            className="nj-card-fan__item"
+            style={{
+              width: cardWidth,
+              height: cardHeight,
+              marginLeft: isFirst ? 0 : -overlap,
+              zIndex: index + 1
+            }}
+          >
+            <NoirCard card={card} faceDown={faceDown.has(index)} animateKey={animateKey} />
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/noirjack/NoirJackTable.tsx
+++ b/src/components/noirjack/NoirJackTable.tsx
@@ -1,0 +1,809 @@
+import React from "react";
+import { Info, Settings2, Sparkles } from "lucide-react";
+import type { GameState, Hand } from "../../engine/types";
+import { PRIMARY_SEAT_INDEX, filterSeatsForMode } from "../../ui/config";
+import type { CoachMode } from "../../store/useGameStore";
+import type { ChipDenomination } from "../../theme/palette";
+import { formatCurrency } from "../../utils/currency";
+import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
+import { getRecommendation, type Action, type PlayerContext } from "../../utils/basicStrategy";
+import { NoirCardFan } from "./NoirCardFan";
+import { Chip } from "../hud/Chip";
+import { cn } from "../../utils/cn";
+import { bestTotal } from "../../engine/totals";
+
+interface NoirJackTableProps {
+  game: GameState;
+  coachMode: CoachMode;
+  actions: {
+    sit: (seatIndex: number) => void;
+    leave: (seatIndex: number) => void;
+    addChip: (seatIndex: number, denom: number) => void;
+    removeChipValue: (seatIndex: number, denom: number) => void;
+    removeTopChip: (seatIndex: number) => void;
+    deal: () => void;
+    playerHit: () => void;
+    playerStand: () => void;
+    playerDouble: () => void;
+    playerSplit: () => void;
+    playerSurrender: () => void;
+    takeInsurance: (seatIndex: number, handId: string, amount: number) => void;
+    declineInsurance: (seatIndex: number, handId: string) => void;
+    finishInsurance: () => void;
+    playDealer: () => void;
+    nextRound: () => void;
+  };
+  onCoachModeChange: (mode: CoachMode) => void;
+  error: string | null;
+  onDismissError: () => void;
+  modeToggle: React.ReactNode;
+}
+
+const CHIP_VALUES: ChipDenomination[] = [1, 5, 25, 100, 500];
+
+const hasReadySeat = (game: GameState): boolean => {
+  const seat = game.seats[PRIMARY_SEAT_INDEX];
+  if (!seat?.occupied) {
+    return false;
+  }
+  if (seat.baseBet < game.rules.minBet || seat.baseBet > game.rules.maxBet) {
+    return false;
+  }
+  return seat.baseBet > 0 && seat.baseBet <= game.bankroll;
+};
+
+const findActiveHand = (game: GameState): Hand | null => {
+  if (!game.activeHandId) {
+    return null;
+  }
+  for (const seat of filterSeatsForMode(game.seats)) {
+    const hand = seat.hands.find((candidate) => candidate.id === game.activeHandId);
+    if (hand) {
+      return hand;
+    }
+  }
+  return null;
+};
+
+const parseResultMessage = (messages: string[]): { tone: ResultTone; message: string } | null => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message.startsWith("Seat 1")) {
+      continue;
+    }
+    if (message.includes("wins")) {
+      const amountMatch = message.match(/€([0-9.,]+)/);
+      const amount = amountMatch ? Number.parseFloat(amountMatch[1].replace(",", "")) : null;
+      return {
+        tone: "win",
+        message: amount ? `Win +€${amount.toFixed(2)}` : "Win"
+      };
+    }
+    if (message.includes("push")) {
+      return { tone: "push", message: "Push" };
+    }
+    if (message.includes("loses")) {
+      const amountMatch = message.match(/€([0-9.,]+)/);
+      const amount = amountMatch ? Number.parseFloat(amountMatch[1].replace(",", "")) : null;
+      return {
+        tone: "lose",
+        message: amount ? `Lose -€${amount.toFixed(2)}` : "Lose"
+      };
+    }
+  }
+  return null;
+};
+
+const buildCoachMessage = (action: Action, correct: boolean): string => {
+  const label = action.charAt(0).toUpperCase() + action.slice(1);
+  return correct ? `Nice! ${label} was the right move.` : `Try ${label} next time.`;
+};
+
+type ResultTone = "win" | "lose" | "push";
+
+const usePrevious = <T,>(value: T): T | undefined => {
+  const ref = React.useRef<T>();
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+};
+
+const usePrefersReducedMotion = (): boolean => {
+  const [prefers, setPrefers] = React.useState<boolean>(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
+  });
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const listener = () => setPrefers(media.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, []);
+
+  return prefers;
+};
+
+const useHaptics = (disabled: boolean): (() => void) => {
+  return React.useCallback(() => {
+    if (disabled || typeof window === "undefined" || typeof navigator === "undefined") {
+      return;
+    }
+    if (navigator.vibrate) {
+      navigator.vibrate(12);
+    }
+  }, [disabled]);
+};
+
+interface ActionAvailability {
+  hit: boolean;
+  stand: boolean;
+  double: boolean;
+  split: boolean;
+  surrender: boolean;
+  deal: boolean;
+  finishInsurance: boolean;
+  playDealer: boolean;
+  nextRound: boolean;
+}
+
+const CoachModeSelector: React.FC<{ mode: CoachMode; onChange: (mode: CoachMode) => void }> = ({ mode, onChange }) => {
+  const labels: Record<CoachMode, string> = {
+    off: "Off",
+    feedback: "Feedback",
+    live: "Live"
+  };
+
+  const next = React.useCallback(() => {
+    const order: CoachMode[] = ["off", "feedback", "live"];
+    const index = order.indexOf(mode);
+    const nextMode = order[(index + 1) % order.length];
+    onChange(nextMode);
+  }, [mode, onChange]);
+
+  return (
+    <button
+      type="button"
+      className="nj-btn nj-btn--ghost nj-coach-toggle"
+      onClick={next}
+      aria-label={`Toggle coach mode (currently ${labels[mode]})`}
+    >
+      <Sparkles size={16} aria-hidden="true" />
+      <span className="nj-coach-toggle__label">Coach</span>
+      <span className="nj-coach-toggle__value">{labels[mode]}</span>
+    </button>
+  );
+};
+
+export const NoirJackTable: React.FC<NoirJackTableProps> = ({
+  game,
+  coachMode,
+  actions,
+  onCoachModeChange,
+  error,
+  onDismissError,
+  modeToggle
+}) => {
+  const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
+  const [coachMessage, setCoachMessage] = React.useState<{ tone: "correct" | "better"; text: string } | null>(null);
+  const [flashAction, setFlashAction] = React.useState<Action | null>(null);
+  const messageTimer = React.useRef<number | null>(null);
+  const highlightTimer = React.useRef<number | null>(null);
+  const [result, setResult] = React.useState<{ tone: ResultTone; message: string } | null>(null);
+  const resultTimer = React.useRef<number | null>(null);
+  const [chipMotion, setChipMotion] = React.useState<{ value: ChipDenomination; type: "add" | "remove"; stamp: number } | null>(
+    null
+  );
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const vibrate = useHaptics(prefersReducedMotion);
+
+  React.useEffect(() => {
+    if (messageTimer.current) {
+      window.clearTimeout(messageTimer.current);
+      messageTimer.current = null;
+    }
+    if (coachMessage) {
+      messageTimer.current = window.setTimeout(() => {
+        setCoachMessage(null);
+        messageTimer.current = null;
+      }, 2500);
+    }
+    return () => {
+      if (messageTimer.current) {
+        window.clearTimeout(messageTimer.current);
+      }
+    };
+  }, [coachMessage]);
+
+  React.useEffect(() => {
+    return () => {
+      if (resultTimer.current) {
+        window.clearTimeout(resultTimer.current);
+      }
+      if (highlightTimer.current) {
+        window.clearTimeout(highlightTimer.current);
+      }
+      if (messageTimer.current) {
+        window.clearTimeout(messageTimer.current);
+      }
+    };
+  }, []);
+
+  const seat = game.seats[PRIMARY_SEAT_INDEX] ?? null;
+  const activeHand = findActiveHand(game);
+
+  const actionContext = React.useMemo(() => {
+    if (!activeHand || !seat || game.phase !== "playerActions") {
+      return null;
+    }
+    return {
+      hand: activeHand,
+      hit: canHit(activeHand),
+      stand: !activeHand.isResolved,
+      double: canDouble(activeHand, game.rules) && game.bankroll >= activeHand.bet,
+      split: canSplit(activeHand, seat, game.rules) && game.bankroll >= activeHand.bet,
+      surrender: canSurrender(activeHand, game.rules)
+    };
+  }, [activeHand, game.bankroll, game.phase, game.rules, seat]);
+
+  const dealerUpcard = game.dealer.upcard;
+
+  const recommendation = React.useMemo(() => {
+    if (!actionContext || !dealerUpcard) {
+      return null;
+    }
+    const rank = dealerUpcard.rank as PlayerContext["dealerUpcard"]["rank"];
+    const context: PlayerContext = {
+      dealerUpcard: {
+        rank,
+        value10: dealerUpcard.rank === "10" || dealerUpcard.rank === "J" || dealerUpcard.rank === "Q" || dealerUpcard.rank === "K"
+      },
+      cards: actionContext.hand.cards.map((card) => ({ rank: card.rank })),
+      isInitialTwoCards: actionContext.hand.cards.length === 2 && !actionContext.hand.hasActed,
+      afterSplit: Boolean(actionContext.hand.isSplitHand),
+      legal: {
+        hit: actionContext.hit,
+        stand: actionContext.stand,
+        double: actionContext.double,
+        split: actionContext.split,
+        surrender: actionContext.surrender
+      }
+    };
+    return getRecommendation(context, game.rules);
+  }, [actionContext, dealerUpcard, game.rules]);
+
+  const recommendedAction = React.useMemo<Action | null>(() => {
+    if (!recommendation || !actionContext) {
+      return null;
+    }
+    const isLegal = (action: Action | undefined): boolean => {
+      if (!action) {
+        return false;
+      }
+      switch (action) {
+        case "hit":
+          return actionContext.hit;
+        case "stand":
+          return actionContext.stand;
+        case "double":
+          return actionContext.double;
+        case "split":
+          return actionContext.split;
+        case "surrender":
+          return actionContext.surrender;
+        default:
+          return false;
+      }
+    };
+    if (isLegal(recommendation.best)) {
+      return recommendation.best;
+    }
+    if (recommendation.fallback && isLegal(recommendation.fallback)) {
+      return recommendation.fallback;
+    }
+    return null;
+  }, [actionContext, recommendation]);
+
+  const highlightedAction = React.useMemo<Action | null>(() => {
+    if (flashAction) {
+      return flashAction;
+    }
+    if (coachMode === "live") {
+      return recommendedAction;
+    }
+    return null;
+  }, [coachMode, flashAction, recommendedAction]);
+
+  const triggerFeedback = React.useCallback(
+    (action: Action, callback: () => void) => {
+      if (coachMode === "feedback" && recommendedAction) {
+        const correct = action === recommendedAction;
+        setCoachMessage({ tone: correct ? "correct" : "better", text: buildCoachMessage(recommendedAction, correct) });
+        if (!correct) {
+          setFlashAction(recommendedAction);
+          if (highlightTimer.current) {
+            window.clearTimeout(highlightTimer.current);
+          }
+          highlightTimer.current = window.setTimeout(() => {
+            setFlashAction(null);
+            highlightTimer.current = null;
+          }, 1000);
+        } else {
+          setFlashAction(null);
+        }
+      }
+      callback();
+      vibrate();
+    },
+    [coachMode, recommendedAction, vibrate]
+  );
+
+  const handleHit = React.useCallback(() => triggerFeedback("hit", actions.playerHit), [actions.playerHit, triggerFeedback]);
+  const handleStand = React.useCallback(() => triggerFeedback("stand", actions.playerStand), [actions.playerStand, triggerFeedback]);
+  const handleDouble = React.useCallback(
+    () => triggerFeedback("double", actions.playerDouble),
+    [actions.playerDouble, triggerFeedback]
+  );
+  const handleSplit = React.useCallback(() => triggerFeedback("split", actions.playerSplit), [actions.playerSplit, triggerFeedback]);
+  const handleSurrender = React.useCallback(
+    () => triggerFeedback("surrender", actions.playerSurrender),
+    [actions.playerSurrender, triggerFeedback]
+  );
+
+  const availability: ActionAvailability = React.useMemo(
+    () => ({
+      hit: Boolean(actionContext?.hit),
+      stand: Boolean(actionContext?.stand),
+      double: Boolean(actionContext?.double),
+      split: Boolean(actionContext?.split),
+      surrender: Boolean(actionContext?.surrender),
+      deal: game.phase === "betting" && hasReadySeat(game),
+      finishInsurance: game.phase === "insurance",
+      playDealer: game.phase === "dealerPlay",
+      nextRound: game.phase === "settlement"
+    }),
+    [actionContext, game]
+  );
+
+  const handleAddChip = React.useCallback(
+    (value: ChipDenomination) => {
+      if (game.phase !== "betting" || !seat) {
+        return;
+      }
+      const nextBet = seat.baseBet + value;
+      if (nextBet > game.rules.maxBet || nextBet > game.bankroll) {
+        return;
+      }
+      actions.addChip(PRIMARY_SEAT_INDEX, value);
+      vibrate();
+      setChipMotion({ value, type: "add", stamp: Date.now() });
+    },
+    [actions, game.bankroll, game.phase, game.rules.maxBet, seat, vibrate]
+  );
+
+  const handleRemoveChipValue = React.useCallback(
+    (value: ChipDenomination) => {
+      if (game.phase !== "betting" || !seat || seat.baseBet <= 0) {
+        return;
+      }
+      actions.removeChipValue(PRIMARY_SEAT_INDEX, value);
+      vibrate();
+      setChipMotion({ value, type: "remove", stamp: Date.now() });
+    },
+    [actions, game.phase, seat, vibrate]
+  );
+
+  const handleRemoveTopChip = React.useCallback(() => {
+    if (game.phase !== "betting" || !seat || seat.baseBet <= 0) {
+      return;
+    }
+    actions.removeTopChip(PRIMARY_SEAT_INDEX);
+    vibrate();
+    setChipMotion({ value: activeChip, type: "remove", stamp: Date.now() });
+  }, [actions, activeChip, game.phase, seat, vibrate]);
+
+  const [insuranceHandId, insuranceAmount] = React.useMemo(() => {
+    if (game.phase !== "insurance" || !seat) {
+      return [null, 0] as const;
+    }
+    const hand = seat.hands.find((candidate) => candidate.insuranceBet === undefined && !candidate.isResolved);
+    if (!hand) {
+      return [null, 0] as const;
+    }
+    return [hand.id, Math.min(hand.bet / 2, game.bankroll)];
+  }, [game.bankroll, game.phase, seat]);
+
+  const showInsuranceSheet = Boolean(insuranceHandId && game.awaitingInsuranceResolution);
+
+  const takeInsurance = React.useCallback(() => {
+    if (!insuranceHandId) {
+      return;
+    }
+    vibrate();
+    actions.takeInsurance(PRIMARY_SEAT_INDEX, insuranceHandId, insuranceAmount);
+  }, [actions, insuranceAmount, insuranceHandId, vibrate]);
+
+  const skipInsurance = React.useCallback(() => {
+    if (!insuranceHandId) {
+      return;
+    }
+    vibrate();
+    actions.declineInsurance(PRIMARY_SEAT_INDEX, insuranceHandId);
+  }, [actions, insuranceHandId, vibrate]);
+
+  const handleDeal = React.useCallback(() => {
+    vibrate();
+    actions.deal();
+  }, [actions, vibrate]);
+
+  const handleFinishInsurance = React.useCallback(() => {
+    vibrate();
+    actions.finishInsurance();
+  }, [actions, vibrate]);
+
+  const handlePlayDealer = React.useCallback(() => {
+    vibrate();
+    actions.playDealer();
+  }, [actions, vibrate]);
+
+  const handleNextRound = React.useCallback(() => {
+    vibrate();
+    actions.nextRound();
+  }, [actions, vibrate]);
+
+  const prevPhase = usePrevious(game.phase);
+
+  React.useEffect(() => {
+    if (game.phase === "settlement" && prevPhase !== "settlement") {
+      const parsed = parseResultMessage(game.messageLog);
+      if (parsed) {
+        setResult(parsed);
+        if (resultTimer.current) {
+          window.clearTimeout(resultTimer.current);
+        }
+        resultTimer.current = window.setTimeout(() => {
+          setResult(null);
+          resultTimer.current = null;
+        }, 1800);
+      }
+    }
+    if (game.phase !== "settlement" && prevPhase === "settlement") {
+      setResult(null);
+    }
+  }, [game.messageLog, game.phase, prevPhase]);
+
+  const dealerCards = game.dealer.hand.cards;
+  const faceDownIndexes = React.useMemo(() => {
+    if (game.phase === "settlement" || game.phase === "dealerPlay") {
+      return [];
+    }
+    if (game.dealer.holeCard) {
+      return [1];
+    }
+    return [];
+  }, [game.dealer.holeCard, game.phase]);
+
+  const playerHands = seat?.hands ?? [];
+  const rawActiveIndex = playerHands.findIndex((hand) => hand.id === game.activeHandId);
+  const resolvedActiveIndex = rawActiveIndex >= 0 ? rawActiveIndex : playerHands.length > 0 ? 0 : -1;
+  const focusedHand = activeHand ?? (resolvedActiveIndex >= 0 ? playerHands[resolvedActiveIndex] : null);
+
+  const dealerStatus = React.useMemo(() => {
+    if (faceDownIndexes.length > 0 && game.dealer.upcard) {
+      return `Showing ${game.dealer.upcard.rank}`;
+    }
+    if (dealerCards.length > 0) {
+      return `Total ${bestTotal(game.dealer.hand)}`;
+    }
+    return "Waiting";
+  }, [dealerCards, faceDownIndexes, game.dealer.hand, game.dealer.upcard]);
+
+  const playerTotal = focusedHand ? bestTotal(focusedHand) : null;
+  const playerBet = focusedHand?.bet ?? seat?.baseBet ?? 0;
+
+  const errorBanner = error ? (
+    <div className="nj-glass nj-error" role="alert">
+      <span>{error}</span>
+      <button type="button" className="nj-btn nj-btn--ghost" onClick={onDismissError}>
+        Dismiss
+      </button>
+    </div>
+  ) : null;
+
+  const stats = [
+    { label: "Bankroll", value: formatCurrency(game.bankroll) },
+    { label: "Round", value: game.roundCount },
+    { label: "Phase", value: game.phase },
+    { label: "Cards", value: game.shoe.cards.length },
+    { label: "Discard", value: game.shoe.discard.length },
+    { label: "Min", value: formatCurrency(game.rules.minBet) },
+    { label: "Max", value: formatCurrency(game.rules.maxBet) }
+  ];
+
+  const actionHighlight = (action: Action): "best" | undefined =>
+    highlightedAction === action ? "best" : undefined;
+
+  const roundControls = [
+    availability.deal
+      ? {
+          label: "Deal",
+          onClick: handleDeal,
+          disabled: !availability.deal
+        }
+      : null,
+    availability.finishInsurance
+      ? {
+          label: "Finish insurance",
+          onClick: handleFinishInsurance,
+          disabled: !availability.finishInsurance
+        }
+      : null,
+    availability.playDealer
+      ? {
+          label: "Play dealer",
+          onClick: handlePlayDealer,
+          disabled: !availability.playDealer
+        }
+      : null,
+    availability.nextRound
+      ? {
+          label: "Next round",
+          onClick: handleNextRound,
+          disabled: !availability.nextRound
+        }
+      : null
+  ].filter((control): control is { label: string; onClick: () => void; disabled: boolean } => control !== null);
+
+  return (
+    <div className="noirjack-app">
+      <div className="noirjack-felt" />
+      <div className="noirjack-content">
+        <header className="nj-topbar">
+          <div className="nj-topbar__brand">
+            <span className="nj-logo" aria-hidden="true">
+              NOIRJACK
+            </span>
+            <span className="sr-only">NoirJack Blackjack table</span>
+            <div className="nj-topbar__controls">
+              <button type="button" className="nj-btn nj-btn--ghost" aria-label="Table information">
+                <Info size={18} aria-hidden="true" />
+              </button>
+              <CoachModeSelector mode={coachMode} onChange={onCoachModeChange} />
+              <button type="button" className="nj-btn nj-btn--ghost" aria-label="Table settings">
+                <Settings2 size={18} aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+          <div className="nj-topbar__mode">{modeToggle}</div>
+          <div className="nj-topbar__stats nj-glass">
+            {stats.map((item) => (
+              <div key={item.label} className="nj-stat">
+                <span className="nj-stat__label">{item.label}</span>
+                <span className="nj-stat__value">{item.value}</span>
+              </div>
+            ))}
+          </div>
+          {errorBanner}
+        </header>
+
+        <section className="nj-section nj-section--dealer">
+          <div className="nj-glass nj-panel">
+            <div className="nj-panel__header">
+              <span className="nj-panel__title">Dealer</span>
+              <span className="nj-panel__subtitle">{dealerStatus}</span>
+            </div>
+            <NoirCardFan cards={dealerCards} faceDownIndexes={faceDownIndexes} />
+            {game.phase === "insurance" && (
+              <div className="nj-panel__footer">Insurance available</div>
+            )}
+          </div>
+        </section>
+
+        <section className="nj-section nj-section--player">
+          <div className="nj-glass nj-panel">
+            <div className="nj-panel__header">
+              <span className="nj-panel__title">Player</span>
+              <div className="nj-panel__meta">
+                <div>
+                  <span className="nj-stat__label">Total</span>
+                  <span className="nj-panel__value">{playerTotal ?? "--"}</span>
+                </div>
+                <div>
+                  <span className="nj-stat__label">Bet</span>
+                  <span className="nj-panel__value">{formatCurrency(playerBet)}</span>
+                </div>
+              </div>
+            </div>
+            <div className="nj-hand-carousel">
+              <NoirCardFan cards={focusedHand?.cards ?? []} />
+              {playerHands.length > 1 && (
+                <div className="nj-hand-tabs" role="tablist" aria-label="Split hands">
+                  {playerHands.map((hand, index) => (
+                    <div
+                      key={hand.id}
+                      className={cn("nj-hand-tab", index === resolvedActiveIndex && "nj-hand-tab--active")}
+                      role="tab"
+                      aria-selected={index === resolvedActiveIndex}
+                    >
+                      <span>Hand {index + 1}</span>
+                      <span>{bestTotal(hand)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+            {coachMessage && (
+              <div
+                className={cn(
+                  "nj-coach-banner",
+                  coachMessage.tone === "correct" ? "nj-coach-banner--good" : "nj-coach-banner--warn"
+                )}
+              >
+                {coachMessage.text}
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <div className="nj-controls nj-sticky-bottom">
+        <div className="nj-controls__tray nj-glass">
+          <div className="nj-controls__tray-header">
+            <span>Chips</span>
+            <span>{formatCurrency(seat?.baseBet ?? 0)}</span>
+          </div>
+          <div className="nj-chip-row">
+            {CHIP_VALUES.map((value) => (
+              <Chip
+                key={value}
+                value={value}
+                size={56}
+                selected={activeChip === value}
+                onClick={() => {
+                  setActiveChip(value);
+                  handleAddChip(value);
+                }}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  setActiveChip(value);
+                  handleRemoveChipValue(value);
+                }}
+                aria-label={`Select ${value} chip`}
+                data-chip-motion={
+                  chipMotion?.value === value ? `${chipMotion.type}-${chipMotion.stamp}` : undefined
+                }
+                className="nj-chip"
+              />
+            ))}
+          </div>
+          <div className="nj-tray-actions">
+            <button
+              type="button"
+              className="nj-btn"
+              onClick={() => handleAddChip(activeChip)}
+              disabled={game.phase !== "betting"}
+            >
+              Add {activeChip}
+            </button>
+            <button
+              type="button"
+              className="nj-btn nj-btn--ghost"
+              onClick={() => handleRemoveChipValue(activeChip)}
+              disabled={game.phase !== "betting" || (seat?.baseBet ?? 0) <= 0}
+            >
+              Remove
+            </button>
+            <button
+              type="button"
+              className="nj-btn nj-btn--ghost"
+              onClick={handleRemoveTopChip}
+              disabled={game.phase !== "betting" || (seat?.baseBet ?? 0) <= 0}
+            >
+              Undo last
+            </button>
+          </div>
+        </div>
+
+        <div className="nj-controls__actions nj-glass">
+          <div className="nj-actions-primary">
+            <button
+              type="button"
+              className="nj-btn nj-btn-primary"
+              onClick={handleHit}
+              disabled={game.phase !== "playerActions" || !availability.hit}
+              data-coach={game.phase === "playerActions" ? actionHighlight("hit") : undefined}
+            >
+              Hit
+            </button>
+            <button
+              type="button"
+              className="nj-btn nj-btn-primary"
+              onClick={handleStand}
+              disabled={game.phase !== "playerActions" || !availability.stand}
+              data-coach={game.phase === "playerActions" ? actionHighlight("stand") : undefined}
+            >
+              Stand
+            </button>
+          </div>
+          <div className="nj-actions-secondary">
+            <button
+              type="button"
+              className="nj-btn"
+              onClick={handleDouble}
+              disabled={game.phase !== "playerActions" || !availability.double}
+              data-coach={game.phase === "playerActions" ? actionHighlight("double") : undefined}
+            >
+              Double
+            </button>
+            <button
+              type="button"
+              className="nj-btn"
+              onClick={handleSplit}
+              disabled={game.phase !== "playerActions" || !availability.split}
+              data-coach={game.phase === "playerActions" ? actionHighlight("split") : undefined}
+            >
+              Split
+            </button>
+            <button
+              type="button"
+              className="nj-btn"
+              onClick={handleSurrender}
+              disabled={game.phase !== "playerActions" || !availability.surrender}
+              data-coach={game.phase === "playerActions" ? actionHighlight("surrender") : undefined}
+            >
+              Surrender
+            </button>
+          </div>
+          {roundControls.length > 0 && (
+            <div className="nj-actions-round">
+              {roundControls.map((control) => (
+                <button
+                  key={control.label}
+                  type="button"
+                  className={cn("nj-btn", control.label === "Deal" ? "nj-btn-primary" : "nj-btn--ghost")}
+                  onClick={control.onClick}
+                  disabled={control.disabled}
+                >
+                  {control.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showInsuranceSheet && (
+        <div className="nj-insurance" role="dialog" aria-modal="true" aria-label="Insurance decision">
+          <div className="nj-insurance__sheet nj-glass">
+            <h2>Insurance?</h2>
+            <p>Take insurance for €{insuranceAmount.toFixed(2)}?</p>
+            <div className="nj-insurance__actions">
+              <button type="button" className="nj-btn nj-btn-primary" onClick={takeInsurance}>
+                Take insurance
+              </button>
+              <button type="button" className="nj-btn nj-btn--ghost" onClick={skipInsurance}>
+                Skip
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {result && (
+        <div className={cn("nj-result", `nj-result--${result.tone}`)} role="status" aria-live="polite">
+          <span className="nj-result__label">{result.message}</span>
+        </div>
+      )}
+
+      <div className="sr-only" aria-live="polite">
+        {result ? `Player ${result.message}` : ""}
+      </div>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -317,7 +317,8 @@ body.skin-noirjack {
 body.skin-noirjack .noirjack-app {
   position: relative;
   min-height: 100vh;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
@@ -605,6 +606,36 @@ body.skin-noirjack .nj-controls {
   gap: clamp(16px, 3vw, 28px);
   padding: clamp(16px, 4vw, 32px);
   background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(4, 10, 10, 0.65) 100%);
+}
+
+@media (max-height: 720px) {
+  body.skin-noirjack .noirjack-content {
+    gap: clamp(10px, 2.5vw, 18px);
+    padding: clamp(12px, 3vw, 24px);
+  }
+
+  body.skin-noirjack .nj-topbar {
+    gap: clamp(8px, 2vh, 12px);
+  }
+
+  body.skin-noirjack .nj-topbar__stats {
+    padding: 12px clamp(14px, 4vw, 18px);
+    gap: 10px;
+  }
+
+  body.skin-noirjack .nj-controls {
+    gap: clamp(12px, 2.5vw, 20px);
+    padding: clamp(12px, 3vw, 24px);
+  }
+
+  body.skin-noirjack .nj-controls__layout {
+    gap: 12px;
+  }
+
+  body.skin-noirjack .nj-controls__tray,
+  body.skin-noirjack .nj-controls__actions {
+    padding: clamp(12px, 3vw, 18px);
+  }
 }
 
 body.skin-noirjack .nj-controls__layout {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Inter:wght@400;500;600&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -18,6 +20,17 @@
   --result-fg: #0b1f19;
   --result-bg: rgba(11, 31, 25, 0.75);
   --result-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+  --nj-felt: #064e3b;
+  --nj-glass: rgba(10, 15, 20, 0.7);
+  --nj-gold: #e9c46a;
+  --nj-mint: #2dd4bf;
+  --nj-text: #ffffff;
+  --nj-text-muted: #d1d5db;
+  --nj-win: #22c55e;
+  --nj-lose: #dc2626;
+  --nj-card-face: #f9fafb;
+  --nj-outline: rgba(255, 255, 255, 0.12);
+  --nj-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
 .dealer-area {
@@ -276,5 +289,747 @@ button:disabled {
 @media (prefers-reduced-motion: reduce) {
   [data-coach="best"]::after {
     animation: none;
+  }
+}
+
+body.skin-noirjack {
+  font-family: "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(45, 212, 191, 0.06), transparent 55%),
+    radial-gradient(circle at 80% 80%, rgba(233, 196, 106, 0.08), transparent 60%),
+    linear-gradient(180deg, rgba(6, 78, 59, 0.95), rgba(3, 24, 18, 0.98));
+  color: var(--nj-text);
+  font-size: 18px;
+  line-height: 1.5;
+}
+
+@media (min-width: 768px) {
+  body.skin-noirjack {
+    font-size: 20px;
+  }
+}
+
+@media (min-width: 1200px) {
+  body.skin-noirjack {
+    font-size: 22px;
+  }
+}
+
+body.skin-noirjack .noirjack-app {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+body.skin-noirjack .noirjack-felt {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 25% 20%, rgba(45, 212, 191, 0.08), transparent 55%),
+    radial-gradient(circle at 70% 80%, rgba(233, 196, 106, 0.08), transparent 60%),
+    linear-gradient(180deg, rgba(6, 78, 59, 0.96), rgba(2, 17, 12, 0.98));
+  pointer-events: none;
+  z-index: 0;
+}
+
+body.skin-noirjack .noirjack-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 32px);
+  padding: clamp(18px, 5vw, 36px);
+}
+
+body.skin-noirjack .nj-topbar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 2vw, 18px);
+  z-index: 10;
+}
+
+body.skin-noirjack .nj-logo {
+  font-family: "Cinzel", "Times New Roman", serif;
+  letter-spacing: 0.32em;
+  font-size: clamp(1.1rem, 5vw, 1.6rem);
+}
+
+body.skin-noirjack .nj-topbar__brand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+body.skin-noirjack .nj-topbar__controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+body.skin-noirjack .nj-topbar__mode {
+  display: flex;
+  justify-content: flex-end;
+}
+
+body.skin-noirjack .nj-topbar__mode > * {
+  border-color: rgba(233, 196, 106, 0.3) !important;
+  background: rgba(15, 23, 42, 0.4) !important;
+  color: var(--nj-text) !important;
+}
+
+body.skin-noirjack .nj-topbar__mode button {
+  color: var(--nj-text-muted) !important;
+}
+
+body.skin-noirjack .nj-topbar__mode button[aria-pressed="true"] {
+  background: rgba(45, 212, 191, 0.2) !important;
+  color: var(--nj-text) !important;
+  border-radius: 999px;
+}
+
+body.skin-noirjack .nj-topbar__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 14px clamp(16px, 4vw, 22px);
+}
+
+@media (min-width: 640px) {
+  body.skin-noirjack .nj-topbar__stats {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  body.skin-noirjack .nj-topbar__stats {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+}
+
+body.skin-noirjack .nj-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+body.skin-noirjack .nj-stat__label {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.24em;
+  color: var(--nj-text-muted);
+}
+
+body.skin-noirjack .nj-stat__value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+body.skin-noirjack .nj-glass {
+  background: var(--nj-glass);
+  border: 1px solid var(--nj-outline);
+  border-radius: 20px;
+  box-shadow: var(--nj-shadow);
+  backdrop-filter: blur(10px) saturate(1.1);
+}
+
+body.skin-noirjack .nj-panel {
+  padding: clamp(18px, 4vw, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+  align-items: center;
+  text-align: center;
+}
+
+body.skin-noirjack .nj-panel__header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+}
+
+body.skin-noirjack .nj-panel__title {
+  font-size: 0.75rem;
+  color: var(--nj-text-muted);
+}
+
+body.skin-noirjack .nj-panel__subtitle {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+body.skin-noirjack .nj-panel__meta {
+  display: inline-flex;
+  gap: 18px;
+}
+
+body.skin-noirjack .nj-panel__value {
+  display: block;
+  font-size: clamp(1rem, 4vw, 1.4rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+body.skin-noirjack .nj-panel__footer {
+  width: 100%;
+  padding-top: 10px;
+  border-top: 1px solid rgba(233, 196, 106, 0.2);
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  color: var(--nj-text-muted);
+  text-transform: uppercase;
+}
+
+body.skin-noirjack .nj-section {
+  position: relative;
+}
+
+body.skin-noirjack .nj-hand-carousel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  width: 100%;
+  align-items: center;
+}
+
+body.skin-noirjack .nj-hand-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  width: 100%;
+}
+
+body.skin-noirjack .nj-hand-tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 120px;
+  padding: 8px 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--nj-text-muted);
+}
+
+body.skin-noirjack .nj-hand-tab--active {
+  color: var(--nj-text);
+  border-color: rgba(233, 196, 106, 0.45);
+  background: rgba(233, 196, 106, 0.14);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+}
+
+body.skin-noirjack .nj-coach-banner {
+  width: 100%;
+  border-radius: 18px;
+  padding: 12px 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+body.skin-noirjack .nj-coach-banner--good {
+  background: rgba(34, 197, 94, 0.18);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  color: rgba(45, 255, 160, 0.9);
+}
+
+body.skin-noirjack .nj-coach-banner--warn {
+  background: rgba(233, 196, 106, 0.18);
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  color: rgba(233, 196, 106, 0.92);
+}
+
+body.skin-noirjack .nj-controls {
+  position: relative;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 28px);
+  padding: clamp(16px, 4vw, 32px);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(4, 10, 10, 0.65) 100%);
+}
+
+body.skin-noirjack .nj-controls__tray,
+body.skin-noirjack .nj-controls__actions {
+  padding: clamp(16px, 3vw, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 3vw, 22px);
+}
+
+body.skin-noirjack .nj-controls__tray-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.72rem;
+  color: var(--nj-text-muted);
+}
+
+body.skin-noirjack .nj-chip-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+body.skin-noirjack .nj-chip {
+  outline: 1px solid rgba(233, 196, 106, 0.45);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.45), inset 0 2px 12px rgba(0, 0, 0, 0.35);
+  transition: transform 0.16s ease, box-shadow 0.16s ease, outline-color 0.16s ease;
+}
+
+body.skin-noirjack .nj-chip:hover:not(.is-disabled) {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.55);
+}
+
+body.skin-noirjack .nj-chip.is-selected {
+  outline: 2px solid rgba(233, 196, 106, 0.85);
+  box-shadow: 0 0 0 3px rgba(233, 196, 106, 0.32), 0 18px 32px rgba(0, 0, 0, 0.55);
+}
+
+body.skin-noirjack .nj-chip .chip-value {
+  color: rgba(0, 0, 0, 0.82);
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.42);
+}
+
+body.skin-noirjack .nj-tray-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+body.skin-noirjack .nj-controls__actions {
+  gap: clamp(12px, 2vw, 18px);
+}
+
+body.skin-noirjack .nj-actions-primary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+body.skin-noirjack .nj-actions-secondary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+body.skin-noirjack .nj-actions-round {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+body.skin-noirjack .nj-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--nj-outline);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--nj-text);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+  min-height: 48px;
+}
+
+body.skin-noirjack .nj-btn-primary {
+  color: var(--nj-text);
+  background: linear-gradient(180deg, #0f7a63, #0b6150);
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  box-shadow: 0 12px 24px rgba(6, 24, 16, 0.45);
+}
+
+body.skin-noirjack .nj-btn-primary:hover {
+  background: linear-gradient(180deg, #13a38a, #0b6150);
+}
+
+body.skin-noirjack .nj-btn--ghost {
+  background: rgba(255, 255, 255, 0.02);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: var(--nj-text);
+}
+
+body.skin-noirjack .nj-btn:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+body.skin-noirjack .nj-btn[disabled] {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+body.skin-noirjack .nj-controls__tray button,
+body.skin-noirjack .nj-controls__actions button {
+  font-size: 0.75rem;
+}
+
+body.skin-noirjack .nj-coach-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--nj-text);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.7rem;
+}
+
+body.skin-noirjack .nj-coach-toggle__label {
+  color: var(--nj-text-muted);
+}
+
+body.skin-noirjack .nj-coach-toggle__value {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(233, 196, 106, 0.18);
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  letter-spacing: 0.28em;
+}
+
+body.skin-noirjack .nj-card-fan {
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  position: relative;
+  pointer-events: none;
+}
+
+body.skin-noirjack .nj-card-fan__item {
+  position: relative;
+  pointer-events: none;
+}
+
+body.skin-noirjack .nj-card-wrapper {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  perspective: 1200px;
+  display: block;
+  transform-origin: center bottom;
+}
+
+body.skin-noirjack .nj-card-wrapper--deal {
+  animation: njDealWrapper 0.34s ease-out;
+}
+
+body.skin-noirjack .nj-card {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  transform-style: preserve-3d;
+  transition: transform 0.32s ease;
+  box-shadow: var(--nj-shadow);
+  background: var(--nj-card-face);
+}
+
+body.skin-noirjack .nj-card-wrapper[data-facedown="true"] .nj-card {
+  transform: rotateY(180deg);
+}
+
+body.skin-noirjack .nj-card__face,
+body.skin-noirjack .nj-card__back {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  backface-visibility: hidden;
+}
+
+body.skin-noirjack .nj-card__face {
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #0f172a;
+  background: var(--nj-card-face);
+}
+
+body.skin-noirjack .nj-card__face[data-tone="red"] {
+  color: #ef4444;
+}
+
+body.skin-noirjack .nj-card__corner {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  font-weight: 600;
+  font-size: clamp(0.9rem, 4vw, 1.1rem);
+}
+
+body.skin-noirjack .nj-card__corner--top {
+  left: 10px;
+  top: 10px;
+}
+
+body.skin-noirjack .nj-card__corner--bottom {
+  right: 10px;
+  bottom: 10px;
+  transform: rotate(180deg);
+}
+
+body.skin-noirjack .nj-card__pip {
+  font-size: clamp(1.6rem, 6vw, 2rem);
+  opacity: 0.8;
+}
+
+body.skin-noirjack .nj-card__back {
+  transform: rotateY(180deg);
+  background: linear-gradient(135deg, rgba(4, 11, 16, 0.95), rgba(8, 18, 24, 0.95));
+  border: 1px solid rgba(233, 196, 106, 0.45);
+  overflow: hidden;
+}
+
+body.skin-noirjack .nj-card__back-border {
+  position: absolute;
+  inset: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(233, 196, 106, 0.35);
+}
+
+body.skin-noirjack .nj-card__back-pattern {
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+      45deg,
+      rgba(233, 196, 106, 0.1) 0,
+      rgba(233, 196, 106, 0.1) 12px,
+      transparent 12px,
+      transparent 24px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      rgba(233, 196, 106, 0.08) 0,
+      rgba(233, 196, 106, 0.08) 12px,
+      transparent 12px,
+      transparent 24px
+    );
+  opacity: 0.9;
+}
+
+body.skin-noirjack .nj-chip[data-chip-motion^="add"] {
+  animation: njChipBounce 0.22s ease-out;
+}
+
+body.skin-noirjack .nj-chip[data-chip-motion^="remove"] {
+  animation: njChipFade 0.22s ease-out;
+}
+
+body.skin-noirjack .nj-result {
+  position: fixed;
+  top: clamp(80px, 25vh, 160px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(233, 196, 106, 0.3);
+  background: rgba(10, 18, 24, 0.78);
+  box-shadow: var(--nj-shadow);
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-weight: 600;
+  opacity: 0;
+  animation: njResultFade 1.8s ease forwards;
+  z-index: 30;
+}
+
+body.skin-noirjack .nj-result--win {
+  color: var(--nj-win);
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+body.skin-noirjack .nj-result--lose {
+  color: var(--nj-lose);
+  border-color: rgba(220, 38, 38, 0.45);
+}
+
+body.skin-noirjack .nj-result--push {
+  color: rgba(233, 196, 106, 0.92);
+  border-color: rgba(233, 196, 106, 0.45);
+}
+
+body.skin-noirjack .nj-error {
+  padding: 10px 14px;
+  margin-top: 6px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  background: rgba(220, 38, 38, 0.22);
+  border-color: rgba(220, 38, 38, 0.4);
+  color: #fecdd3;
+}
+
+body.skin-noirjack .nj-insurance {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 10, 12, 0.68);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: clamp(18px, 6vw, 36px);
+}
+
+body.skin-noirjack .nj-insurance__sheet {
+  width: min(520px, 100%);
+  border-radius: 26px 26px 18px 18px;
+  padding: clamp(20px, 5vw, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  text-align: center;
+}
+
+body.skin-noirjack .nj-insurance__sheet h2 {
+  margin: 0;
+  font-family: "Cinzel", serif;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 1rem;
+}
+
+body.skin-noirjack .nj-insurance__sheet p {
+  margin: 0;
+  color: var(--nj-text-muted);
+}
+
+body.skin-noirjack .nj-insurance__actions {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+body.skin-noirjack .nj-result__label {
+  font-size: 0.85rem;
+}
+
+body.skin-noirjack .nj-sticky-bottom {
+  position: sticky;
+  bottom: 0;
+  padding-bottom: max(env(safe-area-inset-bottom), 12px);
+}
+
+body.skin-noirjack [data-coach="best"] {
+  box-shadow: 0 0 0 2px rgba(233, 196, 106, 0.55), 0 0 18px rgba(233, 196, 106, 0.35);
+  position: relative;
+}
+
+body.skin-noirjack [data-coach="best"]::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(ellipse at center, rgba(233, 196, 106, 0.12), transparent 70%);
+  animation: njPulse 1.8s ease-in-out infinite;
+}
+
+body.skin-noirjack .nj-chip[data-chip-motion] {
+  pointer-events: auto;
+}
+
+body.skin-noirjack .nj-card-wrapper,
+body.skin-noirjack .nj-card {
+  pointer-events: none;
+}
+
+@keyframes njDealWrapper {
+  0% {
+    transform: translate3d(-28px, -48px, 0) scale(0.92);
+    opacity: 0;
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes njChipBounce {
+  0% {
+    transform: translateY(6px) scale(0.92);
+    opacity: 0.6;
+  }
+  70% {
+    transform: translateY(-4px) scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes njChipFade {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(4px) scale(0.9);
+  }
+}
+
+@keyframes njResultFade {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -12px);
+  }
+  15% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  85% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, 8px);
+  }
+}
+
+@keyframes njPulse {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.skin-noirjack .nj-card {
+    transition: none;
+  }
+  body.skin-noirjack .nj-card-wrapper--deal,
+  body.skin-noirjack .nj-chip[data-chip-motion],
+  body.skin-noirjack .nj-result {
+    animation: none !important;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -337,8 +337,37 @@ body.skin-noirjack .noirjack-content {
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: clamp(16px, 3vw, 32px);
-  padding: clamp(18px, 5vw, 36px);
+  flex: 1;
+  min-height: 0;
+  gap: clamp(12px, 3vw, 24px);
+  padding: clamp(16px, 4vw, 32px);
+}
+
+body.skin-noirjack .nj-play-area {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  gap: clamp(12px, 3vw, 24px);
+  align-items: stretch;
+}
+
+@media (max-width: 480px) {
+  body.skin-noirjack .nj-play-area {
+    grid-template-rows: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  }
+}
+
+@media (min-width: 481px) and (max-width: 1024px) {
+  body.skin-noirjack .nj-play-area {
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1025px) {
+  body.skin-noirjack .nj-play-area {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: minmax(0, 1fr);
+  }
 }
 
 body.skin-noirjack .nj-topbar {
@@ -440,8 +469,10 @@ body.skin-noirjack .nj-panel {
   display: flex;
   flex-direction: column;
   gap: clamp(16px, 3vw, 24px);
-  align-items: center;
+  align-items: stretch;
   text-align: center;
+  flex: 1;
+  min-height: 0;
 }
 
 body.skin-noirjack .nj-panel__header {
@@ -475,6 +506,15 @@ body.skin-noirjack .nj-panel__value {
   letter-spacing: 0.08em;
 }
 
+body.skin-noirjack .nj-panel__cards {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
 body.skin-noirjack .nj-panel__footer {
   width: 100%;
   padding-top: 10px;
@@ -487,6 +527,10 @@ body.skin-noirjack .nj-panel__footer {
 
 body.skin-noirjack .nj-section {
   position: relative;
+  min-height: 0;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
 }
 
 body.skin-noirjack .nj-hand-carousel {
@@ -495,6 +539,9 @@ body.skin-noirjack .nj-hand-carousel {
   gap: 18px;
   width: 100%;
   align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 0;
 }
 
 body.skin-noirjack .nj-hand-tabs {
@@ -560,12 +607,38 @@ body.skin-noirjack .nj-controls {
   background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(4, 10, 10, 0.65) 100%);
 }
 
+body.skin-noirjack .nj-controls__layout {
+  display: grid;
+  gap: clamp(14px, 3vw, 24px);
+}
+
+@media (min-width: 481px) {
+  body.skin-noirjack .nj-controls__layout {
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+    align-items: stretch;
+  }
+}
+
+@media (min-width: 960px) {
+  body.skin-noirjack .nj-controls__layout {
+    grid-template-columns: minmax(0, 0.75fr) minmax(0, 1.25fr);
+  }
+}
+
+body.skin-noirjack .nj-controls__tray-slot {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 body.skin-noirjack .nj-controls__tray,
 body.skin-noirjack .nj-controls__actions {
   padding: clamp(16px, 3vw, 24px);
   display: flex;
   flex-direction: column;
   gap: clamp(14px, 3vw, 22px);
+  height: 100%;
+  min-height: 0;
 }
 
 body.skin-noirjack .nj-controls__tray-header {
@@ -578,10 +651,21 @@ body.skin-noirjack .nj-controls__tray-header {
   color: var(--nj-text-muted);
 }
 
+body.skin-noirjack .nj-controls__tray-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
 body.skin-noirjack .nj-chip-row {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+body.skin-noirjack .nj-chip-trigger {
+  width: 100%;
+  min-height: 56px;
 }
 
 body.skin-noirjack .nj-chip {
@@ -956,6 +1040,51 @@ body.skin-noirjack .nj-chip[data-chip-motion] {
 body.skin-noirjack .nj-card-wrapper,
 body.skin-noirjack .nj-card {
   pointer-events: none;
+}
+
+body.skin-noirjack .nj-chip-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0 clamp(16px, 5vw, 32px) calc(max(env(safe-area-inset-bottom), 20px));
+  background: rgba(4, 10, 10, 0.6);
+}
+
+body.skin-noirjack .nj-chip-sheet__backdrop {
+  position: absolute;
+  inset: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+body.skin-noirjack .nj-chip-sheet__panel {
+  position: relative;
+  width: min(100%, 420px);
+  border-radius: 24px 24px 0 0;
+  padding: clamp(18px, 5vw, 26px);
+}
+
+body.skin-noirjack .nj-chip-sheet__close {
+  appearance: none;
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.48);
+  color: var(--nj-text);
+  padding: 6px 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.65rem;
+  cursor: pointer;
+}
+
+body.skin-noirjack .nj-chip-sheet__close:focus-visible {
+  outline: 2px solid rgba(233, 196, 106, 0.7);
+  outline-offset: 2px;
 }
 
 @keyframes njDealWrapper {

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -3,7 +3,7 @@ import { Table } from "../components/Table";
 import { useGameStore } from "../store/useGameStore";
 import { Button } from "../components/ui/button";
 import { isSingleSeatMode, PRIMARY_SEAT_INDEX } from "../ui/config";
-import { MobileTable } from "../components/mobile/MobileTable";
+import { NoirJackTable } from "../components/noirjack/NoirJackTable";
 import { useDisplayMode } from "../ui/displayMode";
 import { UIModeToggle } from "../components/UIModeToggle";
 import type { DisplayMode } from "../ui/displayMode";
@@ -77,9 +77,19 @@ export const App: React.FC = () => {
     />
   );
 
-  if (displayMode === "mobile") {
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    document.body.classList.toggle("skin-noirjack", displayMode === "noirjack");
+    return () => {
+      document.body.classList.remove("skin-noirjack");
+    };
+  }, [displayMode]);
+
+  if (displayMode === "noirjack") {
     return (
-      <MobileTable
+      <NoirJackTable
         game={game}
         coachMode={coachMode}
         actions={actions}

--- a/src/ui/displayMode.ts
+++ b/src/ui/displayMode.ts
@@ -1,12 +1,26 @@
 import React from "react";
 
-export type DisplayMode = "classic" | "mobile";
+export type DisplayMode = "classic" | "noirjack";
 
-const DISPLAY_QUERY_KEY = "ui";
+const DISPLAY_QUERY_KEY = "skin";
+const LEGACY_QUERY_KEY = "ui";
 const DISPLAY_STORAGE_KEY = "ui.display";
-const DEFAULT_MODE: DisplayMode = "classic";
+const DEFAULT_MODE: DisplayMode = "noirjack";
 
-const isValidMode = (value: string | null): value is DisplayMode => value === "classic" || value === "mobile";
+const isValidMode = (value: string | null): value is DisplayMode => value === "classic" || value === "noirjack";
+
+const mapLegacyMode = (value: string | null): DisplayMode | null => {
+  if (!value) {
+    return null;
+  }
+  if (value === "classic") {
+    return "classic";
+  }
+  if (value === "mobile" || value === "noirjack") {
+    return "noirjack";
+  }
+  return null;
+};
 
 const readStoredMode = (): DisplayMode | null => {
   if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
@@ -14,8 +28,9 @@ const readStoredMode = (): DisplayMode | null => {
   }
   try {
     const stored = window.localStorage.getItem(DISPLAY_STORAGE_KEY);
-    if (isValidMode(stored)) {
-      return stored;
+    const mapped = mapLegacyMode(stored);
+    if (mapped) {
+      return mapped;
     }
   } catch {
     // ignore storage errors
@@ -42,8 +57,10 @@ const setQueryParam = (mode: DisplayMode): void => {
     const url = new URL(window.location.href);
     if (mode === DEFAULT_MODE) {
       url.searchParams.delete(DISPLAY_QUERY_KEY);
+      url.searchParams.delete(LEGACY_QUERY_KEY);
     } else {
       url.searchParams.set(DISPLAY_QUERY_KEY, mode);
+      url.searchParams.set(LEGACY_QUERY_KEY, mode);
     }
     window.history.replaceState({}, "", url.toString());
   } catch {
@@ -57,10 +74,11 @@ const resolveInitialMode = (): DisplayMode => {
   }
   try {
     const params = new URLSearchParams(window.location.search);
-    const queryMode = params.get(DISPLAY_QUERY_KEY);
-    if (isValidMode(queryMode)) {
-      persistMode(queryMode);
-      return queryMode;
+    const queryMode = params.get(DISPLAY_QUERY_KEY) ?? params.get(LEGACY_QUERY_KEY);
+    const mappedQuery = mapLegacyMode(queryMode);
+    if (mappedQuery) {
+      persistMode(mappedQuery);
+      return mappedQuery;
     }
   } catch {
     // ignore query parse errors

--- a/tests/components/mobile/hooks.test.ts
+++ b/tests/components/mobile/hooks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { computeCardMetrics } from "../../../src/components/mobile/hooks";
+
+describe("computeCardMetrics", () => {
+  it("limits card width when viewport height is tight", () => {
+    const metrics = computeCardMetrics(480, { width: 480, height: 520 });
+    expect(metrics.width).toBeLessThanOrEqual(Math.round((520 * 0.28) / 1.4));
+    expect(metrics.height).toBe(Math.round(metrics.width * 1.4));
+  });
+
+  it("clamps card width to the maximum when space allows", () => {
+    const metrics = computeCardMetrics(800, { width: 800, height: 1080 });
+    expect(metrics.width).toBe(132);
+    expect(metrics.height).toBe(Math.round(132 * 1.4));
+  });
+
+  it("never goes below the minimum card width", () => {
+    const metrics = computeCardMetrics(120, { width: 120, height: 400 });
+    expect(metrics.width).toBeGreaterThanOrEqual(64);
+  });
+});


### PR DESCRIPTION
## Summary
- add the NoirJack table experience with dealer/player layout, chip tray, action bar, insurance sheet, and result banner that reuse the existing engine actions
- create NoirJack-specific card and fan components to deliver the new card materials and animations
- introduce NoirJack design tokens, typography, and button/chip styles while defaulting the UI mode switcher to the new skin and keeping the classic table accessible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5483c06bc8329903b337f4179afe8