### PR TITLE
Fix auto-stand when player reaches 21

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -344,6 +344,10 @@ export const playerHit = (state: GameState): void => {
     hand.isResolved = true;
     appendLog(state, `Seat ${hand.parentSeatIndex + 1} busts`);
     moveToNextHand(state);
+  } else if (bestTotal(hand) === 21) {
+    hand.isResolved = true;
+    appendLog(state, `Seat ${hand.parentSeatIndex + 1} stands on 21`);
+    moveToNextHand(state);
   }
 };
 

--- a/src/engine/rules.ts
+++ b/src/engine/rules.ts
@@ -25,6 +25,9 @@ export const canHit = (hand: Hand): boolean => {
   if (hand.isSplitAce && hand.cards.length >= 2) {
     return false;
   }
+  if (bestTotal(hand) === 21) {
+    return false;
+  }
   return !isBust(hand);
 };
 

--- a/tests/actions.test.ts
+++ b/tests/actions.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { initGame, deal, playerDouble, playerSurrender, playDealer, settleAllHands } from "../src/engine/engine";
+import {
+  initGame,
+  deal,
+  playerDouble,
+  playerHit,
+  playerSurrender,
+  playDealer,
+  settleAllHands
+} from "../src/engine/engine";
 import type { Card } from "../src/engine/types";
 
 const card = (rank: Card["rank"], suit: Card["suit"] = "♠"): Card => ({ rank, suit });
@@ -38,5 +46,18 @@ describe("double and surrender", () => {
     playerSurrender(game);
     expect(game.seats[0].hands[0].isSurrendered).toBe(true);
     expect(game.bankroll).toBe(95);
+  });
+
+  it("auto stands when hit results in 21", () => {
+    const game = initGame();
+    game.seats[0].occupied = true;
+    game.seats[0].baseBet = 10;
+    game.shoe.cards = [card("10"), card("7"), card("5"), card("6"), card("6"), card("K")];
+    deal(game);
+    playerHit(game);
+    const hand = game.seats[0].hands[0];
+    expect(hand.isResolved).toBe(true);
+    expect(game.phase).toBe("dealerPlay");
+    expect(game.activeHandId).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- resolve player hands automatically when a hit brings the total to 21
- prevent the UI from offering further hits after reaching 21
- cover the behaviour with a regression test for the action flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e65ca59a9c8329a64881a9e70511fd