### PR TITLE
feat: rebuild bet control for noir

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -14,6 +14,7 @@ interface TableProps {
   actions: {
     sit: (seatIndex: number) => void;
     leave: (seatIndex: number) => void;
+    setBet: (seatIndex: number, amount: number) => void;
     addChip: (seatIndex: number, denom: number) => void;
     removeChipValue: (seatIndex: number, denom: number) => void;
     removeTopChip: (seatIndex: number) => void;
@@ -107,6 +108,7 @@ export const Table: React.FC<TableProps> = ({ game, coachMode, actions, onCoachM
     () => ({
       sit: restrictSeatAction(actions.sit),
       leave: restrictSeatAction(actions.leave),
+      setBet: restrictSeatAction(actions.setBet),
       addChip: restrictSeatAction(actions.addChip),
       removeChipValue: restrictSeatAction(actions.removeChipValue),
       removeTopChip: restrictSeatAction(actions.removeTopChip),

--- a/src/components/betting/BetControl.tsx
+++ b/src/components/betting/BetControl.tsx
@@ -1,0 +1,526 @@
+import React from "react";
+import { Chip } from "../hud/Chip";
+import { useHoldRepeat } from "../../hooks/useHoldRepeat";
+import { useLongPress } from "../../hooks/useLongPress";
+import {
+  makeChange,
+  reconcileChipItems,
+  type ChipItem,
+  type Denom,
+} from "../../utils/chips";
+
+const EURO_FORMATTER = new Intl.NumberFormat("fr-FR", {
+  style: "currency",
+  currency: "EUR",
+});
+
+const formatEuro = (value: number): string => {
+  const parts = EURO_FORMATTER.formatToParts(value);
+  const currency = parts.find((part) => part.type === "currency")?.value ?? "€";
+  const number = parts
+    .filter((part) => part.type !== "currency")
+    .map((part) => part.value)
+    .join("")
+    .trim();
+  return `${currency}${number}`;
+};
+
+const DEFAULT_DENOMS: ReadonlyArray<Denom> = [500, 100, 25, 5, 1];
+const MAX_CHIPS_PER_COLUMN = 10;
+const HOLD_SOURCE = "hold" as const;
+
+export type BetBlockReason = "min" | "bankroll" | "max" | "disabled";
+
+type HoldDirection = "increment" | "decrement";
+
+type BetControlProps = {
+  amount: number;
+  min: number;
+  max: number;
+  bankroll: number;
+  disabled?: boolean;
+  denoms?: ReadonlyArray<Denom>;
+  prefersReducedMotion?: boolean;
+  onChange: (amount: number) => void;
+  onCommit?: (delta: number) => void;
+  onBlocked?: (reason: BetBlockReason) => void;
+  onUndo?: (previous: number | null) => void;
+};
+
+interface DeltaHintState {
+  direction: HoldDirection;
+  amount: number;
+}
+
+const clampValue = (
+  target: number,
+  {
+    min,
+    max,
+    bankroll,
+    canAffordMin,
+  }: { min: number; max: number; bankroll: number; canAffordMin: boolean }
+): { value: number; reason: BetBlockReason | null } => {
+  if (!canAffordMin) {
+    const value = Math.max(0, Math.min(Math.floor(target), Math.floor(bankroll)));
+    return { value, reason: bankroll <= 0 ? "bankroll" : null };
+  }
+
+  const floored = Math.floor(target);
+  const cappedByBankroll = Math.min(floored, Math.floor(bankroll));
+  const capped = Math.min(cappedByBankroll, Math.floor(max));
+  const finalValue = Math.max(min, Math.max(0, capped));
+
+  if (finalValue === min && floored < min) {
+    return { value: finalValue, reason: "min" };
+  }
+  if (finalValue === Math.floor(bankroll) && floored > bankroll) {
+    return { value: finalValue, reason: "bankroll" };
+  }
+  if (Number.isFinite(max) && finalValue === Math.floor(max) && floored > max) {
+    return { value: finalValue, reason: "max" };
+  }
+  return { value: finalValue, reason: null };
+};
+
+const useChipStack = (amount: number, denoms: ReadonlyArray<Denom>): ChipItem[] => {
+  const idRef = React.useRef(0);
+  const [items, setItems] = React.useState<ChipItem[]>(() => {
+    const initial = makeChange(amount, denoms);
+    return initial.map((value) => ({
+      id: `chip-${value}-${idRef.current++}`,
+      value,
+    }));
+  });
+
+  React.useEffect(() => {
+    const nextValues = makeChange(amount, denoms);
+    setItems((previous) =>
+      reconcileChipItems(previous, nextValues, () => `chip-${idRef.current++}`)
+    );
+  }, [amount, denoms]);
+
+  return items;
+};
+
+const useFeedback = () => {
+  const [message, setMessage] = React.useState<string | null>(null);
+  const timerRef = React.useRef<number | null>(null);
+
+  const clear = React.useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const show = React.useCallback(
+    (text: string) => {
+      clear();
+      setMessage(text);
+      timerRef.current = window.setTimeout(() => {
+        setMessage(null);
+        timerRef.current = null;
+      }, 1800);
+    },
+    [clear]
+  );
+
+  React.useEffect(() => () => clear(), [clear]);
+
+  return { message, show, clear };
+};
+
+const reasonMessage = (
+  reason: BetBlockReason,
+  {
+    min,
+    max,
+    bankroll,
+  }: { min: number; max: number; bankroll: number }
+): string => {
+  switch (reason) {
+    case "min":
+      return `Min bet ${formatEuro(min)}`;
+    case "max":
+      return `Max bet ${formatEuro(Math.floor(max))}`;
+    case "bankroll":
+      return `Insufficient bankroll (${formatEuro(Math.floor(bankroll))})`;
+    case "disabled":
+    default:
+      return "Betting locked";
+  }
+};
+
+const splitIntoColumns = (items: ChipItem[]): ChipItem[][] => {
+  const columns: ChipItem[][] = [];
+  for (let index = 0; index < items.length; index += MAX_CHIPS_PER_COLUMN) {
+    columns.push(items.slice(index, index + MAX_CHIPS_PER_COLUMN));
+  }
+  return columns;
+};
+
+const usePrevious = <T,>(value: T): T | undefined => {
+  const ref = React.useRef<T>();
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+};
+
+const ChipShortcut: React.FC<{
+  value: Denom;
+  disabled: boolean;
+  className?: string;
+  onAdd: () => void;
+  onSubtract: () => void;
+  onContextMenu: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}> = ({ value, disabled, className, onAdd, onSubtract, onContextMenu }) => {
+  const handlers = useLongPress(
+    () => {
+      onSubtract();
+    },
+    () => {
+      onAdd();
+    },
+    { disabled }
+  );
+
+  return (
+    <Chip
+      value={value}
+      size={52}
+      className={className}
+      disabled={disabled}
+      aria-label={`Adjust bet by ${value}`}
+      onContextMenu={onContextMenu}
+      {...handlers}
+    />
+  );
+};
+
+export const BetControl: React.FC<BetControlProps> = ({
+  amount,
+  min,
+  max,
+  bankroll,
+  disabled = false,
+  denoms = DEFAULT_DENOMS,
+  prefersReducedMotion = false,
+  onChange,
+  onCommit,
+  onBlocked,
+  onUndo,
+}) => {
+  const normalizedMax = Number.isFinite(max) ? max : Number.MAX_SAFE_INTEGER;
+  const canAffordMin = bankroll >= min && min > 0;
+  const incrementsDisabled = disabled || !canAffordMin;
+  const { message, show: showFeedback } = useFeedback();
+  const [deltaHint, setDeltaHint] = React.useState<DeltaHintState | null>(null);
+  const historyRef = React.useRef<number[]>([]);
+  const prevAmount = usePrevious(amount);
+
+  React.useEffect(() => {
+    if (prevAmount !== undefined && prevAmount !== amount) {
+      if (historyRef.current.length > 64) {
+        historyRef.current.splice(0, historyRef.current.length - 64);
+      }
+    }
+  }, [amount, prevAmount]);
+
+  const chipItems = useChipStack(amount, denoms);
+  const columns = splitIntoColumns(chipItems);
+
+  const triggerBlocked = React.useCallback(
+    (reason: BetBlockReason) => {
+      if (onBlocked) {
+        onBlocked(reason);
+      }
+      if (reason !== "disabled") {
+        showFeedback(reasonMessage(reason, { min, max: normalizedMax, bankroll }));
+      }
+    },
+    [bankroll, min, normalizedMax, onBlocked, showFeedback]
+  );
+
+  const commitChange = React.useCallback(
+    (next: number, deltaSource?: { direction: HoldDirection; origin?: typeof HOLD_SOURCE }) => {
+      const sanitizedNext = Math.floor(next);
+      if (sanitizedNext === amount) {
+        return false;
+      }
+      historyRef.current.push(amount);
+      onChange(sanitizedNext);
+      if (onCommit) {
+        onCommit(sanitizedNext - amount);
+      }
+      if (deltaSource?.origin === HOLD_SOURCE) {
+        const difference = sanitizedNext - amount;
+        const magnitude = Math.abs(difference);
+        if (magnitude > 0) {
+          setDeltaHint((current) => {
+            if (!current || current.direction !== deltaSource.direction) {
+              return { direction: deltaSource.direction, amount: magnitude };
+            }
+            return {
+              direction: current.direction,
+              amount: current.amount + magnitude,
+            };
+          });
+        }
+      } else {
+        setDeltaHint(null);
+      }
+      return true;
+    },
+    [amount, onChange, onCommit]
+  );
+
+  const evaluateAndCommit = React.useCallback(
+    (
+      target: number,
+      options?: { direction: HoldDirection; origin?: typeof HOLD_SOURCE }
+    ): boolean => {
+      if (disabled) {
+        triggerBlocked("disabled");
+        return false;
+      }
+      const { value, reason } = clampValue(target, {
+        min,
+        max: normalizedMax,
+        bankroll,
+        canAffordMin,
+      });
+      const changed = commitChange(value, options);
+      if (!changed && reason) {
+        triggerBlocked(reason);
+      }
+      return changed;
+    },
+    [bankroll, canAffordMin, commitChange, disabled, min, normalizedMax, triggerBlocked]
+  );
+
+  const handleIncrement = React.useCallback(
+    (step: number, origin?: typeof HOLD_SOURCE): boolean =>
+      evaluateAndCommit(amount + step, { direction: "increment", origin }),
+    [amount, evaluateAndCommit]
+  );
+
+  const handleDecrement = React.useCallback(
+    (step: number, origin?: typeof HOLD_SOURCE): boolean =>
+      evaluateAndCommit(amount - step, { direction: "decrement", origin }),
+    [amount, evaluateAndCommit]
+  );
+
+  const plusHold = useHoldRepeat(() => handleIncrement(1, HOLD_SOURCE), {
+    disabled: incrementsDisabled,
+    onStop: prefersReducedMotion ? undefined : () => setDeltaHint(null),
+  });
+  const minusHold = useHoldRepeat(() => handleDecrement(1, HOLD_SOURCE), {
+    disabled,
+    onStop: prefersReducedMotion ? undefined : () => setDeltaHint(null),
+  });
+
+  const handlePlusClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const step = event.shiftKey ? 5 : 1;
+      handleIncrement(step);
+    },
+    [handleIncrement]
+  );
+
+  const handleMinusClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const step = event.shiftKey ? 5 : 1;
+      handleDecrement(step);
+    },
+    [handleDecrement]
+  );
+
+  const handleChipAdd = React.useCallback(
+    (value: Denom) => handleIncrement(value),
+    [handleIncrement]
+  );
+
+  const handleChipSubtract = React.useCallback(
+    (value: Denom) => handleDecrement(value),
+    [handleDecrement]
+  );
+
+  const [pulsingChip, setPulsingChip] = React.useState<{ value: Denom; direction: HoldDirection } | null>(
+    null
+  );
+  const pulseTimer = React.useRef<number | null>(null);
+
+  const triggerPulse = React.useCallback(
+    (value: Denom, direction: HoldDirection) => {
+      if (prefersReducedMotion) {
+        return;
+      }
+      if (pulseTimer.current !== null) {
+        window.clearTimeout(pulseTimer.current);
+      }
+      setPulsingChip({ value, direction });
+      pulseTimer.current = window.setTimeout(() => {
+        setPulsingChip(null);
+        pulseTimer.current = null;
+      }, 240);
+    },
+    [prefersReducedMotion]
+  );
+
+  React.useEffect(() => () => {
+    if (pulseTimer.current !== null) {
+      window.clearTimeout(pulseTimer.current);
+    }
+  }, []);
+
+  const handleUndo = React.useCallback(() => {
+    if (disabled) {
+      triggerBlocked("disabled");
+      return;
+    }
+    const previous = historyRef.current.pop() ?? null;
+    if (previous === null) {
+      if (onUndo) {
+        onUndo(null);
+      }
+      return;
+    }
+    onChange(previous);
+    if (onUndo) {
+      onUndo(previous);
+    }
+    if (onCommit) {
+      onCommit(previous - amount);
+    }
+  }, [amount, disabled, onChange, onCommit, onUndo, triggerBlocked]);
+
+  const affordHint = !canAffordMin;
+
+  return (
+    <div className="nj-bet-control nj-glass">
+      <div className="nj-bet-control__top">
+        <div className="nj-bet-control__summary">
+          <span className="nj-bet-control__label">Bet</span>
+          <span className="nj-bet-control__amount">{formatEuro(amount)}</span>
+          {!prefersReducedMotion && deltaHint ? (
+            <span
+              className={"nj-bet-control__delta"}
+              data-direction={deltaHint.direction}
+            >
+              {deltaHint.direction === "increment" ? "+" : "-"}
+              {deltaHint.amount}
+            </span>
+          ) : null}
+        </div>
+        {onUndo ? (
+          <button
+            type="button"
+            className="nj-bet-control__undo"
+            onClick={handleUndo}
+            disabled={disabled || historyRef.current.length === 0}
+            aria-label="Undo last bet adjustment"
+          >
+            Undo
+          </button>
+        ) : null}
+      </div>
+
+      <div className="nj-bet-control__stepper" aria-hidden={disabled}>
+        <button
+          type="button"
+          className="nj-bet-control__step"
+          onClick={handleMinusClick}
+          disabled={disabled}
+          {...minusHold}
+        >
+          −
+        </button>
+        <button
+          type="button"
+          className="nj-bet-control__step"
+          onClick={handlePlusClick}
+          disabled={incrementsDisabled}
+          {...plusHold}
+        >
+          +
+        </button>
+      </div>
+
+      <div className="nj-bet-control__rack" role="group" aria-label="Chip shortcuts">
+        {denoms.map((value) => {
+          const isPulsing = pulsingChip?.value === value;
+          return (
+            <ChipShortcut
+              key={value}
+              value={value}
+              disabled={disabled}
+              className={"nj-bet-chip" + (isPulsing ? " is-pulsing" : "")}
+              onAdd={() => {
+                if (handleChipAdd(value)) {
+                  triggerPulse(value, "increment");
+                }
+              }}
+              onSubtract={() => {
+                if (handleChipSubtract(value)) {
+                  triggerPulse(value, "decrement");
+                }
+              }}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                if (handleChipSubtract(value)) {
+                  triggerPulse(value, "decrement");
+                }
+              }}
+            />
+          );
+        })}
+      </div>
+
+      <div className="nj-bet-control__stack" aria-hidden={chipItems.length === 0}>
+        {columns.map((column, columnIndex) => {
+          const height = 44 + Math.max(0, column.length - 1) * 12;
+          return (
+            <div
+              key={`column-${columnIndex}`}
+              className="nj-bet-stack__column"
+              style={{ height }}
+            >
+              {column.map((chip, index) => (
+                <div
+                  key={chip.id}
+                  className="nj-bet-stack__chip"
+                  style={{
+                    zIndex: column.length - index,
+                    bottom: index * 12,
+                  }}
+                >
+                  <Chip
+                    value={chip.value}
+                    size={44}
+                    className="nj-bet-stack__token"
+                    disabled
+                    aria-hidden
+                    tabIndex={-1}
+                  />
+                </div>
+              ))}
+            </div>
+          );
+        })}
+        {chipItems.length === 0 ? (
+          <span className="nj-bet-stack__empty">No chips</span>
+        ) : null}
+      </div>
+
+      <div className="nj-bet-control__footer" role="status" aria-live="polite">
+        {affordHint ? (
+          <span>Bankroll below minimum bet {formatEuro(min)}</span>
+        ) : message ? (
+          <span>{message}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+};

--- a/src/components/table/BetSpotOverlay.tsx
+++ b/src/components/table/BetSpotOverlay.tsx
@@ -4,6 +4,7 @@ import { Button } from "../ui/button";
 import { ChipSVG } from "./ChipSVG";
 import type { ChipDenomination } from "../../theme/palette";
 import { palette } from "../../theme/palette";
+import { makeChange } from "../../utils/chips";
 import { defaultTableAnchors, toPixels } from "./coords";
 import type { GameState, Seat } from "../../engine/types";
 import { formatCurrency } from "../../utils/currency";
@@ -77,7 +78,7 @@ export const BetSpotOverlay: React.FC<BetSpotOverlayProps> = ({
         const { x, y } = toPixels(anchor.x, anchor.y, dimensions);
         const scaleX = dimensions.width / defaultTableAnchors.viewBox.width;
         const circleSize = defaultTableAnchors.seatRadius * 2 * scaleX;
-        const chipStack = Array.isArray(seat.chips) ? seat.chips : [];
+        const chipStack = makeChange(seat.baseBet);
         const showSit = !isSingleSeatMode && isBettingPhase && !seat.occupied;
         const showLeave = !isSingleSeatMode && seat.occupied && isBettingPhase;
         const visibleStart = Math.max(0, chipStack.length - MAX_VISIBLE_CHIPS);

--- a/src/hooks/useHoldRepeat.ts
+++ b/src/hooks/useHoldRepeat.ts
@@ -1,0 +1,70 @@
+import React from "react";
+
+interface HoldRepeatOptions {
+  disabled?: boolean;
+  initialDelay?: number;
+  repeatInterval?: number;
+  onStop?: () => void;
+}
+
+interface HoldHandlers {
+  onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  onPointerUp: () => void;
+  onPointerLeave: () => void;
+  onPointerCancel: () => void;
+}
+
+export const useHoldRepeat = (
+  action: () => void,
+  { disabled = false, initialDelay = 350, repeatInterval = 70, onStop }: HoldRepeatOptions = {}
+): HoldHandlers => {
+  const actionRef = React.useRef(action);
+  const disabledRef = React.useRef(disabled);
+  const timeoutRef = React.useRef<number | null>(null);
+  const intervalRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    actionRef.current = action;
+  }, [action]);
+
+  React.useEffect(() => {
+    disabledRef.current = disabled;
+  }, [disabled]);
+
+  const clearTimers = React.useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    if (onStop) {
+      onStop();
+    }
+  }, [onStop]);
+
+  React.useEffect(() => () => clearTimers(), [clearTimers]);
+
+  const start = React.useCallback(() => {
+    if (disabledRef.current) {
+      return;
+    }
+    actionRef.current();
+    timeoutRef.current = window.setTimeout(() => {
+      intervalRef.current = window.setInterval(() => {
+        actionRef.current();
+      }, repeatInterval);
+    }, initialDelay);
+  }, [initialDelay, repeatInterval]);
+
+  return {
+    onPointerDown: () => {
+      start();
+    },
+    onPointerUp: clearTimers,
+    onPointerLeave: clearTimers,
+    onPointerCancel: clearTimers,
+  };
+};

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,103 @@
+import React from "react";
+
+interface LongPressOptions {
+  delay?: number;
+  disabled?: boolean;
+}
+
+interface LongPressHandlers {
+  onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  onPointerUp: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  onPointerLeave: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  onPointerCancel: (event: React.PointerEvent<HTMLButtonElement>) => void;
+}
+
+export const useLongPress = (
+  onLongPress: (event: React.PointerEvent<HTMLButtonElement>) => void,
+  onTap: (event: React.PointerEvent<HTMLButtonElement>) => void,
+  { delay = 400, disabled = false }: LongPressOptions = {}
+): LongPressHandlers => {
+  const timeoutRef = React.useRef<number | null>(null);
+  const longPressTriggered = React.useRef(false);
+  const disabledRef = React.useRef(disabled);
+  const longPressRef = React.useRef(onLongPress);
+  const tapRef = React.useRef(onTap);
+
+  React.useEffect(() => {
+    disabledRef.current = disabled;
+  }, [disabled]);
+
+  React.useEffect(() => {
+    longPressRef.current = onLongPress;
+  }, [onLongPress]);
+
+  React.useEffect(() => {
+    tapRef.current = onTap;
+  }, [onTap]);
+
+  const clearTimeoutRef = React.useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  React.useEffect(() => () => clearTimeoutRef(), [clearTimeoutRef]);
+
+  const handlePointerDown = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (disabledRef.current) {
+        return;
+      }
+      if (event.button !== undefined && event.button !== 0) {
+        return;
+      }
+      longPressTriggered.current = false;
+      if (event.currentTarget.setPointerCapture) {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }
+      clearTimeoutRef();
+      timeoutRef.current = window.setTimeout(() => {
+        longPressTriggered.current = true;
+        longPressRef.current(event);
+      }, delay);
+    },
+    [clearTimeoutRef, delay]
+  );
+
+  const handlePointerEnd = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>, shouldTriggerTap: boolean) => {
+      if (disabledRef.current) {
+        return;
+      }
+      if (
+        event.currentTarget.releasePointerCapture &&
+        event.currentTarget.hasPointerCapture &&
+        event.currentTarget.hasPointerCapture(event.pointerId)
+      ) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      const triggered = longPressTriggered.current;
+      clearTimeoutRef();
+      if (!triggered && shouldTriggerTap) {
+        tapRef.current(event);
+      }
+      longPressTriggered.current = false;
+    },
+    [clearTimeoutRef]
+  );
+
+  const handlePointerLeave = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      handlePointerEnd(event, false);
+    },
+    [handlePointerEnd]
+  );
+
+  return {
+    onPointerDown: handlePointerDown,
+    onPointerUp: (event) => handlePointerEnd(event, true),
+    onPointerLeave: handlePointerLeave,
+    onPointerCancel: handlePointerLeave,
+  };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -737,6 +737,213 @@ body.skin-noirjack .nj-controls__tray-slot {
   gap: 12px;
 }
 
+body.skin-noirjack .nj-bet-control__wrapper {
+  width: 100%;
+  max-width: 440px;
+  margin: 0 auto;
+}
+
+body.skin-noirjack .nj-bet-control {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px clamp(16px, 4vw, 22px) max(18px, env(safe-area-inset-bottom, 18px));
+  border-radius: 18px;
+  border: 1px solid rgba(233, 196, 106, 0.25);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+}
+
+body.skin-noirjack .nj-bet-control__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+body.skin-noirjack .nj-bet-control__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+body.skin-noirjack .nj-bet-control__label {
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.7rem;
+  color: rgba(233, 196, 106, 0.75);
+}
+
+body.skin-noirjack .nj-bet-control__amount {
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-weight: 700;
+  color: var(--nj-text);
+  line-height: 1.1;
+}
+
+body.skin-noirjack .nj-bet-control__delta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 4px;
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(233, 196, 106, 0.16);
+  color: var(--nj-text);
+  border: 1px solid rgba(233, 196, 106, 0.35);
+}
+
+body.skin-noirjack .nj-bet-control__delta[data-direction="decrement"] {
+  background: rgba(248, 113, 113, 0.14);
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+body.skin-noirjack .nj-bet-control__undo {
+  align-self: flex-start;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(233, 196, 106, 0.25);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--nj-text);
+  font-size: 0.65rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  transition: background 0.16s ease, border-color 0.16s ease;
+}
+
+body.skin-noirjack .nj-bet-control__undo:hover:not(:disabled) {
+  background: rgba(233, 196, 106, 0.16);
+  border-color: rgba(233, 196, 106, 0.45);
+}
+
+body.skin-noirjack .nj-bet-control__undo:disabled {
+  opacity: 0.45;
+}
+
+body.skin-noirjack .nj-bet-control__stepper {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+body.skin-noirjack .nj-bet-control__step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  font-weight: 600;
+  height: clamp(64px, 16vw, 82px);
+  border-radius: 18px;
+  border: 1px solid rgba(233, 196, 106, 0.35);
+  color: var(--nj-text);
+  background: linear-gradient(180deg, rgba(22, 57, 46, 0.95), rgba(12, 32, 26, 0.95));
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45);
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+  touch-action: manipulation;
+}
+
+body.skin-noirjack .nj-bet-control__step:hover:not(:disabled) {
+  background: linear-gradient(180deg, rgba(32, 80, 66, 0.98), rgba(16, 42, 34, 0.98));
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.5);
+}
+
+body.skin-noirjack .nj-bet-control__step:active:not(:disabled) {
+  transform: translateY(1px) scale(0.99);
+}
+
+body.skin-noirjack .nj-bet-control__step:disabled {
+  opacity: 0.4;
+}
+
+body.skin-noirjack .nj-bet-control__rack {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+body.skin-noirjack .nj-bet-chip {
+  outline: 1px solid rgba(233, 196, 106, 0.35);
+  box-shadow:
+    0 16px 34px rgba(0, 0, 0, 0.5),
+    inset 0 2px 8px rgba(0, 0, 0, 0.38);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, outline-color 0.18s ease;
+}
+
+body.skin-noirjack .nj-bet-chip:not(.is-disabled):hover {
+  transform: translateY(-6px);
+  outline-color: rgba(233, 196, 106, 0.8);
+  box-shadow: 0 22px 38px rgba(0, 0, 0, 0.6);
+}
+
+@keyframes nj-bet-chip-pulse {
+  from {
+    transform: translateY(-4px) scale(1.04);
+  }
+  to {
+    transform: translateY(0) scale(1);
+  }
+}
+
+body.skin-noirjack .nj-bet-chip.is-pulsing {
+  animation: nj-bet-chip-pulse 0.22s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.skin-noirjack .nj-bet-chip.is-pulsing {
+    animation: none;
+  }
+}
+
+body.skin-noirjack .nj-bet-control__stack {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 14px;
+  min-height: clamp(84px, 20vw, 120px);
+  position: relative;
+}
+
+body.skin-noirjack .nj-bet-stack__column {
+  position: relative;
+  width: 56px;
+}
+
+body.skin-noirjack .nj-bet-stack__chip {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+body.skin-noirjack .nj-bet-stack__token {
+  pointer-events: none;
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.45));
+}
+
+body.skin-noirjack .nj-bet-stack__empty {
+  color: var(--nj-text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+body.skin-noirjack .nj-bet-control__footer {
+  min-height: 18px;
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgba(233, 196, 106, 0.75);
+}
+
+body.skin-noirjack .nj-bet-control__footer span {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(233, 196, 106, 0.25);
+}
+
 body.skin-noirjack .nj-controls__tray,
 body.skin-noirjack .nj-controls__actions {
   padding: clamp(16px, 3vw, 24px);

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -19,6 +19,7 @@ export const App: React.FC = () => {
     setCoachMode,
     sit,
     leave,
+    setBet,
     addChip,
     removeChipValue,
     removeTopChip,
@@ -75,6 +76,7 @@ export const App: React.FC = () => {
   const actions = {
     sit,
     leave,
+    setBet,
     addChip,
     removeChipValue,
     removeTopChip,

--- a/src/utils/chips.ts
+++ b/src/utils/chips.ts
@@ -1,0 +1,91 @@
+export type Denom = 1 | 5 | 25 | 100 | 500;
+
+const DEFAULT_DENOMS: ReadonlyArray<Denom> = [500, 100, 25, 5, 1];
+
+/**
+ * Greedy coin change for canonical Euro chip denominations. Returns the set ordered
+ * from largest to smallest value.
+ */
+export const makeChange = (
+  amount: number,
+  denoms: ReadonlyArray<Denom> = DEFAULT_DENOMS
+): Denom[] => {
+  const output: Denom[] = [];
+  const ordered = [...denoms].sort((a, b) => b - a) as Denom[];
+  let rest = Math.max(0, Math.floor(amount));
+  for (const denom of ordered) {
+    while (rest >= denom) {
+      output.push(denom);
+      rest -= denom;
+    }
+  }
+  return output;
+};
+
+export interface StackDiff {
+  add: Denom[];
+  remove: Denom[];
+}
+
+/**
+ * Produces the multiset difference required to reconcile the previous stack with the
+ * next stack. Both stacks are treated as unordered multisets.
+ */
+export const diffStacks = (prev: Denom[], next: Denom[]): StackDiff => {
+  const prevCounts = new Map<Denom, number>();
+  for (const value of prev) {
+    prevCounts.set(value, (prevCounts.get(value) ?? 0) + 1);
+  }
+
+  const additions: Denom[] = [];
+  for (const value of next) {
+    const existing = prevCounts.get(value) ?? 0;
+    if (existing > 0) {
+      prevCounts.set(value, existing - 1);
+    } else {
+      additions.push(value);
+    }
+  }
+
+  const removals: Denom[] = [];
+  for (const [value, remaining] of prevCounts) {
+    for (let index = 0; index < remaining; index += 1) {
+      removals.push(value);
+    }
+  }
+
+  return { add: additions, remove: removals };
+};
+
+export interface ChipItem {
+  id: string;
+  value: Denom;
+}
+
+/**
+ * Reconciles the previous rendered chip items with the next values, reusing existing
+ * identifiers whenever possible to minimise DOM churn and jitter.
+ */
+export const reconcileChipItems = (
+  previous: ChipItem[],
+  nextValues: Denom[],
+  createId: () => string
+): ChipItem[] => {
+  const pool = new Map<Denom, ChipItem[]>();
+  previous.forEach((item) => {
+    const bucket = pool.get(item.value);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      pool.set(item.value, [item]);
+    }
+  });
+
+  return nextValues.map((value) => {
+    const bucket = pool.get(value);
+    if (bucket && bucket.length > 0) {
+      return bucket.pop()!;
+    }
+    return { id: createId(), value };
+  });
+};


### PR DESCRIPTION
## Summary
- introduce a reusable BetControl component with hold-to-repeat steppers, chip shortcuts, and make-change reconciliation
- wire the Noir table to the new betting flow and update the table overlay to derive stacks from the current bet
- refresh Noir styling to showcase the glass bet panel and chip stack presentation

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e668843b108329a66cfb08f9d0c730