### PR TITLE
fix: raise noirjack insurance overlay layer

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1234,6 +1234,7 @@ body.skin-noirjack .nj-error {
 body.skin-noirjack .nj-insurance {
   position: fixed;
   inset: 0;
+  z-index: 50;
   background: rgba(3, 10, 12, 0.68);
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
## Summary
- raise the NoirJack insurance overlay onto its own z-layer so the dialog renders above the table

## Testing
- npm run lint *(fails: PlayerHandView hook dependency warning from existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68e6394b7a308329bd22aa9d9a4804a8