### PR TITLE
Refactor NoirJack table into modular components and hooks

### DIFF
--- a/src/components/noirjack/NoirJackTable.tsx
+++ b/src/components/noirjack/NoirJackTable.tsx
@@ -1,29 +1,41 @@
-import React from "react";
-import { Info, Settings2, Sparkles } from "lucide-react";
+import * as React from "react";
 import type { GameState, Hand } from "../../engine/types";
-import { PRIMARY_SEAT_INDEX, filterSeatsForMode } from "../../ui/config";
+import { bestTotal } from "../../engine/totals";
+import { PRIMARY_SEAT_INDEX } from "../../ui/config";
 import type { CoachMode } from "../../store/useGameStore";
 import type { ChipDenomination } from "../../theme/palette";
 import { formatCurrency } from "../../utils/currency";
-import { canDouble, canHit, canSplit, canSurrender } from "../../engine/rules";
-import {
-  getRecommendation,
-  type Action,
-  type PlayerContext,
-} from "../../utils/basicStrategy";
-import { NoirCardFan } from "./NoirCardFan";
-import { Chip } from "../hud/Chip";
-import { cn } from "../../utils/cn";
-import { bestTotal, isBust } from "../../engine/totals";
-import { ResultToast, type ResultKind } from "./ResultToast";
-import { NoirJackResultToaster } from "./NoirJackResultToaster";
 import { audioService } from "../../services/AudioService";
-import { NoirSoundControls } from "./NoirSoundControls";
+import type { Action } from "../../utils/basicStrategy";
+import { NoirJackResultToaster } from "./NoirJackResultToaster";
+import { FireworksOverlay } from "../effects/FireworksOverlay";
+import { Topbar } from "./components/Topbar";
+import { DealerPanel } from "./components/DealerPanel";
+import { PlayerPanel, type CoachMessage } from "./components/PlayerPanel";
+import { ActionsDock } from "./components/ActionsDock";
+import { BetTray } from "./components/BetTray";
+import { SettingsSheet } from "./components/SettingsSheet";
+import { InsuranceSheet } from "./components/InsuranceSheet";
+import { useMediaQuery } from "./hooks/useMediaQuery";
+import { usePrefersReducedMotion } from "./hooks/usePrefersReducedMotion";
+import { useHaptics } from "./hooks/useHaptics";
+import { useActionRecommendation } from "./hooks/useActionRecommendation";
+import { useCelebrations } from "./hooks/useCelebrations";
+import { useResultToastOnSettlement } from "./hooks/useResultToastOnSettlement";
+import { useFireworksOnWin } from "./hooks/useFireworksOnWin";
+import { useDealSoundOnNewCard } from "./hooks/useDealSoundOnNewCard";
+import { useFlipSoundOnHoleReveal } from "./hooks/useFlipSoundOnHoleReveal";
+import { useInsurancePromptSound } from "./hooks/useInsurancePromptSound";
+import { useMessageLogSounds } from "./hooks/useMessageLogSounds";
+import { useCelebrationPreference } from "./hooks/useCelebrationPreference";
 import {
-  FireworksOverlay,
-  type FireworksOverlayHandle,
-} from "../effects/FireworksOverlay";
-import logoImage from "../../assets/images/logo.png";
+  selectPrimarySeat,
+  findActiveHand,
+  deriveActionContext,
+  deriveActionAvailability,
+  deriveFaceDownIndexes,
+  deriveDealerStatus,
+} from "./selectors";
 
 interface NoirJackTableProps {
   game: GameState;
@@ -54,307 +66,15 @@ interface NoirJackTableProps {
 
 const CHIP_VALUES: ChipDenomination[] = [1, 5, 25, 100, 500];
 
-const CELEBRATIONS_STORAGE_KEY = "noirjack.celebrations";
-const CELEBRATION_SOUND_COOLDOWN_MS = 320;
-
-const getSystemPrefersReducedMotion = (): boolean => {
-  if (typeof window === "undefined" || !window.matchMedia) {
-    return false;
-  }
-  try {
-    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  } catch {
-    return false;
-  }
-};
-
-const readCelebrationsPreference = (): boolean | null => {
-  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
-    return null;
-  }
-  try {
-    const stored = window.localStorage.getItem(CELEBRATIONS_STORAGE_KEY);
-    if (stored === null) {
-      return null;
-    }
-    return stored === "true";
-  } catch {
-    return null;
-  }
-};
-
-const persistCelebrationsPreference = (enabled: boolean): void => {
-  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
-    return;
-  }
-  try {
-    window.localStorage.setItem(
-      CELEBRATIONS_STORAGE_KEY,
-      enabled ? "true" : "false"
-    );
-  } catch {
-    // ignore persistence errors
-  }
-};
-
-const hasReadySeat = (game: GameState): boolean => {
-  const seat = game.seats[PRIMARY_SEAT_INDEX];
-  if (!seat?.occupied) {
-    return false;
-  }
-  if (seat.baseBet < game.rules.minBet || seat.baseBet > game.rules.maxBet) {
-    return false;
-  }
-  return seat.baseBet > 0 && seat.baseBet <= game.bankroll;
-};
-
-const findActiveHand = (game: GameState): Hand | null => {
-  if (!game.activeHandId) {
-    return null;
-  }
-  for (const seat of filterSeatsForMode(game.seats)) {
-    const hand = seat.hands.find(
-      (candidate) => candidate.id === game.activeHandId
-    );
-    if (hand) {
-      return hand;
-    }
-  }
-  return null;
-};
+interface ChipMotion {
+  value: ChipDenomination;
+  type: "add" | "remove";
+  stamp: number;
+}
 
 const buildCoachMessage = (action: Action, correct: boolean): string => {
   const label = action.charAt(0).toUpperCase() + action.slice(1);
-  return correct
-    ? `Nice! ${label} was the right move.`
-    : `Try ${label} next time.`;
-};
-
-const usePrevious = <T,>(value: T): T | undefined => {
-  const ref = React.useRef<T>();
-  React.useEffect(() => {
-    ref.current = value;
-  }, [value]);
-  return ref.current;
-};
-
-const usePrefersReducedMotion = (): boolean => {
-  const [prefers, setPrefers] = React.useState<boolean>(getSystemPrefersReducedMotion);
-
-  React.useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) {
-      return;
-    }
-    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const listener = () => setPrefers(media.matches);
-    listener();
-    media.addEventListener("change", listener);
-    return () => media.removeEventListener("change", listener);
-  }, []);
-
-  return prefers;
-};
-
-const useMediaQuery = (query: string): boolean => {
-  const [matches, setMatches] = React.useState<boolean>(() => {
-    if (typeof window === "undefined" || !window.matchMedia) {
-      return false;
-    }
-    return window.matchMedia(query).matches;
-  });
-
-  React.useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) {
-      return;
-    }
-    const media = window.matchMedia(query);
-    const handler = () => setMatches(media.matches);
-    handler();
-    media.addEventListener("change", handler);
-    return () => media.removeEventListener("change", handler);
-  }, [query]);
-
-  return matches;
-};
-
-const useHaptics = (disabled: boolean): (() => void) => {
-  return React.useCallback(() => {
-    if (
-      disabled ||
-      typeof window === "undefined" ||
-      typeof navigator === "undefined"
-    ) {
-      return;
-    }
-    if (navigator.vibrate) {
-      navigator.vibrate(12);
-    }
-  }, [disabled]);
-};
-
-interface HandResolution {
-  net: number;
-  outcome: ResultKind;
-  detail?: string;
-}
-
-const normalizeAmount = (value: number): number => {
-  const rounded = Math.round(value * 100) / 100;
-  return Math.abs(rounded) < 0.005 ? 0 : rounded;
-};
-
-const describeHand = (hand: Hand, game: GameState): HandResolution => {
-  const bet = hand.bet;
-  const insurance = hand.insuranceBet ?? 0;
-  const dealerHand = game.dealer.hand;
-  const dealerBust = isBust(dealerHand);
-  const dealerBlackjack = dealerHand.isBlackjack;
-  const playerBust = isBust(hand);
-  const blackjackMultiplier = game.rules.blackjackPayout === "6:5" ? 1.2 : 1.5;
-
-  let net = 0;
-  let outcome: ResultKind = "push";
-  let detail: string | undefined;
-
-  if (hand.isSurrendered) {
-    net -= bet / 2;
-    outcome = "lose";
-    detail = "Surrendered";
-  } else if (dealerBlackjack) {
-    if (hand.isBlackjack) {
-      outcome = "push";
-      detail = "Blackjack push";
-    } else {
-      net -= bet;
-      outcome = "lose";
-      detail = "Dealer blackjack";
-    }
-  } else if (playerBust) {
-    net -= bet;
-    outcome = "lose";
-    detail = "Player busts";
-  } else if (hand.isBlackjack) {
-    net += bet * blackjackMultiplier;
-    outcome = "blackjack";
-    detail = `Blackjack ${game.rules.blackjackPayout}`;
-  } else if (dealerBust) {
-    net += bet;
-    outcome = "win";
-    detail = "Dealer busts";
-  } else {
-    const playerTotal = bestTotal(hand);
-    const dealerTotal = bestTotal(dealerHand);
-    if (playerTotal > dealerTotal) {
-      net += bet;
-      outcome = "win";
-      detail = `${playerTotal} vs ${dealerTotal}`;
-    } else if (playerTotal === dealerTotal) {
-      outcome = "push";
-      detail = `${playerTotal} each`;
-    } else {
-      net -= bet;
-      outcome = "lose";
-      detail = `${playerTotal} vs ${dealerTotal}`;
-    }
-  }
-
-  if (insurance > 0) {
-    if (dealerBlackjack) {
-      net += insurance * 2;
-      detail = detail ? `${detail} • Insurance pays` : "Insurance pays";
-    } else {
-      net -= insurance;
-      detail = detail ? `${detail} • Insurance lost` : "Insurance lost";
-    }
-  }
-
-  return { net, outcome, detail };
-};
-
-const summarizeSettlement = (
-  game: GameState
-): { kind: ResultKind; amount: number; details?: string } | null => {
-  const seat = game.seats[PRIMARY_SEAT_INDEX];
-  if (!seat || !seat.occupied) {
-    return null;
-  }
-  const hands = seat.hands;
-  if (!hands || hands.length === 0) {
-    return null;
-  }
-
-  const resolutions = hands.map((hand) => describeHand(hand, game));
-  const total = resolutions.reduce((sum, entry) => sum + entry.net, 0);
-  const amount = normalizeAmount(total);
-  const anyBlackjack = resolutions.some(
-    (entry) => entry.outcome === "blackjack" && entry.net > 0
-  );
-
-  let kind: ResultKind;
-  if (amount > 0) {
-    kind = anyBlackjack ? "blackjack" : "win";
-  } else if (amount < 0) {
-    kind = "lose";
-  } else {
-    kind = "push";
-  }
-
-  const details =
-    resolutions.length > 1
-      ? `${resolutions.length} hands settled`
-      : resolutions[0]?.detail;
-
-  const meaningful = resolutions.some(
-    (entry) => Math.abs(entry.net) > 0.004 || entry.outcome !== "push"
-  );
-  if (!meaningful && amount === 0) {
-    return { kind: "push", amount: 0, details };
-  }
-
-  return { kind, amount, details };
-};
-
-interface ActionAvailability {
-  hit: boolean;
-  stand: boolean;
-  double: boolean;
-  split: boolean;
-  surrender: boolean;
-  deal: boolean;
-  finishInsurance: boolean;
-  playDealer: boolean;
-  nextRound: boolean;
-}
-
-const CoachModeSelector: React.FC<{
-  mode: CoachMode;
-  onChange: (mode: CoachMode) => void;
-}> = ({ mode, onChange }) => {
-  const labels: Record<CoachMode, string> = {
-    off: "Off",
-    feedback: "Feedback",
-    live: "Live",
-  };
-
-  const next = React.useCallback(() => {
-    const order: CoachMode[] = ["off", "feedback", "live"];
-    const index = order.indexOf(mode);
-    const nextMode = order[(index + 1) % order.length];
-    onChange(nextMode);
-  }, [mode, onChange]);
-
-  return (
-    <button
-      type="button"
-      className="nj-btn nj-btn--ghost nj-coach-toggle"
-      onClick={next}
-      aria-label={`Toggle coach mode (currently ${labels[mode]})`}
-    >
-      <Sparkles size={16} aria-hidden="true" />
-      <span className="nj-coach-toggle__label">Coach</span>
-      <span className="nj-coach-toggle__value">{labels[mode]}</span>
-    </button>
-  );
+  return correct ? `Nice! ${label} was the right move.` : `Try ${label} next time.`;
 };
 
 export const NoirJackTable: React.FC<NoirJackTableProps> = ({
@@ -367,83 +87,54 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
   modeToggle,
 }) => {
   const [activeChip, setActiveChip] = React.useState<ChipDenomination>(25);
-  const [coachMessage, setCoachMessage] = React.useState<{
-    tone: "correct" | "better";
-    text: string;
-  } | null>(null);
+  const [chipMotion, setChipMotion] = React.useState<ChipMotion | null>(null);
+  const [coachMessage, setCoachMessage] = React.useState<CoachMessage | null>(null);
   const [flashAction, setFlashAction] = React.useState<Action | null>(null);
-  const messageTimer = React.useRef<number | null>(null);
-  const highlightTimer = React.useRef<number | null>(null);
-  const [chipMotion, setChipMotion] = React.useState<{
-    value: ChipDenomination;
-    type: "add" | "remove";
-    stamp: number;
-  } | null>(null);
-  const prefersReducedMotion = usePrefersReducedMotion();
-  const vibrate = useHaptics(prefersReducedMotion);
-  const isMobile = useMediaQuery("(max-width: 480px)");
-  const chipSheetId = React.useId();
-  const settingsSheetId = React.useId();
   const [chipsOpen, setChipsOpen] = React.useState(false);
   const [settingsOpen, setSettingsOpen] = React.useState(false);
-  const [hasStoredCelebrations, setHasStoredCelebrations] = React.useState<boolean>(
-    () => readCelebrationsPreference() !== null
-  );
-  const [celebrationsEnabled, setCelebrationsEnabled] = React.useState<boolean>(() => {
-    const stored = readCelebrationsPreference();
-    if (stored !== null) {
-      return stored;
-    }
-    return getSystemPrefersReducedMotion() ? false : true;
-  });
-  const fireworksRef = React.useRef<FireworksOverlayHandle | null>(null);
-  const celebrationSoundAtRef = React.useRef<number>(0);
-  const messageCountRef = React.useRef<number>(game.messageLog.length);
 
-  const toggleSettings = React.useCallback(() => {
-    setSettingsOpen((open) => !open);
-  }, []);
+  const chipSheetId = React.useId();
+  const settingsSheetId = React.useId();
 
-  const closeSettings = React.useCallback(() => {
-    setSettingsOpen(false);
-  }, []);
+  const messageTimer = React.useRef<number | undefined>();
+  const highlightTimer = React.useRef<number | undefined>();
 
-  const toggleCelebrations = React.useCallback(() => {
-    setCelebrationsEnabled((value) => {
-      const next = !value;
-      persistCelebrationsPreference(next);
-      setHasStoredCelebrations(true);
-      return next;
-    });
-  }, [setHasStoredCelebrations]);
+  const isMobile = useMediaQuery("(max-width: 480px)");
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const vibrate = useHaptics(prefersReducedMotion);
+
+  const celebrationPreference = useCelebrationPreference(prefersReducedMotion);
+  const celebrationsEnabled = celebrationPreference.enabled;
+
+  const { ref: fireworksRef, start: startCelebration, stop: stopCelebration, intensity } =
+    useCelebrations({ enabled: celebrationsEnabled, prefersReduced: prefersReducedMotion });
 
   React.useEffect(() => {
     if (messageTimer.current) {
       window.clearTimeout(messageTimer.current);
-      messageTimer.current = null;
+      messageTimer.current = undefined;
     }
     if (coachMessage) {
       messageTimer.current = window.setTimeout(() => {
         setCoachMessage(null);
-        messageTimer.current = null;
+        messageTimer.current = undefined;
       }, 2500);
     }
     return () => {
       if (messageTimer.current) {
         window.clearTimeout(messageTimer.current);
+        messageTimer.current = undefined;
       }
     };
   }, [coachMessage]);
 
-  React.useEffect(() => {
-    return () => {
-      if (highlightTimer.current) {
-        window.clearTimeout(highlightTimer.current);
-      }
-      if (messageTimer.current) {
-        window.clearTimeout(messageTimer.current);
-      }
-    };
+  React.useEffect(() => () => {
+    if (highlightTimer.current) {
+      window.clearTimeout(highlightTimer.current);
+    }
+    if (messageTimer.current) {
+      window.clearTimeout(messageTimer.current);
+    }
   }, []);
 
   React.useEffect(() => {
@@ -451,36 +142,6 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
       setChipsOpen(false);
     }
   }, [isMobile]);
-
-  React.useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const handleStorage = (event: StorageEvent) => {
-      if (event.key !== CELEBRATIONS_STORAGE_KEY || event.storageArea !== window.localStorage) {
-        return;
-      }
-      if (event.newValue === null) {
-        setHasStoredCelebrations(false);
-        const fallback = getSystemPrefersReducedMotion() ? false : true;
-        setCelebrationsEnabled(fallback);
-        return;
-      }
-      const parsed = event.newValue === "true";
-      setHasStoredCelebrations(true);
-      setCelebrationsEnabled(parsed);
-    };
-    window.addEventListener("storage", handleStorage);
-    return () => window.removeEventListener("storage", handleStorage);
-  }, []);
-
-  React.useEffect(() => {
-    if (hasStoredCelebrations) {
-      return;
-    }
-    const desired = prefersReducedMotion ? false : true;
-    setCelebrationsEnabled((current) => (current === desired ? current : desired));
-  }, [prefersReducedMotion, hasStoredCelebrations]);
 
   React.useEffect(() => {
     if (!settingsOpen) {
@@ -497,12 +158,6 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
   }, [settingsOpen]);
 
   React.useEffect(() => {
-    if (!celebrationsEnabled) {
-      fireworksRef.current?.stop();
-    }
-  }, [celebrationsEnabled]);
-
-  React.useEffect(() => {
     if (!chipsOpen || !isMobile) {
       return;
     }
@@ -516,98 +171,71 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [chipsOpen, isMobile]);
 
-  const seat = game.seats[PRIMARY_SEAT_INDEX] ?? null;
-  const activeHand = findActiveHand(game);
+  const seat = selectPrimarySeat(game);
+  const activeHand = React.useMemo<Hand | null>(() => findActiveHand(game), [game]);
+  const actionContext = React.useMemo(
+    () => deriveActionContext(game, activeHand, seat),
+    [game, activeHand, seat]
+  );
 
-  const actionContext = React.useMemo(() => {
-    if (!activeHand || !seat || game.phase !== "playerActions") {
-      return null;
-    }
-    return {
-      hand: activeHand,
-      hit: canHit(activeHand),
-      stand: !activeHand.isResolved,
-      double:
-        canDouble(activeHand, game.rules) && game.bankroll >= activeHand.bet,
-      split:
-        canSplit(activeHand, seat, game.rules) &&
-        game.bankroll >= activeHand.bet,
-      surrender: canSurrender(activeHand, game.rules),
-    };
-  }, [activeHand, game.bankroll, game.phase, game.rules, seat]);
+  const { recommendedAction, highlightedAction } = useActionRecommendation({
+    game,
+    hand: activeHand,
+    legal: actionContext,
+    coachMode,
+    dealerUpcard: game.dealer.upcard,
+    flashOverride: flashAction,
+  });
 
-  const dealerUpcard = game.dealer.upcard;
+  const availability = React.useMemo(
+    () => deriveActionAvailability(game, actionContext),
+    [game, actionContext]
+  );
 
-  const recommendation = React.useMemo(() => {
-    if (!actionContext || !dealerUpcard) {
-      return null;
-    }
-    const rank = dealerUpcard.rank as PlayerContext["dealerUpcard"]["rank"];
-    const context: PlayerContext = {
-      dealerUpcard: {
-        rank,
-        value10:
-          dealerUpcard.rank === "10" ||
-          dealerUpcard.rank === "J" ||
-          dealerUpcard.rank === "Q" ||
-          dealerUpcard.rank === "K",
-      },
-      cards: actionContext.hand.cards.map((card) => ({ rank: card.rank })),
-      isInitialTwoCards:
-        actionContext.hand.cards.length === 2 && !actionContext.hand.hasActed,
-      afterSplit: Boolean(actionContext.hand.isSplitHand),
-      legal: {
-        hit: actionContext.hit,
-        stand: actionContext.stand,
-        double: actionContext.double,
-        split: actionContext.split,
-        surrender: actionContext.surrender,
-      },
-    };
-    return getRecommendation(context, game.rules);
-  }, [actionContext, dealerUpcard, game.rules]);
+  const faceDownIndexes = React.useMemo(() => deriveFaceDownIndexes(game), [game]);
+  const dealerStatus = React.useMemo(
+    () => deriveDealerStatus(game, faceDownIndexes),
+    [game, faceDownIndexes]
+  );
 
-  const recommendedAction = React.useMemo<Action | null>(() => {
-    if (!recommendation || !actionContext) {
-      return null;
-    }
-    const isLegal = (action: Action | undefined): boolean => {
-      if (!action) {
-        return false;
-      }
-      switch (action) {
-        case "hit":
-          return actionContext.hit;
-        case "stand":
-          return actionContext.stand;
-        case "double":
-          return actionContext.double;
-        case "split":
-          return actionContext.split;
-        case "surrender":
-          return actionContext.surrender;
-        default:
-          return false;
-      }
-    };
-    if (isLegal(recommendation.best)) {
-      return recommendation.best;
-    }
-    if (recommendation.fallback && isLegal(recommendation.fallback)) {
-      return recommendation.fallback;
-    }
-    return null;
-  }, [actionContext, recommendation]);
+  const playerHands = React.useMemo<Hand[]>(() => seat?.hands ?? [], [seat]);
+  const rawActiveIndex = playerHands.findIndex((hand) => hand.id === game.activeHandId);
+  const resolvedActiveIndex =
+    rawActiveIndex >= 0 ? rawActiveIndex : playerHands.length > 0 ? 0 : -1;
+  const focusedHand =
+    activeHand ?? (resolvedActiveIndex >= 0 ? playerHands[resolvedActiveIndex] : null);
+  const playerTotal = focusedHand ? bestTotal(focusedHand) : null;
+  const playerBet = focusedHand?.bet ?? seat?.baseBet ?? 0;
 
-  const highlightedAction = React.useMemo<Action | null>(() => {
-    if (flashAction) {
-      return flashAction;
+  const stats = [
+    { label: "Bankroll", value: formatCurrency(game.bankroll) },
+    { label: "Round", value: game.roundCount },
+    { label: "Phase", value: game.phase },
+    { label: "Cards", value: game.shoe.cards.length },
+    { label: "Discard", value: game.shoe.discard.length },
+    { label: "Min", value: formatCurrency(game.rules.minBet) },
+    { label: "Max", value: formatCurrency(game.rules.maxBet) },
+  ];
+
+  const insurance = useInsurancePromptSound(game, audioService);
+
+  React.useEffect(() => {
+    if (chipsOpen || settingsOpen || insurance.open) {
+      stopCelebration();
     }
-    if (coachMode === "live") {
-      return recommendedAction;
-    }
-    return null;
-  }, [coachMode, flashAction, recommendedAction]);
+  }, [chipsOpen, settingsOpen, insurance.open, stopCelebration]);
+
+  useResultToastOnSettlement(game);
+  useFireworksOnWin(game, {
+    start: startCelebration,
+    stop: stopCelebration,
+    enabled: celebrationsEnabled,
+    prefersReduced: prefersReducedMotion,
+    audio: audioService,
+  });
+  useDealSoundOnNewCard(game, audioService);
+  useFlipSoundOnHoleReveal(game, audioService);
+  useMessageLogSounds(game.messageLog, audioService);
 
   const playActionTap = React.useCallback((action: Action) => {
     if (action === "hit" || action === "stand") {
@@ -630,7 +258,7 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
           }
           highlightTimer.current = window.setTimeout(() => {
             setFlashAction(null);
-            highlightTimer.current = null;
+            highlightTimer.current = undefined;
           }, 1000);
         } else {
           setFlashAction(null);
@@ -643,41 +271,11 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
     [coachMode, playActionTap, recommendedAction, vibrate]
   );
 
-  const handleHit = React.useCallback(
-    () => triggerFeedback("hit", actions.playerHit),
-    [actions.playerHit, triggerFeedback]
-  );
-  const handleStand = React.useCallback(
-    () => triggerFeedback("stand", actions.playerStand),
-    [actions.playerStand, triggerFeedback]
-  );
-  const handleDouble = React.useCallback(
-    () => triggerFeedback("double", actions.playerDouble),
-    [actions.playerDouble, triggerFeedback]
-  );
-  const handleSplit = React.useCallback(
-    () => triggerFeedback("split", actions.playerSplit),
-    [actions.playerSplit, triggerFeedback]
-  );
-  const handleSurrender = React.useCallback(
-    () => triggerFeedback("surrender", actions.playerSurrender),
-    [actions.playerSurrender, triggerFeedback]
-  );
-
-  const availability: ActionAvailability = React.useMemo(
-    () => ({
-      hit: Boolean(actionContext?.hit),
-      stand: Boolean(actionContext?.stand),
-      double: Boolean(actionContext?.double),
-      split: Boolean(actionContext?.split),
-      surrender: Boolean(actionContext?.surrender),
-      deal: game.phase === "betting" && hasReadySeat(game),
-      finishInsurance: game.phase === "insurance",
-      playDealer: game.phase === "dealerPlay",
-      nextRound: game.phase === "settlement",
-    }),
-    [actionContext, game]
-  );
+  const handleHit = React.useCallback(() => triggerFeedback("hit", actions.playerHit), [actions.playerHit, triggerFeedback]);
+  const handleStand = React.useCallback(() => triggerFeedback("stand", actions.playerStand), [actions.playerStand, triggerFeedback]);
+  const handleDouble = React.useCallback(() => triggerFeedback("double", actions.playerDouble), [actions.playerDouble, triggerFeedback]);
+  const handleSplit = React.useCallback(() => triggerFeedback("split", actions.playerSplit), [actions.playerSplit, triggerFeedback]);
+  const handleSurrender = React.useCallback(() => triggerFeedback("surrender", actions.playerSurrender), [actions.playerSurrender, triggerFeedback]);
 
   const handleAddChip = React.useCallback(
     (value: ChipDenomination) => {
@@ -723,8 +321,6 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
     setChipMotion({ value: activeChip, type: "remove", stamp: Date.now() });
   }, [actions, activeChip, game.phase, seat, vibrate]);
 
-  const closeChipSheet = React.useCallback(() => setChipsOpen(false), []);
-
   const handleSelectChip = React.useCallback(
     (value: ChipDenomination) => {
       setActiveChip(value);
@@ -765,55 +361,23 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
     }
   }, [handleRemoveTopChip, isMobile]);
 
-  const [insuranceHandId, insuranceAmount] = React.useMemo(() => {
-    if (game.phase !== "insurance" || !seat) {
-      return [null, 0] as const;
-    }
-    const hand = seat.hands.find(
-      (candidate) =>
-        candidate.insuranceBet === undefined && !candidate.isResolved
-    );
-    if (!hand) {
-      return [null, 0] as const;
-    }
-    return [hand.id, Math.min(hand.bet / 2, game.bankroll)];
-  }, [game.bankroll, game.phase, seat]);
-
-  const showInsuranceSheet = Boolean(
-    insuranceHandId && game.awaitingInsuranceResolution
-  );
-
-  const wasInsuranceOpen = usePrevious(showInsuranceSheet);
-
-  React.useEffect(() => {
-    if (showInsuranceSheet && !wasInsuranceOpen) {
-      audioService.play("insurancePrompt");
-    }
-  }, [showInsuranceSheet, wasInsuranceOpen]);
-
-  React.useEffect(() => {
-    if (chipsOpen || showInsuranceSheet || settingsOpen) {
-      fireworksRef.current?.stop();
-    }
-  }, [chipsOpen, showInsuranceSheet, settingsOpen]);
-
   const takeInsurance = React.useCallback(() => {
-    if (!insuranceHandId) {
+    if (!insurance.handId) {
       return;
     }
     audioService.play("button");
     vibrate();
-    actions.takeInsurance(PRIMARY_SEAT_INDEX, insuranceHandId, insuranceAmount);
-  }, [actions, insuranceAmount, insuranceHandId, vibrate]);
+    actions.takeInsurance(PRIMARY_SEAT_INDEX, insurance.handId, insurance.amount);
+  }, [actions, insurance.amount, insurance.handId, vibrate]);
 
   const skipInsurance = React.useCallback(() => {
-    if (!insuranceHandId) {
+    if (!insurance.handId) {
       return;
     }
     audioService.play("button");
     vibrate();
-    actions.declineInsurance(PRIMARY_SEAT_INDEX, insuranceHandId);
-  }, [actions, insuranceHandId, vibrate]);
+    actions.declineInsurance(PRIMARY_SEAT_INDEX, insurance.handId);
+  }, [actions, insurance.handId, vibrate]);
 
   const handleDeal = React.useCallback(() => {
     audioService.play("button");
@@ -839,428 +403,90 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
     actions.nextRound();
   }, [actions, vibrate]);
 
-  const prevPhase = usePrevious(game.phase);
-
-  React.useEffect(() => {
-    if (game.phase === "settlement" && prevPhase !== "settlement") {
-      const summary = summarizeSettlement(game);
-      if (summary) {
-        ResultToast.show(summary.kind, summary.amount, summary.details);
-        if (
-          celebrationsEnabled &&
-          (summary.kind === "win" || summary.kind === "blackjack")
-        ) {
-          const overlay = fireworksRef.current;
-          if (overlay) {
-            const duration = prefersReducedMotion
-              ? summary.kind === "blackjack"
-                ? 2600
-                : 2200
-              : summary.kind === "blackjack"
-              ? 3800
-              : 3200;
-            overlay.start(duration);
-            const now =
-              typeof performance !== "undefined"
-                ? performance.now()
-                : Date.now();
-            if (now - celebrationSoundAtRef.current >= CELEBRATION_SOUND_COOLDOWN_MS) {
-              celebrationSoundAtRef.current = now;
-              audioService.play("celebration");
-            }
-          }
-        }
-      }
+  const roundControls = React.useMemo(() => {
+    const controls: {
+      label: string;
+      onClick(): void;
+      disabled: boolean;
+      variant?: "primary" | "ghost";
+    }[] = [];
+    if (availability.deal) {
+      controls.push({
+        label: "Deal",
+        onClick: handleDeal,
+        disabled: !availability.deal,
+        variant: "primary",
+      });
     }
-  }, [game, prevPhase, celebrationsEnabled, prefersReducedMotion]);
-
-  React.useEffect(() => {
-    if (game.phase !== "settlement" && prevPhase === "settlement") {
-      fireworksRef.current?.stop();
+    if (availability.finishInsurance) {
+      controls.push({
+        label: "Finish insurance",
+        onClick: handleFinishInsurance,
+        disabled: !availability.finishInsurance,
+        variant: "ghost",
+      });
     }
-  }, [game.phase, prevPhase]);
-
-  const dealerCards = game.dealer.hand.cards;
-  const faceDownIndexes = React.useMemo(() => {
-    if (game.phase === "settlement" || game.phase === "dealerPlay") {
-      return [];
+    if (availability.playDealer) {
+      controls.push({
+        label: "Play dealer",
+        onClick: handlePlayDealer,
+        disabled: !availability.playDealer,
+        variant: "ghost",
+      });
     }
-    if (game.dealer.holeCard) {
-      return [1];
+    if (availability.nextRound) {
+      controls.push({
+        label: "Next round",
+        onClick: handleNextRound,
+        disabled: !availability.nextRound,
+        variant: "ghost",
+      });
     }
-    return [];
-  }, [game.dealer.holeCard, game.phase]);
+    return controls;
+  }, [availability, handleDeal, handleFinishInsurance, handlePlayDealer, handleNextRound]);
 
-  const totalCardCount = React.useMemo(() => {
-    const dealerCount = dealerCards.length + (game.dealer.holeCard ? 1 : 0);
-    const playerCount = game.seats.reduce((sum, seatItem) => {
-      const seatCards = seatItem.hands.reduce(
-        (inner, hand) => inner + hand.cards.length,
-        0
-      );
-      return sum + seatCards;
-    }, 0);
-    return dealerCount + playerCount;
-  }, [dealerCards, game.dealer.holeCard, game.seats]);
-  const previousCardCount = usePrevious(totalCardCount);
+  const closeChipSheet = React.useCallback(() => setChipsOpen(false), []);
 
-  React.useEffect(() => {
-    if (
-      typeof previousCardCount === "number" &&
-      totalCardCount > previousCardCount
-    ) {
-      audioService.play("deal");
-    }
-  }, [previousCardCount, totalCardCount]);
-
-  const playerHands = seat?.hands ?? [];
-  const rawActiveIndex = playerHands.findIndex(
-    (hand) => hand.id === game.activeHandId
-  );
-  const resolvedActiveIndex =
-    rawActiveIndex >= 0 ? rawActiveIndex : playerHands.length > 0 ? 0 : -1;
-  const focusedHand =
-    activeHand ??
-    (resolvedActiveIndex >= 0 ? playerHands[resolvedActiveIndex] : null);
-
-  const dealerStatus = React.useMemo(() => {
-    if (faceDownIndexes.length > 0 && game.dealer.upcard) {
-      return `Showing ${game.dealer.upcard.rank}`;
-    }
-    if (dealerCards.length > 0) {
-      return `Total ${bestTotal(game.dealer.hand)}`;
-    }
-    return "Waiting";
-  }, [dealerCards, faceDownIndexes, game.dealer.hand, game.dealer.upcard]);
-
-  const previousHoleCard = usePrevious(game.dealer.holeCard);
-
-  React.useEffect(() => {
-    if (previousHoleCard && !game.dealer.holeCard) {
-      audioService.play("flip");
-    }
-  }, [game.dealer.holeCard, previousHoleCard]);
-
-  const playerTotal = focusedHand ? bestTotal(focusedHand) : null;
-  const playerBet = focusedHand?.bet ?? seat?.baseBet ?? 0;
-
-  const errorBanner = error ? (
-    <div className="nj-glass nj-error" role="alert">
-      <span>{error}</span>
-      <button
-        type="button"
-        className="nj-btn nj-btn--ghost"
-        onClick={onDismissError}
-      >
-        Dismiss
-      </button>
-    </div>
-  ) : null;
-
-  const stats = [
-    { label: "Bankroll", value: formatCurrency(game.bankroll) },
-    { label: "Round", value: game.roundCount },
-    { label: "Phase", value: game.phase },
-    { label: "Cards", value: game.shoe.cards.length },
-    { label: "Discard", value: game.shoe.discard.length },
-    { label: "Min", value: formatCurrency(game.rules.minBet) },
-    { label: "Max", value: formatCurrency(game.rules.maxBet) },
-  ];
-
-  React.useEffect(() => {
-    if (game.messageLog.length <= messageCountRef.current) {
-      messageCountRef.current = game.messageLog.length;
-      return;
-    }
-    const newMessages = game.messageLog.slice(messageCountRef.current);
-    messageCountRef.current = game.messageLog.length;
-    newMessages.forEach((message) => {
-      const normalized = message.toLowerCase();
-      if (normalized.includes("shoe reshuffled")) {
-        audioService.play("shuffle");
-        return;
-      }
-      if (normalized.includes("doubles and draws")) {
-        audioService.play("double");
-        return;
-      }
-      if (/splits\s/.test(normalized)) {
-        audioService.play("split");
-        return;
-      }
-      if (normalized.includes("surrenders")) {
-        audioService.play("surrender");
-        return;
-      }
-      if (
-        normalized.includes("blackjack wins") ||
-        normalized.startsWith("dealer has blackjack")
-      ) {
-        audioService.play("blackjack");
-        return;
-      }
-      if (normalized.includes("busts and loses")) {
-        audioService.play("lose");
-        return;
-      }
-      if (normalized.endsWith("busts")) {
-        audioService.play("bust");
-        return;
-      }
-      if (normalized.includes("wins")) {
-        audioService.play("win");
-        return;
-      }
-      if (normalized.includes("pushes")) {
-        audioService.play("push");
-        return;
-      }
-      if (normalized.includes("loses")) {
-        audioService.play("lose");
-      }
-    });
-  }, [game.messageLog]);
-
-  const actionHighlight = (action: Action): "best" | undefined =>
-    highlightedAction === action ? "best" : undefined;
-
-  const roundControls = [
-    availability.deal
-      ? {
-          label: "Deal",
-          onClick: handleDeal,
-          disabled: !availability.deal,
-        }
-      : null,
-    availability.finishInsurance
-      ? {
-          label: "Finish insurance",
-          onClick: handleFinishInsurance,
-          disabled: !availability.finishInsurance,
-        }
-      : null,
-    availability.playDealer
-      ? {
-          label: "Play dealer",
-          onClick: handlePlayDealer,
-          disabled: !availability.playDealer,
-        }
-      : null,
-    availability.nextRound
-      ? {
-          label: "Next round",
-          onClick: handleNextRound,
-          disabled: !availability.nextRound,
-        }
-      : null,
-  ].filter(
-    (
-      control
-    ): control is { label: string; onClick: () => void; disabled: boolean } =>
-      control !== null
-  );
-
-  const renderChipTray = (options?: {
-    closable?: boolean;
-  }): React.ReactNode => (
-    <>
-      <div className="nj-controls__tray-header">
-        <span>Chips</span>
-        <div className="nj-controls__tray-meta">
-          <span>{formatCurrency(seat?.baseBet ?? 0)}</span>
-          {options?.closable ? (
-            <button
-              type="button"
-              className="nj-chip-sheet__close"
-              onClick={closeChipSheet}
-            >
-              Close
-            </button>
-          ) : null}
-        </div>
-      </div>
-      <div className="nj-chip-row">
-        {CHIP_VALUES.map((value) => (
-          <Chip
-            key={value}
-            value={value}
-            size={56}
-            selected={activeChip === value}
-            onClick={() => handleSelectChip(value)}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              handleChipRemoval(value);
-            }}
-            aria-label={`Select ${value} chip`}
-            data-chip-motion={
-              chipMotion?.value === value
-                ? `${chipMotion.type}-${chipMotion.stamp}`
-                : undefined
-            }
-            className="nj-chip"
-          />
-        ))}
-      </div>
-      <div className="nj-tray-actions">
-        <button
-          type="button"
-          className="nj-btn"
-          onClick={handleAddActiveChip}
-          disabled={game.phase !== "betting"}
-        >
-          Add {activeChip}
-        </button>
-        <button
-          type="button"
-          className="nj-btn nj-btn--ghost"
-          onClick={handleRemoveActiveChip}
-          disabled={game.phase !== "betting" || (seat?.baseBet ?? 0) <= 0}
-        >
-          Remove
-        </button>
-        <button
-          type="button"
-          className="nj-btn nj-btn--ghost"
-          onClick={handleUndoChip}
-          disabled={game.phase !== "betting" || (seat?.baseBet ?? 0) <= 0}
-        >
-          Undo last
-        </button>
-      </div>
-    </>
-  );
+  const toggleSettings = React.useCallback(() => {
+    setSettingsOpen((open) => !open);
+  }, []);
 
   return (
     <div className="noirjack-app">
       <FireworksOverlay
         ref={fireworksRef}
         disabled={!celebrationsEnabled}
-        intensity={prefersReducedMotion ? "reduced" : "default"}
+        intensity={intensity}
       />
       <NoirJackResultToaster isMobile={isMobile} />
       <div className="noirjack-felt" />
       <div className="noirjack-content">
-        <header className="nj-topbar">
-          <div className="nj-topbar__brand">
-            <img src={logoImage} alt="NoirJack logo" className="nj-logo" />
-            <span className="sr-only">NoirJack Blackjack table</span>
-            <div className="nj-topbar__controls">
-              <button
-                type="button"
-                className="nj-btn nj-btn--ghost"
-                aria-label="Table information"
-              >
-                <Info size={18} aria-hidden="true" />
-              </button>
-              <CoachModeSelector
-                mode={coachMode}
-                onChange={onCoachModeChange}
-              />
-              <NoirSoundControls />
-              <button
-                type="button"
-                className="nj-btn nj-btn--ghost"
-                aria-label="Table settings"
-                onClick={toggleSettings}
-                aria-expanded={settingsOpen}
-                aria-controls={settingsSheetId}
-                aria-haspopup="dialog"
-              >
-                <Settings2 size={18} aria-hidden="true" />
-              </button>
-            </div>
-          </div>
-          <div className="nj-topbar__mode">{modeToggle}</div>
-          <div className="nj-topbar__stats nj-glass">
-            {stats.map((item) => (
-              <div key={item.label} className="nj-stat">
-                <span className="nj-stat__label">{item.label}</span>
-                <span className="nj-stat__value">{item.value}</span>
-              </div>
-            ))}
-          </div>
-          {errorBanner}
-        </header>
-
+        <Topbar
+          coachMode={coachMode}
+          onCoachModeChange={onCoachModeChange}
+          onOpenSettings={toggleSettings}
+          settingsOpen={settingsOpen}
+          settingsSheetId={settingsSheetId}
+          modeToggle={modeToggle}
+          stats={stats}
+          error={error}
+          onDismissError={onDismissError}
+        />
         <div className="nj-play-area">
-          <section className="nj-section nj-section--dealer">
-            <div className="nj-glass nj-panel">
-              <div className="nj-panel__header">
-                <span className="nj-panel__title">Dealer</span>
-                <span className="nj-panel__subtitle">{dealerStatus}</span>
-              </div>
-              <div className="nj-panel__cards">
-                <NoirCardFan
-                  cards={dealerCards}
-                  faceDownIndexes={faceDownIndexes}
-                />
-              </div>
-              {game.phase === "insurance" && (
-                <div className="nj-panel__footer">Insurance available</div>
-              )}
-            </div>
-          </section>
-
-          <section className="nj-section nj-section--player">
-            <div className="nj-glass nj-panel">
-              <div className="nj-panel__header">
-                <span className="nj-panel__title">Player</span>
-                <div className="nj-panel__meta">
-                  <div>
-                    <span className="nj-stat__label">Total</span>
-                    <span className="nj-panel__value">
-                      {playerTotal ?? "--"}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="nj-stat__label">Bet</span>
-                    <span className="nj-panel__value">
-                      {formatCurrency(playerBet)}
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div className="nj-hand-carousel">
-                <div className="nj-panel__cards">
-                  <NoirCardFan cards={focusedHand?.cards ?? []} />
-                </div>
-                {playerHands.length > 1 && (
-                  <div
-                    className="nj-hand-tabs"
-                    role="tablist"
-                    aria-label="Split hands"
-                  >
-                    {playerHands.map((hand, index) => (
-                      <div
-                        key={hand.id}
-                        className={cn(
-                          "nj-hand-tab",
-                          index === resolvedActiveIndex && "nj-hand-tab--active"
-                        )}
-                        role="tab"
-                        aria-selected={index === resolvedActiveIndex}
-                      >
-                        <span>Hand {index + 1}</span>
-                        <span>{bestTotal(hand)}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-              {coachMessage && (
-                <div
-                  className={cn(
-                    "nj-coach-banner",
-                    coachMessage.tone === "correct"
-                      ? "nj-coach-banner--good"
-                      : "nj-coach-banner--warn"
-                  )}
-                >
-                  {coachMessage.text}
-                </div>
-              )}
-            </div>
-          </section>
+          <DealerPanel
+            cards={game.dealer.hand.cards}
+            faceDownIndexes={faceDownIndexes}
+            status={dealerStatus}
+            showInsuranceFooter={game.phase === "insurance"}
+          />
+          <PlayerPanel
+            hands={playerHands}
+            activeIndex={resolvedActiveIndex}
+            focusedHand={focusedHand}
+            playerTotal={playerTotal}
+            playerBet={playerBet}
+            coachMessage={coachMessage}
+          />
         </div>
       </div>
 
@@ -1278,7 +504,7 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
                 >
                   Chips
                 </button>
-                {chipsOpen && (
+                {chipsOpen ? (
                   <div
                     className="nj-chip-sheet"
                     id={chipSheetId}
@@ -1293,198 +519,70 @@ export const NoirJackTable: React.FC<NoirJackTableProps> = ({
                       onClick={closeChipSheet}
                     />
                     <div className="nj-controls__tray nj-glass nj-chip-sheet__panel">
-                      {renderChipTray({ closable: true })}
+                      <BetTray
+                        chipValues={CHIP_VALUES}
+                        activeChip={activeChip}
+                        baseBet={seat?.baseBet ?? 0}
+                        isBettingPhase={game.phase === "betting"}
+                        onSelectChip={handleSelectChip}
+                        onRemoveChip={handleChipRemoval}
+                        onAddActive={handleAddActiveChip}
+                        onRemoveActive={handleRemoveActiveChip}
+                        onUndo={handleUndoChip}
+                        chipMotion={chipMotion}
+                        closable
+                        onClose={closeChipSheet}
+                      />
                     </div>
                   </div>
-                )}
+                ) : null}
               </>
             ) : (
               <div className="nj-controls__tray nj-glass">
-                {renderChipTray()}
+                <BetTray
+                  chipValues={CHIP_VALUES}
+                  activeChip={activeChip}
+                  baseBet={seat?.baseBet ?? 0}
+                  isBettingPhase={game.phase === "betting"}
+                  onSelectChip={handleSelectChip}
+                  onRemoveChip={handleChipRemoval}
+                  onAddActive={handleAddActiveChip}
+                  onRemoveActive={handleRemoveActiveChip}
+                  onUndo={handleUndoChip}
+                  chipMotion={chipMotion}
+                />
               </div>
             )}
           </div>
-          <div className="nj-controls__actions nj-glass">
-            <div className="nj-actions-primary">
-              <button
-                type="button"
-                className="nj-btn nj-btn-primary"
-                onClick={handleHit}
-                disabled={game.phase !== "playerActions" || !availability.hit}
-                data-coach={
-                  game.phase === "playerActions"
-                    ? actionHighlight("hit")
-                    : undefined
-                }
-              >
-                Hit
-              </button>
-              <button
-                type="button"
-                className="nj-btn nj-btn-primary"
-                onClick={handleStand}
-                disabled={game.phase !== "playerActions" || !availability.stand}
-                data-coach={
-                  game.phase === "playerActions"
-                    ? actionHighlight("stand")
-                    : undefined
-                }
-              >
-                Stand
-              </button>
-            </div>
-            <div className="nj-actions-secondary">
-              <button
-                type="button"
-                className="nj-btn"
-                onClick={handleDouble}
-                disabled={
-                  game.phase !== "playerActions" || !availability.double
-                }
-                data-coach={
-                  game.phase === "playerActions"
-                    ? actionHighlight("double")
-                    : undefined
-                }
-              >
-                Double
-              </button>
-              <button
-                type="button"
-                className="nj-btn"
-                onClick={handleSplit}
-                disabled={game.phase !== "playerActions" || !availability.split}
-                data-coach={
-                  game.phase === "playerActions"
-                    ? actionHighlight("split")
-                    : undefined
-                }
-              >
-                Split
-              </button>
-              <button
-                type="button"
-                className="nj-btn"
-                onClick={handleSurrender}
-                disabled={
-                  game.phase !== "playerActions" || !availability.surrender
-                }
-                data-coach={
-                  game.phase === "playerActions"
-                    ? actionHighlight("surrender")
-                    : undefined
-                }
-              >
-                Surrender
-              </button>
-            </div>
-            {roundControls.length > 0 && (
-              <div className="nj-actions-round">
-                {roundControls.map((control) => (
-                  <button
-                    key={control.label}
-                    type="button"
-                    className={cn(
-                      "nj-btn",
-                      control.label === "Deal"
-                        ? "nj-btn-primary"
-                        : "nj-btn--ghost"
-                    )}
-                    onClick={control.onClick}
-                    disabled={control.disabled}
-                  >
-                    {control.label}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-      </div>
-    </div>
-
-      {settingsOpen && (
-        <div
-          className="nj-settings"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby={`${settingsSheetId}-title`}
-        >
-          <button
-            type="button"
-            className="nj-settings__backdrop"
-            aria-label="Close settings"
-            onClick={closeSettings}
+          <ActionsDock
+            phase={game.phase}
+            availability={availability}
+            highlightedAction={highlightedAction}
+            onHit={handleHit}
+            onStand={handleStand}
+            onDouble={handleDouble}
+            onSplit={handleSplit}
+            onSurrender={handleSurrender}
+            roundControls={roundControls}
           />
-          <div className="nj-settings__panel nj-glass" id={settingsSheetId}>
-            <div className="nj-settings__header">
-              <h2 id={`${settingsSheetId}-title`}>Settings</h2>
-              <button
-                type="button"
-                className="nj-settings__close"
-                onClick={closeSettings}
-              >
-                Close
-              </button>
-            </div>
-            <div className="nj-settings__section">
-              <div className="nj-settings__row">
-                <div className="nj-settings__info">
-                  <span className="nj-settings__label">Celebrations</span>
-                  <span className="nj-settings__description">
-                    Fireworks play when you win a round.
-                  </span>
-                  {prefersReducedMotion ? (
-                    <span className="nj-settings__note">
-                      System reduced motion disables celebrations by default.
-                    </span>
-                  ) : null}
-                </div>
-                <button
-                  type="button"
-                  className={cn(
-                    "nj-settings__toggle",
-                    celebrationsEnabled && "nj-settings__toggle--on"
-                  )}
-                  onClick={toggleCelebrations}
-                  aria-pressed={celebrationsEnabled}
-                >
-                  <span>{celebrationsEnabled ? "On" : "Off"}</span>
-                </button>
-              </div>
-            </div>
-          </div>
         </div>
-      )}
+      </div>
 
-      {showInsuranceSheet && (
-        <div
-          className="nj-insurance"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Insurance decision"
-        >
-          <div className="nj-insurance__sheet nj-glass">
-            <h2>Insurance?</h2>
-            <p>Take insurance for €{insuranceAmount.toFixed(2)}?</p>
-            <div className="nj-insurance__actions">
-              <button
-                type="button"
-                className="nj-btn nj-btn-primary"
-                onClick={takeInsurance}
-              >
-                Take insurance
-              </button>
-              <button
-                type="button"
-                className="nj-btn nj-btn--ghost"
-                onClick={skipInsurance}
-              >
-                Skip
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <SettingsSheet
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        sheetId={settingsSheetId}
+        celebrationsEnabled={celebrationsEnabled}
+        toggleCelebrations={celebrationPreference.toggle}
+        prefersReducedMotion={prefersReducedMotion}
+      />
+
+      <InsuranceSheet
+        open={insurance.open}
+        amount={insurance.amount}
+        onTake={takeInsurance}
+        onSkip={skipInsurance}
+      />
     </div>
   );
 };

--- a/src/components/noirjack/components/ActionsDock.tsx
+++ b/src/components/noirjack/components/ActionsDock.tsx
@@ -1,0 +1,113 @@
+import * as React from "react";
+import type { GameState } from "../../../engine/types";
+import type { Action } from "../../../utils/basicStrategy";
+import { cn } from "../../../utils/cn";
+import type { ActionAvailability } from "../selectors";
+
+interface RoundControl {
+  label: string;
+  onClick(): void;
+  disabled: boolean;
+  variant?: "primary" | "ghost";
+}
+
+interface ActionsDockProps {
+  phase: GameState["phase"];
+  availability: ActionAvailability;
+  highlightedAction: Action | null;
+  onHit(): void;
+  onStand(): void;
+  onDouble(): void;
+  onSplit(): void;
+  onSurrender(): void;
+  roundControls: RoundControl[];
+}
+
+const highlightAttr = (
+  phase: GameState["phase"],
+  highlighted: Action | null,
+  action: Action
+): "best" | undefined =>
+  phase === "playerActions" && highlighted === action ? "best" : undefined;
+
+export const ActionsDock: React.FC<ActionsDockProps> = ({
+  phase,
+  availability,
+  highlightedAction,
+  onHit,
+  onStand,
+  onDouble,
+  onSplit,
+  onSurrender,
+  roundControls,
+}) => (
+  <div className="nj-controls__actions nj-glass">
+    <div className="nj-actions-primary">
+      <button
+        type="button"
+        className="nj-btn nj-btn-primary"
+        onClick={onHit}
+        disabled={phase !== "playerActions" || !availability.hit}
+        data-coach={highlightAttr(phase, highlightedAction, "hit")}
+      >
+        Hit
+      </button>
+      <button
+        type="button"
+        className="nj-btn nj-btn-primary"
+        onClick={onStand}
+        disabled={phase !== "playerActions" || !availability.stand}
+        data-coach={highlightAttr(phase, highlightedAction, "stand")}
+      >
+        Stand
+      </button>
+    </div>
+    <div className="nj-actions-secondary">
+      <button
+        type="button"
+        className="nj-btn"
+        onClick={onDouble}
+        disabled={phase !== "playerActions" || !availability.double}
+        data-coach={highlightAttr(phase, highlightedAction, "double")}
+      >
+        Double
+      </button>
+      <button
+        type="button"
+        className="nj-btn"
+        onClick={onSplit}
+        disabled={phase !== "playerActions" || !availability.split}
+        data-coach={highlightAttr(phase, highlightedAction, "split")}
+      >
+        Split
+      </button>
+      <button
+        type="button"
+        className="nj-btn"
+        onClick={onSurrender}
+        disabled={phase !== "playerActions" || !availability.surrender}
+        data-coach={highlightAttr(phase, highlightedAction, "surrender")}
+      >
+        Surrender
+      </button>
+    </div>
+    {roundControls.length > 0 ? (
+      <div className="nj-actions-round">
+        {roundControls.map((control) => (
+          <button
+            key={control.label}
+            type="button"
+            className={cn(
+              "nj-btn",
+              control.variant === "primary" ? "nj-btn-primary" : "nj-btn--ghost"
+            )}
+            onClick={control.onClick}
+            disabled={control.disabled}
+          >
+            {control.label}
+          </button>
+        ))}
+      </div>
+    ) : null}
+  </div>
+);

--- a/src/components/noirjack/components/BetTray.tsx
+++ b/src/components/noirjack/components/BetTray.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import type { ChipDenomination } from "../../../theme/palette";
+import { formatCurrency } from "../../../utils/currency";
+import { Chip } from "../../hud/Chip";
+
+interface ChipMotion {
+  value: ChipDenomination;
+  type: "add" | "remove";
+  stamp: number;
+}
+
+interface BetTrayProps {
+  chipValues: readonly ChipDenomination[];
+  activeChip: ChipDenomination;
+  baseBet: number;
+  isBettingPhase: boolean;
+  onSelectChip(value: ChipDenomination): void;
+  onRemoveChip(value: ChipDenomination): void;
+  onAddActive(): void;
+  onRemoveActive(): void;
+  onUndo(): void;
+  chipMotion: ChipMotion | null;
+  closable?: boolean;
+  onClose?(): void;
+}
+
+export const BetTray: React.FC<BetTrayProps> = ({
+  chipValues,
+  activeChip,
+  baseBet,
+  isBettingPhase,
+  onSelectChip,
+  onRemoveChip,
+  onAddActive,
+  onRemoveActive,
+  onUndo,
+  chipMotion,
+  closable,
+  onClose,
+}) => (
+  <>
+    <div className="nj-controls__tray-header">
+      <span>Chips</span>
+      <div className="nj-controls__tray-meta">
+        <span>{formatCurrency(baseBet)}</span>
+        {closable ? (
+          <button
+            type="button"
+            className="nj-chip-sheet__close"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        ) : null}
+      </div>
+    </div>
+    <div className="nj-chip-row">
+      {chipValues.map((value) => (
+        <Chip
+          key={value}
+          value={value}
+          size={56}
+          selected={activeChip === value}
+          onClick={() => onSelectChip(value)}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            onRemoveChip(value);
+          }}
+          aria-label={`Select ${value} chip`}
+          data-chip-motion={
+            chipMotion?.value === value
+              ? `${chipMotion.type}-${chipMotion.stamp}`
+              : undefined
+          }
+          className="nj-chip"
+        />
+      ))}
+    </div>
+    <div className="nj-tray-actions">
+      <button
+        type="button"
+        className="nj-btn"
+        onClick={onAddActive}
+        disabled={!isBettingPhase}
+      >
+        Add {activeChip}
+      </button>
+      <button
+        type="button"
+        className="nj-btn nj-btn--ghost"
+        onClick={onRemoveActive}
+        disabled={!isBettingPhase || baseBet <= 0}
+      >
+        Remove
+      </button>
+      <button
+        type="button"
+        className="nj-btn nj-btn--ghost"
+        onClick={onUndo}
+        disabled={!isBettingPhase || baseBet <= 0}
+      >
+        Undo last
+      </button>
+    </div>
+  </>
+);

--- a/src/components/noirjack/components/CoachModeSelector.tsx
+++ b/src/components/noirjack/components/CoachModeSelector.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { Sparkles } from "lucide-react";
+import type { CoachMode } from "../../../store/useGameStore";
+
+interface CoachModeSelectorProps {
+  mode: CoachMode;
+  onChange(mode: CoachMode): void;
+}
+
+const labels: Record<CoachMode, string> = {
+  off: "Off",
+  feedback: "Feedback",
+  live: "Live",
+};
+
+export const CoachModeSelector: React.FC<CoachModeSelectorProps> = ({
+  mode,
+  onChange,
+}) => {
+  const next = React.useCallback(() => {
+    const order: CoachMode[] = ["off", "feedback", "live"];
+    const index = order.indexOf(mode);
+    const nextMode = order[(index + 1) % order.length];
+    onChange(nextMode);
+  }, [mode, onChange]);
+
+  return (
+    <button
+      type="button"
+      className="nj-btn nj-btn--ghost nj-coach-toggle"
+      onClick={next}
+      aria-label={`Toggle coach mode (currently ${labels[mode]})`}
+    >
+      <Sparkles size={16} aria-hidden="true" />
+      <span className="nj-coach-toggle__label">Coach</span>
+      <span className="nj-coach-toggle__value">{labels[mode]}</span>
+    </button>
+  );
+};

--- a/src/components/noirjack/components/DealerPanel.tsx
+++ b/src/components/noirjack/components/DealerPanel.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import type { Hand } from "../../../engine/types";
+import { NoirCardFan } from "../NoirCardFan";
+
+interface DealerPanelProps {
+  cards: Hand["cards"];
+  faceDownIndexes: number[];
+  status: string;
+  showInsuranceFooter: boolean;
+}
+
+export const DealerPanel: React.FC<DealerPanelProps> = ({
+  cards,
+  faceDownIndexes,
+  status,
+  showInsuranceFooter,
+}) => (
+  <section className="nj-section nj-section--dealer">
+    <div className="nj-glass nj-panel">
+      <div className="nj-panel__header">
+        <span className="nj-panel__title">Dealer</span>
+        <span className="nj-panel__subtitle">{status}</span>
+      </div>
+      <div className="nj-panel__cards">
+        <NoirCardFan cards={cards} faceDownIndexes={faceDownIndexes} />
+      </div>
+      {showInsuranceFooter ? (
+        <div className="nj-panel__footer">Insurance available</div>
+      ) : null}
+    </div>
+  </section>
+);

--- a/src/components/noirjack/components/InsuranceSheet.tsx
+++ b/src/components/noirjack/components/InsuranceSheet.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+interface InsuranceSheetProps {
+  open: boolean;
+  amount: number;
+  onTake(): void;
+  onSkip(): void;
+}
+
+export const InsuranceSheet: React.FC<InsuranceSheetProps> = ({
+  open,
+  amount,
+  onTake,
+  onSkip,
+}) => {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="nj-insurance" role="dialog" aria-modal="true" aria-label="Insurance decision">
+      <div className="nj-insurance__sheet nj-glass">
+        <h2>Insurance?</h2>
+        <p>Take insurance for €{amount.toFixed(2)}?</p>
+        <div className="nj-insurance__actions">
+          <button type="button" className="nj-btn nj-btn-primary" onClick={onTake}>
+            Take insurance
+          </button>
+          <button type="button" className="nj-btn nj-btn--ghost" onClick={onSkip}>
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/noirjack/components/PlayerPanel.tsx
+++ b/src/components/noirjack/components/PlayerPanel.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { bestTotal } from "../../../engine/totals";
+import type { Hand } from "../../../engine/types";
+import { formatCurrency } from "../../../utils/currency";
+import { cn } from "../../../utils/cn";
+import { NoirCardFan } from "../NoirCardFan";
+
+export interface CoachMessage {
+  tone: "correct" | "better";
+  text: string;
+}
+
+interface PlayerPanelProps {
+  hands: Hand[];
+  activeIndex: number;
+  focusedHand: Hand | null;
+  playerTotal: number | null;
+  playerBet: number;
+  coachMessage: CoachMessage | null;
+}
+
+export const PlayerPanel: React.FC<PlayerPanelProps> = ({
+  hands,
+  activeIndex,
+  focusedHand,
+  playerTotal,
+  playerBet,
+  coachMessage,
+}) => (
+  <section className="nj-section nj-section--player">
+    <div className="nj-glass nj-panel">
+      <div className="nj-panel__header">
+        <span className="nj-panel__title">Player</span>
+        <div className="nj-panel__meta">
+          <div>
+            <span className="nj-stat__label">Total</span>
+            <span className="nj-panel__value">{playerTotal ?? "--"}</span>
+          </div>
+          <div>
+            <span className="nj-stat__label">Bet</span>
+            <span className="nj-panel__value">{formatCurrency(playerBet)}</span>
+          </div>
+        </div>
+      </div>
+      <div className="nj-hand-carousel">
+        <div className="nj-panel__cards">
+          <NoirCardFan cards={focusedHand?.cards ?? []} />
+        </div>
+        {hands.length > 1 ? (
+          <div className="nj-hand-tabs" role="tablist" aria-label="Split hands">
+            {hands.map((hand, index) => (
+              <div
+                key={hand.id}
+                className={cn(
+                  "nj-hand-tab",
+                  index === activeIndex && "nj-hand-tab--active"
+                )}
+                role="tab"
+                aria-selected={index === activeIndex}
+              >
+                <span>Hand {index + 1}</span>
+                <span>{bestTotal(hand)}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      {coachMessage ? (
+        <div
+          className={cn(
+            "nj-coach-banner",
+            coachMessage.tone === "correct"
+              ? "nj-coach-banner--good"
+              : "nj-coach-banner--warn"
+          )}
+        >
+          {coachMessage.text}
+        </div>
+      ) : null}
+    </div>
+  </section>
+);

--- a/src/components/noirjack/components/SettingsSheet.tsx
+++ b/src/components/noirjack/components/SettingsSheet.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { cn } from "../../../utils/cn";
+
+interface SettingsSheetProps {
+  open: boolean;
+  onClose(): void;
+  sheetId: string;
+  celebrationsEnabled: boolean;
+  toggleCelebrations(): void;
+  prefersReducedMotion: boolean;
+}
+
+export const SettingsSheet: React.FC<SettingsSheetProps> = ({
+  open,
+  onClose,
+  sheetId,
+  celebrationsEnabled,
+  toggleCelebrations,
+  prefersReducedMotion,
+}) => {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="nj-settings"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`${sheetId}-title`}
+    >
+      <button
+        type="button"
+        className="nj-settings__backdrop"
+        aria-label="Close settings"
+        onClick={onClose}
+      />
+      <div className="nj-settings__panel nj-glass" id={sheetId}>
+        <div className="nj-settings__header">
+          <h2 id={`${sheetId}-title`}>Settings</h2>
+          <button
+            type="button"
+            className="nj-settings__close"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+        <div className="nj-settings__section">
+          <div className="nj-settings__row">
+            <div className="nj-settings__info">
+              <span className="nj-settings__label">Celebrations</span>
+              <span className="nj-settings__description">
+                Fireworks play when you win a round.
+              </span>
+              {prefersReducedMotion ? (
+                <span className="nj-settings__note">
+                  System reduced motion disables celebrations by default.
+                </span>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className={cn(
+                "nj-settings__toggle",
+                celebrationsEnabled && "nj-settings__toggle--on"
+              )}
+              onClick={toggleCelebrations}
+              aria-pressed={celebrationsEnabled}
+            >
+              <span>{celebrationsEnabled ? "On" : "Off"}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/noirjack/components/Topbar.tsx
+++ b/src/components/noirjack/components/Topbar.tsx
@@ -1,0 +1,89 @@
+import * as React from "react";
+import { Info, Settings2 } from "lucide-react";
+import type { CoachMode } from "../../../store/useGameStore";
+import { NoirSoundControls } from "../NoirSoundControls";
+import logoImage from "../../../assets/images/logo.png";
+import { CoachModeSelector } from "./CoachModeSelector";
+
+interface TopbarStat {
+  label: string;
+  value: React.ReactNode;
+}
+
+interface TopbarProps {
+  coachMode: CoachMode;
+  onCoachModeChange(mode: CoachMode): void;
+  onOpenSettings(): void;
+  settingsOpen: boolean;
+  settingsSheetId: string;
+  modeToggle: React.ReactNode;
+  stats: TopbarStat[];
+  error: string | null;
+  onDismissError(): void;
+}
+
+export const Topbar: React.FC<TopbarProps> = ({
+  coachMode,
+  onCoachModeChange,
+  onOpenSettings,
+  settingsOpen,
+  settingsSheetId,
+  modeToggle,
+  stats,
+  error,
+  onDismissError,
+}) => {
+  const errorBanner = error ? (
+    <div className="nj-glass nj-error" role="alert">
+      <span>{error}</span>
+      <button
+        type="button"
+        className="nj-btn nj-btn--ghost"
+        onClick={onDismissError}
+      >
+        Dismiss
+      </button>
+    </div>
+  ) : null;
+
+  return (
+    <header className="nj-topbar">
+      <div className="nj-topbar__brand">
+        <img src={logoImage} alt="NoirJack logo" className="nj-logo" />
+        <span className="sr-only">NoirJack Blackjack table</span>
+        <div className="nj-topbar__controls">
+          <button
+            type="button"
+            className="nj-btn nj-btn--ghost"
+            aria-label="Table information"
+          >
+            <Info size={18} aria-hidden="true" />
+          </button>
+          <CoachModeSelector mode={coachMode} onChange={onCoachModeChange} />
+          <NoirSoundControls />
+          <button
+            type="button"
+            className="nj-btn nj-btn--ghost"
+            aria-label="Table settings"
+            onClick={onOpenSettings}
+            aria-expanded={settingsOpen}
+            aria-controls={settingsSheetId}
+            aria-haspopup="dialog"
+          >
+            <Settings2 size={18} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+      <div className="nj-topbar__mode">{modeToggle}</div>
+      <div className="nj-topbar__stats nj-glass">
+        {stats.map((item) => (
+          <div key={item.label} className="nj-stat">
+            <span className="nj-stat__label">{item.label}</span>
+            <span className="nj-stat__value">{item.value}</span>
+          </div>
+        ))}
+      </div>
+      {errorBanner}
+    </header>
+  );
+};

--- a/src/components/noirjack/hooks/useActionRecommendation.ts
+++ b/src/components/noirjack/hooks/useActionRecommendation.ts
@@ -1,0 +1,104 @@
+import * as React from "react";
+import type { GameState, Hand } from "../../../engine/types";
+import type { CoachMode } from "../../../store/useGameStore";
+import {
+  getRecommendation,
+  type Action,
+  type PlayerContext,
+} from "../../../utils/basicStrategy";
+import type { ActionContext } from "../selectors";
+
+interface UseActionRecommendationArgs {
+  game: GameState;
+  hand: Hand | null;
+  legal: ActionContext | null;
+  coachMode: CoachMode;
+  dealerUpcard?: GameState["dealer"]["upcard"];
+  flashOverride?: Action | null;
+}
+
+interface UseActionRecommendationResult {
+  recommendedAction: Action | null;
+  highlightedAction: Action | null;
+}
+
+export function useActionRecommendation({
+  game,
+  hand,
+  legal,
+  coachMode,
+  dealerUpcard,
+  flashOverride,
+}: UseActionRecommendationArgs): UseActionRecommendationResult {
+  const recommendation = React.useMemo(() => {
+    if (!legal || !hand || !dealerUpcard) {
+      return null;
+    }
+    const rank = dealerUpcard.rank as PlayerContext["dealerUpcard"]["rank"];
+    const context: PlayerContext = {
+      dealerUpcard: {
+        rank,
+        value10:
+          dealerUpcard.rank === "10" ||
+          dealerUpcard.rank === "J" ||
+          dealerUpcard.rank === "Q" ||
+          dealerUpcard.rank === "K",
+      },
+      cards: hand.cards.map((card: Hand["cards"][number]) => ({ rank: card.rank })),
+      isInitialTwoCards: hand.cards.length === 2 && !hand.hasActed,
+      afterSplit: Boolean(hand.isSplitHand),
+      legal: {
+        hit: legal.hit,
+        stand: legal.stand,
+        double: legal.double,
+        split: legal.split,
+        surrender: legal.surrender,
+      },
+    };
+    return getRecommendation(context, game.rules);
+  }, [dealerUpcard, game.rules, hand, legal]);
+
+  const recommendedAction = React.useMemo<Action | null>(() => {
+    if (!recommendation || !legal) {
+      return null;
+    }
+    const isLegal = (action: Action | undefined): boolean => {
+      if (!action) {
+        return false;
+      }
+      switch (action) {
+        case "hit":
+          return legal.hit;
+        case "stand":
+          return legal.stand;
+        case "double":
+          return legal.double;
+        case "split":
+          return legal.split;
+        case "surrender":
+          return legal.surrender;
+        default:
+          return false;
+      }
+    };
+    if (isLegal(recommendation.best)) {
+      return recommendation.best;
+    }
+    if (recommendation.fallback && isLegal(recommendation.fallback)) {
+      return recommendation.fallback;
+    }
+    return null;
+  }, [legal, recommendation]);
+
+  const highlightedAction = React.useMemo<Action | null>(() => {
+    if (flashOverride) {
+      return flashOverride;
+    }
+    if (coachMode === "live") {
+      return recommendedAction;
+    }
+    return null;
+  }, [coachMode, flashOverride, recommendedAction]);
+
+  return { recommendedAction, highlightedAction };
+}

--- a/src/components/noirjack/hooks/useCelebrationPreference.ts
+++ b/src/components/noirjack/hooks/useCelebrationPreference.ts
@@ -1,0 +1,99 @@
+import * as React from "react";
+import { getPrefersReducedMotion } from "./usePrefersReducedMotion";
+
+const CELEBRATIONS_STORAGE_KEY = "noirjack.celebrations";
+
+const readCelebrationsPreference = (): boolean | null => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(CELEBRATIONS_STORAGE_KEY);
+    if (stored === null) {
+      return null;
+    }
+    return stored === "true";
+  } catch {
+    return null;
+  }
+};
+
+const persistCelebrationsPreference = (enabled: boolean): void => {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(
+      CELEBRATIONS_STORAGE_KEY,
+      enabled ? "true" : "false"
+    );
+  } catch {
+    // ignore persistence errors
+  }
+};
+
+interface CelebrationPreference {
+  enabled: boolean;
+  setEnabled(next: boolean): void;
+  toggle(): void;
+  hasStoredPreference: boolean;
+}
+
+export function useCelebrationPreference(
+  prefersReducedMotion: boolean
+): CelebrationPreference {
+  const initialStored = React.useMemo(() => readCelebrationsPreference(), []);
+  const [hasStoredPreference, setHasStoredPreference] = React.useState<boolean>(
+    initialStored !== null
+  );
+  const [enabled, setEnabledState] = React.useState<boolean>(() => {
+    if (initialStored !== null) {
+      return initialStored;
+    }
+    const systemPrefersReduced = getPrefersReducedMotion();
+    return systemPrefersReduced ? false : true;
+  });
+
+  const setEnabled = React.useCallback((next: boolean) => {
+    setEnabledState(next);
+    persistCelebrationsPreference(next);
+    setHasStoredPreference(true);
+  }, []);
+
+  const toggle = React.useCallback(() => {
+    setEnabled(!enabled);
+  }, [enabled, setEnabled]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const handler = (event: StorageEvent) => {
+      if (
+        event.key !== CELEBRATIONS_STORAGE_KEY ||
+        event.storageArea !== window.localStorage
+      ) {
+        return;
+      }
+      if (event.newValue === null) {
+        setHasStoredPreference(false);
+        setEnabledState(prefersReducedMotion ? false : true);
+        return;
+      }
+      setHasStoredPreference(true);
+      setEnabledState(event.newValue === "true");
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [prefersReducedMotion]);
+
+  React.useEffect(() => {
+    if (hasStoredPreference) {
+      return;
+    }
+    const desired = prefersReducedMotion ? false : true;
+    setEnabledState((current) => (current === desired ? current : desired));
+  }, [hasStoredPreference, prefersReducedMotion]);
+
+  return { enabled, setEnabled, toggle, hasStoredPreference };
+}

--- a/src/components/noirjack/hooks/useCelebrations.ts
+++ b/src/components/noirjack/hooks/useCelebrations.ts
@@ -1,0 +1,38 @@
+import * as React from "react";
+import type { FireworksOverlayHandle } from "../../effects/FireworksOverlay";
+
+interface UseCelebrationsArgs {
+  enabled: boolean;
+  prefersReduced: boolean;
+}
+
+export function useCelebrations({
+  enabled,
+  prefersReduced,
+}: UseCelebrationsArgs) {
+  const ref = React.useRef<FireworksOverlayHandle | null>(null);
+
+  const start = React.useCallback(
+    (duration: number) => {
+      if (!enabled) {
+        return;
+      }
+      ref.current?.start(duration);
+    },
+    [enabled]
+  );
+
+  const stop = React.useCallback(() => {
+    ref.current?.stop();
+  }, []);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      ref.current?.stop();
+    }
+  }, [enabled]);
+
+  const intensity = prefersReduced ? "reduced" : "default";
+
+  return { ref, start, stop, intensity } as const;
+}

--- a/src/components/noirjack/hooks/useDealSoundOnNewCard.ts
+++ b/src/components/noirjack/hooks/useDealSoundOnNewCard.ts
@@ -1,0 +1,22 @@
+import * as React from "react";
+import type { GameState } from "../../../engine/types";
+import type { AudioService } from "../../../services/AudioService";
+import { calculateTotalCardCount } from "../selectors";
+import { usePrevious } from "./usePrevious";
+
+export function useDealSoundOnNewCard(
+  game: GameState,
+  audio: AudioService
+): void {
+  const totalCardCount = React.useMemo(
+    () => calculateTotalCardCount(game),
+    [game]
+  );
+  const previousCount = usePrevious(totalCardCount);
+
+  React.useEffect(() => {
+    if (typeof previousCount === "number" && totalCardCount > previousCount) {
+      audio.play("deal");
+    }
+  }, [audio, previousCount, totalCardCount]);
+}

--- a/src/components/noirjack/hooks/useFireworksOnWin.ts
+++ b/src/components/noirjack/hooks/useFireworksOnWin.ts
@@ -1,0 +1,59 @@
+import * as React from "react";
+import type { GameState } from "../../../engine/types";
+import type { AudioService } from "../../../services/AudioService";
+import { summarizeSettlement } from "../selectors";
+import { usePrevious } from "./usePrevious";
+
+const CELEBRATION_SOUND_COOLDOWN_MS = 320;
+
+interface FireworksApi {
+  start(duration: number): void;
+  stop(): void;
+  enabled: boolean;
+  prefersReduced: boolean;
+}
+
+interface UseFireworksOnWinArgs extends FireworksApi {
+  audio: AudioService;
+}
+
+const now = (): number =>
+  typeof performance !== "undefined" ? performance.now() : Date.now();
+
+export function useFireworksOnWin(
+  game: GameState,
+  { start, stop, enabled, prefersReduced, audio }: UseFireworksOnWinArgs
+): void {
+  const prevPhase = usePrevious(game.phase);
+  const lastPlayedRef = React.useRef<number>(0);
+
+  React.useEffect(() => {
+    if (game.phase === "settlement" && prevPhase !== "settlement") {
+      const summary = summarizeSettlement(game);
+      if (!summary) {
+        return;
+      }
+      if (enabled && (summary.kind === "win" || summary.kind === "blackjack")) {
+        const duration = prefersReduced
+          ? summary.kind === "blackjack"
+            ? 2600
+            : 2200
+          : summary.kind === "blackjack"
+          ? 3800
+          : 3200;
+        start(duration);
+        const timestamp = now();
+        if (timestamp - lastPlayedRef.current >= CELEBRATION_SOUND_COOLDOWN_MS) {
+          lastPlayedRef.current = timestamp;
+          audio.play("celebration");
+        }
+      }
+    }
+  }, [audio, enabled, game, prefersReduced, prevPhase, start]);
+
+  React.useEffect(() => {
+    if (game.phase !== "settlement" && prevPhase === "settlement") {
+      stop();
+    }
+  }, [game.phase, prevPhase, stop]);
+}

--- a/src/components/noirjack/hooks/useFlipSoundOnHoleReveal.ts
+++ b/src/components/noirjack/hooks/useFlipSoundOnHoleReveal.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+import type { GameState } from "../../../engine/types";
+import type { AudioService } from "../../../services/AudioService";
+import { usePrevious } from "./usePrevious";
+
+export function useFlipSoundOnHoleReveal(
+  game: GameState,
+  audio: AudioService
+): void {
+  const previousHoleCard = usePrevious(game.dealer.holeCard);
+
+  React.useEffect(() => {
+    if (previousHoleCard && !game.dealer.holeCard) {
+      audio.play("flip");
+    }
+  }, [audio, game.dealer.holeCard, previousHoleCard]);
+}

--- a/src/components/noirjack/hooks/useHaptics.ts
+++ b/src/components/noirjack/hooks/useHaptics.ts
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export function useHaptics(disabled: boolean): () => void {
+  return React.useCallback(() => {
+    if (disabled || typeof window === "undefined" || typeof navigator === "undefined") {
+      return;
+    }
+    if (typeof navigator.vibrate === "function") {
+      navigator.vibrate(12);
+    }
+  }, [disabled]);
+}

--- a/src/components/noirjack/hooks/useInsurancePromptSound.ts
+++ b/src/components/noirjack/hooks/useInsurancePromptSound.ts
@@ -1,0 +1,32 @@
+import * as React from "react";
+import type { GameState } from "../../../engine/types";
+import type { AudioService } from "../../../services/AudioService";
+import { deriveInsuranceOffer, selectPrimarySeat } from "../selectors";
+import { usePrevious } from "./usePrevious";
+
+interface InsurancePromptState {
+  handId: string | null;
+  amount: number;
+  open: boolean;
+}
+
+export function useInsurancePromptSound(
+  game: GameState,
+  audio: AudioService
+): InsurancePromptState {
+  const seat = React.useMemo(() => selectPrimarySeat(game), [game]);
+  const offer = React.useMemo(
+    () => deriveInsuranceOffer(game, seat),
+    [game, seat]
+  );
+  const open = Boolean(offer.handId && game.awaitingInsuranceResolution);
+  const wasOpen = usePrevious(open);
+
+  React.useEffect(() => {
+    if (open && !wasOpen) {
+      audio.play("insurancePrompt");
+    }
+  }, [audio, open, wasOpen]);
+
+  return { handId: offer.handId, amount: offer.amount, open };
+}

--- a/src/components/noirjack/hooks/useMediaQuery.ts
+++ b/src/components/noirjack/hooks/useMediaQuery.ts
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return false;
+    }
+    return window.matchMedia(query).matches;
+  });
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+    const media = window.matchMedia(query);
+    const handler = () => setMatches(media.matches);
+    handler();
+    media.addEventListener("change", handler);
+    return () => media.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/src/components/noirjack/hooks/useMessageLogSounds.ts
+++ b/src/components/noirjack/hooks/useMessageLogSounds.ts
@@ -1,0 +1,66 @@
+import * as React from "react";
+import type { AudioService } from "../../../services/AudioService";
+
+const contains = (message: string, needle: string): boolean =>
+  message.includes(needle);
+
+export function useMessageLogSounds(
+  log: readonly string[],
+  audio: AudioService
+): void {
+  const countRef = React.useRef<number>(log.length);
+
+  React.useEffect(() => {
+    if (log.length <= countRef.current) {
+      countRef.current = log.length;
+      return;
+    }
+    const newMessages = log.slice(countRef.current);
+    countRef.current = log.length;
+    newMessages.forEach((raw) => {
+      const message = raw.toLowerCase();
+      if (contains(message, "shoe reshuffled")) {
+        audio.play("shuffle");
+        return;
+      }
+      if (contains(message, "doubles and draws")) {
+        audio.play("double");
+        return;
+      }
+      if (/splits\s/.test(message)) {
+        audio.play("split");
+        return;
+      }
+      if (contains(message, "surrenders")) {
+        audio.play("surrender");
+        return;
+      }
+      if (
+        contains(message, "blackjack wins") ||
+        message.startsWith("dealer has blackjack")
+      ) {
+        audio.play("blackjack");
+        return;
+      }
+      if (contains(message, "busts and loses")) {
+        audio.play("lose");
+        return;
+      }
+      if (message.endsWith("busts")) {
+        audio.play("bust");
+        return;
+      }
+      if (contains(message, "wins")) {
+        audio.play("win");
+        return;
+      }
+      if (contains(message, "pushes")) {
+        audio.play("push");
+        return;
+      }
+      if (contains(message, "loses")) {
+        audio.play("lose");
+      }
+    });
+  }, [audio, log]);
+}

--- a/src/components/noirjack/hooks/usePrefersReducedMotion.ts
+++ b/src/components/noirjack/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+const getPrefersReducedMotion = (): boolean => {
+  if (typeof window === "undefined" || !window.matchMedia) {
+    return false;
+  }
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+};
+
+export function usePrefersReducedMotion(): boolean {
+  const [prefers, setPrefers] = React.useState<boolean>(getPrefersReducedMotion);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const listener = () => setPrefers(media.matches);
+    listener();
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, []);
+
+  return prefers;
+}
+
+export { getPrefersReducedMotion };

--- a/src/components/noirjack/hooks/usePrevious.ts
+++ b/src/components/noirjack/hooks/usePrevious.ts
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = React.useRef<T>();
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}

--- a/src/components/noirjack/hooks/useResultToastOnSettlement.ts
+++ b/src/components/noirjack/hooks/useResultToastOnSettlement.ts
@@ -1,0 +1,18 @@
+import * as React from "react";
+import type { GameState } from "../../../engine/types";
+import { ResultToast } from "../ResultToast";
+import { summarizeSettlement } from "../selectors";
+import { usePrevious } from "./usePrevious";
+
+export function useResultToastOnSettlement(game: GameState): void {
+  const prevPhase = usePrevious(game.phase);
+
+  React.useEffect(() => {
+    if (game.phase === "settlement" && prevPhase !== "settlement") {
+      const summary = summarizeSettlement(game);
+      if (summary) {
+        ResultToast.show(summary.kind, summary.amount, summary.details);
+      }
+    }
+  }, [game, prevPhase]);
+}

--- a/src/components/noirjack/selectors.ts
+++ b/src/components/noirjack/selectors.ts
@@ -1,0 +1,268 @@
+import { PRIMARY_SEAT_INDEX, filterSeatsForMode } from "../../ui/config";
+import { bestTotal, isBust } from "../../engine/totals";
+import {
+  canDouble,
+  canHit,
+  canSplit,
+  canSurrender,
+} from "../../engine/rules";
+import type { GameState, Hand, Seat } from "../../engine/types";
+import type { ResultKind } from "./ResultToast";
+
+export interface HandResolution {
+  net: number;
+  outcome: ResultKind;
+  detail?: string;
+}
+
+export interface SettlementSummary {
+  kind: ResultKind;
+  amount: number;
+  details?: string;
+}
+
+export interface ActionContext {
+  hand: Hand;
+  hit: boolean;
+  stand: boolean;
+  double: boolean;
+  split: boolean;
+  surrender: boolean;
+}
+
+export interface ActionAvailability {
+  hit: boolean;
+  stand: boolean;
+  double: boolean;
+  split: boolean;
+  surrender: boolean;
+  deal: boolean;
+  finishInsurance: boolean;
+  playDealer: boolean;
+  nextRound: boolean;
+}
+
+const normalizeAmount = (value: number): number => {
+  const rounded = Math.round(value * 100) / 100;
+  return Math.abs(rounded) < 0.005 ? 0 : rounded;
+};
+
+export const hasReadySeat = (game: GameState): boolean => {
+  const seat = game.seats[PRIMARY_SEAT_INDEX];
+  if (!seat?.occupied) {
+    return false;
+  }
+  if (seat.baseBet < game.rules.minBet || seat.baseBet > game.rules.maxBet) {
+    return false;
+  }
+  return seat.baseBet > 0 && seat.baseBet <= game.bankroll;
+};
+
+export const findActiveHand = (game: GameState): Hand | null => {
+  if (!game.activeHandId) {
+    return null;
+  }
+  for (const seat of filterSeatsForMode(game.seats)) {
+    const hand = seat.hands.find((candidate) => candidate.id === game.activeHandId);
+    if (hand) {
+      return hand;
+    }
+  }
+  return null;
+};
+
+export const describeHand = (hand: Hand, game: GameState): HandResolution => {
+  const bet = hand.bet;
+  const insurance = hand.insuranceBet ?? 0;
+  const dealerHand = game.dealer.hand;
+  const dealerBust = isBust(dealerHand);
+  const dealerBlackjack = dealerHand.isBlackjack;
+  const playerBust = isBust(hand);
+  const blackjackMultiplier = game.rules.blackjackPayout === "6:5" ? 1.2 : 1.5;
+
+  let net = 0;
+  let outcome: ResultKind = "push";
+  let detail: string | undefined;
+
+  if (hand.isSurrendered) {
+    net -= bet / 2;
+    outcome = "lose";
+    detail = "Surrendered";
+  } else if (dealerBlackjack) {
+    if (hand.isBlackjack) {
+      outcome = "push";
+      detail = "Blackjack push";
+    } else {
+      net -= bet;
+      outcome = "lose";
+      detail = "Dealer blackjack";
+    }
+  } else if (playerBust) {
+    net -= bet;
+    outcome = "lose";
+    detail = "Player busts";
+  } else if (hand.isBlackjack) {
+    net += bet * blackjackMultiplier;
+    outcome = "blackjack";
+    detail = `Blackjack ${game.rules.blackjackPayout}`;
+  } else if (dealerBust) {
+    net += bet;
+    outcome = "win";
+    detail = "Dealer busts";
+  } else {
+    const playerTotal = bestTotal(hand);
+    const dealerTotal = bestTotal(dealerHand);
+    if (playerTotal > dealerTotal) {
+      net += bet;
+      outcome = "win";
+      detail = `${playerTotal} vs ${dealerTotal}`;
+    } else if (playerTotal === dealerTotal) {
+      outcome = "push";
+      detail = `${playerTotal} each`;
+    } else {
+      net -= bet;
+      outcome = "lose";
+      detail = `${playerTotal} vs ${dealerTotal}`;
+    }
+  }
+
+  if (insurance > 0) {
+    if (dealerBlackjack) {
+      net += insurance * 2;
+      detail = detail ? `${detail} • Insurance pays` : "Insurance pays";
+    } else {
+      net -= insurance;
+      detail = detail ? `${detail} • Insurance lost` : "Insurance lost";
+    }
+  }
+
+  return { net, outcome, detail };
+};
+
+export const summarizeSettlement = (game: GameState): SettlementSummary | null => {
+  const seat = game.seats[PRIMARY_SEAT_INDEX];
+  if (!seat || !seat.occupied) {
+    return null;
+  }
+  const hands = seat.hands;
+  if (!hands || hands.length === 0) {
+    return null;
+  }
+
+  const resolutions = hands.map((hand) => describeHand(hand, game));
+  const total = resolutions.reduce((sum, entry) => sum + entry.net, 0);
+  const amount = normalizeAmount(total);
+  const anyBlackjack = resolutions.some(
+    (entry) => entry.outcome === "blackjack" && entry.net > 0
+  );
+
+  let kind: ResultKind;
+  if (amount > 0) {
+    kind = anyBlackjack ? "blackjack" : "win";
+  } else if (amount < 0) {
+    kind = "lose";
+  } else {
+    kind = "push";
+  }
+
+  const details =
+    resolutions.length > 1
+      ? `${resolutions.length} hands settled`
+      : resolutions[0]?.detail;
+
+  const meaningful = resolutions.some(
+    (entry) => Math.abs(entry.net) > 0.004 || entry.outcome !== "push"
+  );
+  if (!meaningful && amount === 0) {
+    return { kind: "push", amount: 0, details };
+  }
+
+  return { kind, amount, details };
+};
+
+export const deriveActionContext = (
+  game: GameState,
+  hand: Hand | null,
+  seat: Seat | null
+): ActionContext | null => {
+  if (!hand || !seat || game.phase !== "playerActions") {
+    return null;
+  }
+  return {
+    hand,
+    hit: canHit(hand),
+    stand: !hand.isResolved,
+    double: canDouble(hand, game.rules) && game.bankroll >= hand.bet,
+    split: canSplit(hand, seat, game.rules) && game.bankroll >= hand.bet,
+    surrender: canSurrender(hand, game.rules),
+  };
+};
+
+export const deriveActionAvailability = (
+  game: GameState,
+  context: ActionContext | null
+): ActionAvailability => ({
+  hit: Boolean(context?.hit),
+  stand: Boolean(context?.stand),
+  double: Boolean(context?.double),
+  split: Boolean(context?.split),
+  surrender: Boolean(context?.surrender),
+  deal: game.phase === "betting" && hasReadySeat(game),
+  finishInsurance: game.phase === "insurance",
+  playDealer: game.phase === "dealerPlay",
+  nextRound: game.phase === "settlement",
+});
+
+export const deriveFaceDownIndexes = (game: GameState): number[] => {
+  if (game.phase === "settlement" || game.phase === "dealerPlay") {
+    return [];
+  }
+  if (game.dealer.holeCard) {
+    return [1];
+  }
+  return [];
+};
+
+export const deriveDealerStatus = (
+  game: GameState,
+  faceDownIndexes: number[]
+): string => {
+  if (faceDownIndexes.length > 0 && game.dealer.upcard) {
+    return `Showing ${game.dealer.upcard.rank}`;
+  }
+  if (game.dealer.hand.cards.length > 0) {
+    return `Total ${bestTotal(game.dealer.hand)}`;
+  }
+  return "Waiting";
+};
+
+export const selectPrimarySeat = (game: GameState): Seat | null =>
+  game.seats[PRIMARY_SEAT_INDEX] ?? null;
+
+export const deriveInsuranceOffer = (
+  game: GameState,
+  seat: Seat | null
+): { handId: string | null; amount: number } => {
+  if (game.phase !== "insurance" || !seat) {
+    return { handId: null, amount: 0 };
+  }
+  const hand = seat.hands.find(
+    (candidate) => candidate.insuranceBet === undefined && !candidate.isResolved
+  );
+  if (!hand) {
+    return { handId: null, amount: 0 };
+  }
+  return { handId: hand.id, amount: Math.min(hand.bet / 2, game.bankroll) };
+};
+
+export const calculateTotalCardCount = (game: GameState): number => {
+  const dealerCount = game.dealer.hand.cards.length + (game.dealer.holeCard ? 1 : 0);
+  const playerCount = game.seats.reduce((sum, seatItem) => {
+    const seatCards = seatItem.hands.reduce(
+      (inner, currentHand) => inner + currentHand.cards.length,
+      0
+    );
+    return sum + seatCards;
+  }, 0);
+  return dealerCount + playerCount;
+};


### PR DESCRIPTION
## Summary
- extract pure game-state selectors for active hands, settlements, action availability, and insurance calculations
- add focused hooks for recommendations, effects, media queries, haptics, celebrations, and audio cues
- rebuild NoirJackTable as a composition of memoized presentational components for the topbar, dealer/player panels, bet tray, action dock, settings, and insurance overlays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6982b455c8329bfbba9347c1f5599