### PR TITLE
Add NoirJack fireworks celebration on wins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-slot": "^1.0.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
+        "fireworks-js": "^2.10.8",
         "framer-motion": "^12.23.22",
         "howler": "^2.2.4",
         "lucide-react": "^0.363.0",
@@ -3445,6 +3446,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/fireworks-js": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/fireworks-js/-/fireworks-js-2.10.8.tgz",
+      "integrity": "sha512-UZNxeJvRmQzLisN4iriWXqKojG9TDJqc0dPmkUw0/+AEQQ3w8z1Jx2YdFSiBGSVb/u4dPTQXU109GMVblzhfpg==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "fireworks-js": "^2.10.8",
     "framer-motion": "^12.23.22",
     "howler": "^2.2.4",
     "lucide-react": "^0.363.0",

--- a/src/components/effects/FireworksOverlay.tsx
+++ b/src/components/effects/FireworksOverlay.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { Fireworks, type FireworksOptions } from "fireworks-js";
+import { cn } from "../../utils/cn";
+
+export interface FireworksOverlayHandle {
+  start(durationMs?: number): void;
+  stop(): void;
+}
+
+interface FireworksOverlayProps {
+  disabled?: boolean;
+  intensity?: "default" | "reduced";
+  className?: string;
+}
+
+const MIN_DURATION = 1200;
+
+const createOptions = (intensity: "default" | "reduced"): FireworksOptions => {
+  const softened = intensity === "reduced";
+  const particles = softened ? 45 : 80;
+  const explosion = softened ? 4.2 : 5.4;
+  const intensityValue = softened ? 22 : 34;
+  return {
+    hue: { min: 38, max: 165 },
+    brightness: { min: 55, max: 85 },
+    opacity: 0.38,
+    acceleration: 1.02,
+    friction: 0.96,
+    gravity: 1.55,
+    particles,
+    explosion,
+    intensity: intensityValue,
+    traceLength: softened ? 3 : 3.5,
+    traceSpeed: softened ? 1.6 : 1.9,
+    lineWidth: {
+      trace: { min: 0.6, max: 1.1 },
+      explosion: { min: 1.3, max: 1.9 }
+    },
+    decay: { min: 0.012, max: 0.028 },
+    flickering: softened ? 35 : 48,
+    delay: { min: softened ? 22 : 16, max: softened ? 32 : 26 },
+    mouse: { click: false, move: false, max: 0 },
+    sound: { enabled: false, files: [], volume: { min: 0, max: 0 } },
+    autoresize: true,
+    rocketsPoint: { min: 20, max: 80 },
+  };
+};
+
+export const FireworksOverlay = React.forwardRef<FireworksOverlayHandle, FireworksOverlayProps>(
+  ({ disabled = false, intensity = "default", className }, ref) => {
+    const containerRef = React.useRef<HTMLDivElement | null>(null);
+    const fireworksRef = React.useRef<Fireworks | null>(null);
+    const stopTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const options = React.useMemo(() => createOptions(intensity), [intensity]);
+
+    const stopInternal = React.useCallback(() => {
+      if (stopTimerRef.current !== null) {
+        clearTimeout(stopTimerRef.current);
+        stopTimerRef.current = null;
+      }
+      const instance = fireworksRef.current;
+      if (instance) {
+        instance.stop();
+        instance.clear();
+      }
+    }, []);
+
+    const ensureInstance = React.useCallback((): Fireworks | null => {
+      if (!containerRef.current) {
+        return null;
+      }
+      if (!fireworksRef.current) {
+        fireworksRef.current = new Fireworks(containerRef.current, options);
+        return fireworksRef.current;
+      }
+      fireworksRef.current.updateOptions(options);
+      return fireworksRef.current;
+    }, [options]);
+
+    const start = React.useCallback(
+      (durationMs?: number) => {
+        if (disabled) {
+          return;
+        }
+        const instance = ensureInstance();
+        if (!instance) {
+          return;
+        }
+        stopInternal();
+        instance.updateOptions(options);
+        instance.start();
+        const duration = Math.max(MIN_DURATION, durationMs ?? 3200);
+        const schedule =
+          typeof window !== "undefined"
+            ? window.setTimeout
+            : (fn: () => void, ms?: number) => setTimeout(fn, ms);
+        stopTimerRef.current = schedule(() => {
+          stopInternal();
+        }, duration);
+      },
+      [disabled, ensureInstance, options, stopInternal]
+    );
+
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        start,
+        stop: stopInternal,
+      }),
+      [start, stopInternal]
+    );
+
+    React.useEffect(() => () => {
+      stopInternal();
+      fireworksRef.current?.stop(true);
+      fireworksRef.current = null;
+    }, [stopInternal]);
+
+    React.useEffect(() => {
+      if (typeof document === "undefined") {
+        return;
+      }
+      const handleVisibility = (): void => {
+        if (document.hidden) {
+          stopInternal();
+        }
+      };
+      document.addEventListener("visibilitychange", handleVisibility);
+      return () => {
+        document.removeEventListener("visibilitychange", handleVisibility);
+      };
+    }, [stopInternal]);
+
+    return <div ref={containerRef} className={cn("nj-fireworks", className)} aria-hidden />;
+  }
+);
+
+FireworksOverlay.displayName = "FireworksOverlay";

--- a/src/index.css
+++ b/src/index.css
@@ -1351,6 +1351,156 @@ body.skin-noirjack .nj-chip-sheet__close:focus-visible {
   outline-offset: 2px;
 }
 
+body.skin-noirjack .nj-fireworks {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 38;
+  mix-blend-mode: screen;
+}
+
+body.skin-noirjack .nj-fireworks canvas {
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 0 18px rgba(233, 196, 106, 0.22))
+    drop-shadow(0 0 28px rgba(45, 212, 191, 0.18));
+}
+
+body.skin-noirjack .nj-settings {
+  position: fixed;
+  inset: 0;
+  z-index: 48;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(20px, 6vw, 40px);
+  background: rgba(4, 10, 10, 0.6);
+}
+
+body.skin-noirjack .nj-settings__backdrop {
+  position: absolute;
+  inset: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+body.skin-noirjack .nj-settings__panel {
+  position: relative;
+  width: min(520px, 100%);
+  border-radius: 26px;
+  padding: clamp(24px, 6vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+body.skin-noirjack .nj-settings__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+body.skin-noirjack .nj-settings__header h2 {
+  margin: 0;
+  font-family: "Cinzel", serif;
+  font-size: 1rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+}
+
+body.skin-noirjack .nj-settings__close {
+  appearance: none;
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.48);
+  color: var(--nj-text);
+  padding: 6px 18px;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.65rem;
+  cursor: pointer;
+}
+
+body.skin-noirjack .nj-settings__close:focus-visible {
+  outline: 2px solid rgba(233, 196, 106, 0.7);
+  outline-offset: 2px;
+}
+
+body.skin-noirjack .nj-settings__section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+body.skin-noirjack .nj-settings__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+body.skin-noirjack .nj-settings__info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 240px;
+}
+
+body.skin-noirjack .nj-settings__label {
+  color: var(--nj-text);
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-family: "Cinzel", serif;
+}
+
+body.skin-noirjack .nj-settings__description {
+  font-size: 0.75rem;
+  color: var(--nj-text-muted);
+}
+
+body.skin-noirjack .nj-settings__note {
+  font-size: 0.72rem;
+  color: rgba(233, 196, 106, 0.85);
+  letter-spacing: 0.04em;
+}
+
+body.skin-noirjack .nj-settings__toggle {
+  appearance: none;
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.58);
+  color: var(--nj-text);
+  padding: 8px 22px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  cursor: pointer;
+  min-width: 80px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+body.skin-noirjack .nj-settings__toggle--on {
+  background: linear-gradient(120deg, rgba(233, 196, 106, 0.9), rgba(45, 212, 191, 0.85));
+  color: #0b1f19;
+  border-color: rgba(233, 196, 106, 0.75);
+  box-shadow:
+    0 0 0 2px rgba(233, 196, 106, 0.35),
+    0 10px 24px rgba(6, 78, 59, 0.35);
+}
+
+body.skin-noirjack .nj-settings__toggle:focus-visible {
+  outline: 2px solid rgba(45, 212, 191, 0.85);
+  outline-offset: 2px;
+}
+
 @keyframes njDealWrapper {
   0% {
     transform: translate3d(-28px, -48px, 0) scale(0.92);

--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -16,7 +16,8 @@ export type SoundKey =
   | "split"
   | "surrender"
   | "insurancePrompt"
-  | "invalid";
+  | "invalid"
+  | "celebration";
 
 export interface SoundDefinition {
   src: string;

--- a/src/services/soundProfiles.ts
+++ b/src/services/soundProfiles.ts
@@ -22,6 +22,7 @@ import splitSoft from "../assets/audio/3 Card Playing FX2_2.wav";
 import surrenderSoft from "../assets/audio/1 Card Playing FX2_4.wav";
 import insuranceSoft from "../assets/audio/Card Dealing FX 1.wav";
 import invalidSoft from "../assets/audio/0 Card Playing FX2_3.wav";
+import celebrationBurst from "../assets/audio/Card Deal 4.wav"; // TODO: Replace with a proper fireworks SFX (soft layered "whoosh + pop")
 
 export const classicSoundProfile: SoundProfile = {
   id: "classic",
@@ -42,7 +43,8 @@ export const classicSoundProfile: SoundProfile = {
     double: { src: classicDeal, volume: 0.38 },
     split: { src: classicFlip, volume: 0.32 },
     surrender: { src: classicInsurance, volume: 0.34 },
-    invalid: { src: classicPush, volume: 0.3 }
+    invalid: { src: classicPush, volume: 0.3 },
+    celebration: { src: celebrationBurst, volume: 0.52 }
   }
 };
 
@@ -65,6 +67,7 @@ export const noirSoundProfile: SoundProfile = {
     split: { src: splitSoft, volume: 0.32 },
     surrender: { src: surrenderSoft, volume: 0.3 },
     insurancePrompt: { src: insuranceSoft, volume: 0.32 },
-    invalid: { src: invalidSoft, volume: 0.28 }
+    invalid: { src: invalidSoft, volume: 0.28 },
+    celebration: { src: celebrationBurst, volume: 0.45 }
   }
 };


### PR DESCRIPTION
## Summary
- introduce a reusable FireworksOverlay powered by fireworks-js for NoirJack win and blackjack celebrations with brand-tuned effects and throttled audio
- add a Settings dialog with a persistent celebrations toggle that respects prefers-reduced-motion defaults and stops effects when modals open
- wire celebrations into settlement handling and extend the audio profiles with a temporary fireworks clip

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5914348ac8329b53bab9d929e774e